### PR TITLE
Support physical unit-aware gradient computation using `brainunit.autograd`

### DIFF
--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -679,7 +679,7 @@ class StateTraceStack(Generic[A]):
         """
         for st, val in zip(self.states, self._original_state_values):
             # internal use
-            st._value = val
+            st.restore_value(val)
 
     def merge(self, *traces) -> 'StateTraceStack':
         """

--- a/brainstate/event/_csr_benchmark.py
+++ b/brainstate/event/_csr_benchmark.py
@@ -1,0 +1,14 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/brainstate/nn/_interaction/_linear.py
+++ b/brainstate/nn/_interaction/_linear.py
@@ -79,7 +79,7 @@ class Linear(Module):
         weight = params['weight']
         if self.w_mask is not None:
             weight = weight * self.w_mask
-        y = u.math.dot(x, weight)
+        y = u.linalg.dot(x, weight)
         if 'bias' in params:
             y = y + params['bias']
         return y
@@ -192,7 +192,7 @@ class ScaledWSLinear(Module):
         w = functional.weight_standardization(w, self.eps, params.get('gain', None))
         if self.w_mask is not None:
             w = w * self.w_mask
-        y = u.math.dot(x, w)
+        y = u.linalg.dot(x, w)
         if 'bias' in params:
             y = y + params['bias']
         return y

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     'jax',
     'jaxlib',
     'numpy',
-    'brainunit>=0.0.2',
+    'brainunit>=0.0.2.post20241125',
 ]
 
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     'jax',
     'jaxlib',
     'numpy',
-    'brainunit>=0.0.2.post20241125',
+    'brainunit>=0.0.3',
 ]
 
 dynamic = ['version']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 jax
 jaxlib
-brainunit>=0.0.2
+brainunit>=0.0.3

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email='chao.brain@qq.com',
     packages=packages,
     python_requires='>=3.9',
-    install_requires=['numpy>=1.15', 'jax', 'tqdm', 'brainunit>=0.0.2'],
+    install_requires=['numpy>=1.15', 'jax', 'tqdm', 'brainunit>=0.0.2.post20241125'],
     url='https://github.com/chaobrain/brainstate',
     project_urls={
         "Bug Tracker": "https://github.com/chaobrain/brainstate/issues",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email='chao.brain@qq.com',
     packages=packages,
     python_requires='>=3.9',
-    install_requires=['numpy>=1.15', 'jax', 'tqdm', 'brainunit>=0.0.2.post20241125'],
+    install_requires=['numpy>=1.15', 'jax', 'tqdm', 'brainunit>=0.0.3'],
     url='https://github.com/chaobrain/brainstate',
     project_urls={
         "Bug Tracker": "https://github.com/chaobrain/brainstate/issues",


### PR DESCRIPTION
This pull request includes several changes to the `brainstate/augment/_autograd.py` file, focusing on the addition of unit-aware functionality and the removal of some redundant functions. Additionally, there are minor changes in `brainstate/_state.py` and `brainstate/augment/_autograd_test.py`. The most important changes include the introduction of the `unit_aware` parameter across various functions, the removal of the `functional_vector_grad` function, and the modification of the `recovery_original_values` method.

Enhancements to unit-aware functionality:

* Added the `unit_aware` parameter to the `grad`, `vector_grad`, `jacrev`, `jacfwd`, and `hessian` functions to enable unit-aware gradient computations. [[1]](diffhunk://#diff-9531532a9b79e2667c9dc10fac91e0ee2cd798f51652d65598342f86572a15f3L326-R312) [[2]](diffhunk://#diff-9531532a9b79e2667c9dc10fac91e0ee2cd798f51652d65598342f86572a15f3R381) [[3]](diffhunk://#diff-9531532a9b79e2667c9dc10fac91e0ee2cd798f51652d65598342f86572a15f3R445) [[4]](diffhunk://#diff-9531532a9b79e2667c9dc10fac91e0ee2cd798f51652d65598342f86572a15f3R511) [[5]](diffhunk://#diff-9531532a9b79e2667c9dc10fac91e0ee2cd798f51652d65598342f86572a15f3L572-R566)
* Modified the `jacrev` and `jacfwd` functions to use `u.autograd.jacrev` and `u.autograd.jacfwd` when `unit_aware` is set to `True`. [[1]](diffhunk://#diff-9531532a9b79e2667c9dc10fac91e0ee2cd798f51652d65598342f86572a15f3L120-R88) [[2]](diffhunk://#diff-9531532a9b79e2667c9dc10fac91e0ee2cd798f51652d65598342f86572a15f3L149-R133)

Codebase simplification:

* Removed the `functional_vector_grad` function and related callable checks to streamline the code.
* Reorganized imports in `brainstate/augment/_autograd.py` to improve readability.

Minor changes:

* Updated the `recovery_original_values` method in `brainstate/_state.py` to use the `restore_value` method instead of directly setting `_value`.
* Added `brainunit` import in `brainstate/augment/_autograd_test.py` for unit-aware testing.

See [`brainunit.autograd` module](https://brainunit.readthedocs.io/en/latest/apis/brainunit.autograd.html) for details.
