### PR TITLE
compatible with jax==0.4.36

### DIFF
--- a/brainstate/compile/_loop_collect_return.py
+++ b/brainstate/compile/_loop_collect_return.py
@@ -211,7 +211,11 @@ def scan(
 
     # scan
     init = (all_writen_state_vals, init)
-    (all_writen_state_vals, carry), ys = jax.lax.scan(wrapped_f, init, xs, length=length, reverse=reverse,
+    (all_writen_state_vals, carry), ys = jax.lax.scan(wrapped_f,
+                                                      init,
+                                                      xs,
+                                                      length=length,
+                                                      reverse=reverse,
                                                       unroll=unroll)
     # assign the written state values and restore the read state values
     write_back_state_values(state_trace, all_read_state_vals, all_writen_state_vals)

--- a/brainstate/functional/_activations.py
+++ b/brainstate/functional/_activations.py
@@ -588,8 +588,7 @@ def glu(x: ArrayLike, axis: int = -1) -> Union[jax.Array, u.Quantity]:
 
 def log_softmax(x: ArrayLike,
                 axis: int | tuple[int, ...] | None = -1,
-                where: ArrayLike | None = None,
-                initial: ArrayLike | None = None) -> Union[jax.Array, u.Quantity]:
+                where: ArrayLike | None = None) -> Union[jax.Array, u.Quantity]:
     r"""Log-Softmax function.
 
     Computes the logarithm of the :code:`softmax` function, which rescales
@@ -604,8 +603,6 @@ def log_softmax(x: ArrayLike,
       axis: the axis or axes along which the :code:`log_softmax` should be
         computed. Either an integer or a tuple of integers.
       where: Elements to include in the :code:`log_softmax`.
-      initial: The minimum value used to shift the input array. Must be present
-        when :code:`where` is not None.
 
     Returns:
       An array.
@@ -613,15 +610,12 @@ def log_softmax(x: ArrayLike,
     See also:
       :func:`softmax`
     """
-    if initial is not None:
-        initial = u.Quantity(initial).in_unit(u.get_unit(x)).mantissa
-    return _keep_unit(jax.nn.log_softmax, x, axis=axis, where=where, initial=initial)
+    return _keep_unit(jax.nn.log_softmax, x, axis=axis, where=where)
 
 
 def softmax(x: ArrayLike,
             axis: int | tuple[int, ...] | None = -1,
-            where: ArrayLike | None = None,
-            initial: ArrayLike | None = None) -> Union[jax.Array, u.Quantity]:
+            where: ArrayLike | None = None) -> Union[jax.Array, u.Quantity]:
     r"""Softmax function.
 
     Computes the function which rescales elements to the range :math:`[0, 1]`
@@ -645,9 +639,7 @@ def softmax(x: ArrayLike,
     See also:
       :func:`log_softmax`
     """
-    if initial is not None:
-        initial = u.Quantity(initial).in_unit(u.get_unit(x)).mantissa
-    return _keep_unit(jax.nn.softmax, x, axis=axis, where=where, initial=initial)
+    return _keep_unit(jax.nn.softmax, x, axis=axis, where=where)
 
 
 def standardize(x: ArrayLike,

--- a/brainstate/util/_tracers.py
+++ b/brainstate/util/_tracers.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import jax
 import jax.core
-from jax.interpreters import partial_eval as pe
 
 from ._pretty_repr import PrettyRepr, PrettyType, PrettyAttr
 
@@ -24,12 +23,6 @@ __all__ = [
     'StateJaxTracer',
 ]
 
-
-def new_jax_trace():
-    main = jax.core.thread_local_state.trace_state.trace_stack.stack[-1]
-    frame = main.jaxpr_stack[-1]
-    trace = pe.DynamicJaxprTrace(main, jax.core.cur_sublevel())
-    return frame, trace
 
 
 def current_jax_trace():

--- a/examples/100_hh_neuron_model.py
+++ b/examples/100_hh_neuron_model.py
@@ -92,6 +92,7 @@ class HH(bst.nn.Dynamics):
         return spike
 
 
+
 hh = HH(10)
 bst.nn.init_all_states(hh)
 dt = 0.01 * u.ms
@@ -104,10 +105,12 @@ def run(t, inp):
 
 
 times = u.math.arange(0. * u.ms, 100. * u.ms, dt)
-vs = bst.compile.for_loop(run,
-                          # times, random inputs
-                          times, bst.random.uniform(1., 10., times.shape) * u.uA / u.cm ** 2,
-                          pbar=bst.compile.ProgressBar(count=100))
+vs = bst.compile.for_loop(
+    run,
+    # times, random inputs
+    times, bst.random.uniform(1., 10., times.shape) * u.uA / u.cm ** 2,
+    pbar=bst.compile.ProgressBar(count=100)
+)
 
 plt.plot(times.to_decimal(u.ms), vs.to_decimal(u.mV))
 plt.show()

--- a/examples/106_COBA_HH_2007.py
+++ b/examples/106_COBA_HH_2007.py
@@ -21,7 +21,6 @@
 #
 
 import brainunit as u
-import dendritex as dx
 import matplotlib.pyplot as plt
 
 import brainstate as bst
@@ -157,7 +156,7 @@ class EINet(bst.nn.DynamicsGroup):
 
 # network
 net = EINet()
-bst.nn.init_all_states(net, exclude=dx.IonChannel)
+bst.nn.init_all_states(net)
 
 # simulation
 with bst.environ.context(dt=0.1 * u.ms):


### PR DESCRIPTION
This pull request includes multiple changes to improve code readability, simplify function definitions, and update method calls across various files in the `brainstate` package. The most important changes include refactoring functions, cleaning up imports, and updating progress bar handling.

close #44 


### Code readability improvements:

* [`brainstate/compile/_loop_collect_return.py`](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L214-R218): Refactored the `scan` function to improve readability by formatting the parameters of `jax.lax.scan` across multiple lines.

### Function and method updates:

* [`brainstate/compile/_make_jaxpr.py`](diffhunk://#diff-3b05e5bec9c3bff8277ee464c225664461a9ca5288f235982df160f3ac8c2bc9L115-R134): Refactored `_init_state_trace` to `_init_state_trace_stack`, including a new method `_new_jax_trace` to handle different JAX versions, and updated calls to use the new method. [[1]](diffhunk://#diff-3b05e5bec9c3bff8277ee464c225664461a9ca5288f235982df160f3ac8c2bc9L115-R134) [[2]](diffhunk://#diff-3b05e5bec9c3bff8277ee464c225664461a9ca5288f235982df160f3ac8c2bc9L386-R392) [[3]](diffhunk://#diff-3b05e5bec9c3bff8277ee464c225664461a9ca5288f235982df160f3ac8c2bc9L422-R437)

### Import cleanup:

* [`brainstate/compile/_make_jaxpr.py`](diffhunk://#diff-3b05e5bec9c3bff8277ee464c225664461a9ca5288f235982df160f3ac8c2bc9L75): Removed an unused import of `new_jax_trace`.
* [`brainstate/util/_tracers.py`](diffhunk://#diff-a20d091603335ca1a4c6a6912cc315fad641d5c6e0c011a4add37d53d405b315L19): Removed the `new_jax_trace` function and its related import, as it is now defined elsewhere. [[1]](diffhunk://#diff-a20d091603335ca1a4c6a6912cc315fad641d5c6e0c011a4add37d53d405b315L19) [[2]](diffhunk://#diff-a20d091603335ca1a4c6a6912cc315fad641d5c6e0c011a4add37d53d405b315L28-L33)

### Progress bar handling:

* [`brainstate/compile/_progress_bar.py`](diffhunk://#diff-3087a1c2ffed5fa433321044effaa3dee679336d128ce7e5d1d1c60df220ea1eR96-R129): Simplified the progress bar update logic by introducing a new `_tqdm` method and updating the `__call__` method to use `jax.debug.callback`.

### Example updates:

* [`examples/100_hh_neuron_model.py`](diffhunk://#diff-d6b4649d58ab685bfad4835e70b32324ab2648bda5d07f3456d42b14331cef48L107-R113): Improved readability by formatting the parameters of `bst.compile.for_loop` across multiple lines.
* [`examples/106_COBA_HH_2007.py`](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcL24): Removed an unused import of `dendritex` and updated the call to `bst.nn.init_all_states` to exclude the `dx.IonChannel` parameter. [[1]](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcL24) [[2]](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcL160-R159)