### PR TITLE
[compatible with jax 0.4.36] remove `ensure_compile_time_eval` context, fix progress bar in loop transformation

### DIFF
--- a/brainstate/compile/_conditions.py
+++ b/brainstate/compile/_conditions.py
@@ -94,9 +94,8 @@ def cond(pred, true_fun: Callable, false_fun: Callable, *operands):
             return false_fun(*operands)
 
     # evaluate jaxpr
-    with jax.ensure_compile_time_eval():
-        stateful_true = StatefulFunction(true_fun).make_jaxpr(*operands)
-        stateful_false = StatefulFunction(false_fun).make_jaxpr(*operands)
+    stateful_true = StatefulFunction(true_fun).make_jaxpr(*operands)
+    stateful_false = StatefulFunction(false_fun).make_jaxpr(*operands)
 
     # state trace and state values
     state_trace = stateful_true.get_state_trace() + stateful_false.get_state_trace()
@@ -175,10 +174,9 @@ def switch(index, branches: Sequence[Callable], *operands):
         return branches[int(index)](*operands)
 
     # evaluate jaxpr
-    with jax.ensure_compile_time_eval():
-        wrapped_branches = [StatefulFunction(branch) for branch in branches]
-        for wrapped_branch in wrapped_branches:
-            wrapped_branch.make_jaxpr(*operands)
+    wrapped_branches = [StatefulFunction(branch) for branch in branches]
+    for wrapped_branch in wrapped_branches:
+        wrapped_branch.make_jaxpr(*operands)
 
     # wrap the functions
     state_trace = wrapped_branches[0].get_state_trace() + wrapped_branches[1].get_state_trace()

--- a/brainstate/compile/_jit.py
+++ b/brainstate/compile/_jit.py
@@ -83,9 +83,9 @@ def _get_jitted_fun(
             return fun.fun(*args, **params)
 
         # compile the function and get the state trace
-        with jax.ensure_compile_time_eval():
-            state_trace = fun.compile_function_and_get_state_trace(*args, **params, return_only_write=True)
-            read_state_vals = state_trace.get_read_state_values(True)
+        state_trace = fun.compile_function_and_get_state_trace(*args, **params, return_only_write=True)
+        read_state_vals = state_trace.get_read_state_values(True)
+
         # call the jitted function
         write_state_vals, outs = jit_fun(state_trace.get_state_values(), *args, **params)
         # write the state values back to the states

--- a/brainstate/compile/_loop_collect_return.py
+++ b/brainstate/compile/_loop_collect_return.py
@@ -202,12 +202,11 @@ def scan(
     # ------------------------------ #
     xs_avals = [jax.core.raise_to_shaped(jax.core.get_aval(x)) for x in xs_flat]
     x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
-    with jax.ensure_compile_time_eval():
-        stateful_fun = StatefulFunction(f).make_jaxpr(init, xs_tree.unflatten(x_avals))
-        state_trace = stateful_fun.get_state_trace()
-        all_writen_state_vals = state_trace.get_write_state_values(True)
-        all_read_state_vals = state_trace.get_read_state_values(True)
-        wrapped_f = wrap_single_fun(stateful_fun, state_trace.been_writen, all_read_state_vals)
+    stateful_fun = StatefulFunction(f).make_jaxpr(init, xs_tree.unflatten(x_avals))
+    state_trace = stateful_fun.get_state_trace()
+    all_writen_state_vals = state_trace.get_write_state_values(True)
+    all_read_state_vals = state_trace.get_read_state_values(True)
+    wrapped_f = wrap_single_fun(stateful_fun, state_trace.been_writen, all_read_state_vals)
 
     # scan
     init = (all_writen_state_vals, init)

--- a/brainstate/compile/_loop_no_collection.py
+++ b/brainstate/compile/_loop_no_collection.py
@@ -103,11 +103,10 @@ def while_loop(
             pass
 
     # evaluate jaxpr
-    with jax.ensure_compile_time_eval():
-        stateful_cond = StatefulFunction(cond_fun).make_jaxpr(init_val)
-        stateful_body = StatefulFunction(body_fun).make_jaxpr(init_val)
-        if len(stateful_cond.get_write_states()) != 0:
-            raise ValueError("while_loop: cond_fun should not have any write states.")
+    stateful_cond = StatefulFunction(cond_fun).make_jaxpr(init_val)
+    stateful_body = StatefulFunction(body_fun).make_jaxpr(init_val)
+    if len(stateful_cond.get_write_states()) != 0:
+        raise ValueError("while_loop: cond_fun should not have any write states.")
 
     # state trace and state values
     state_trace = stateful_cond.get_state_trace() + stateful_body.get_state_trace()

--- a/brainstate/compile/_progress_bar.py
+++ b/brainstate/compile/_progress_bar.py
@@ -105,25 +105,26 @@ class ProgressBarRunner(object):
             self.tqdm_bars[0].close()
 
     def __call__(self, iter_num, *args, **kwargs):
-        jax.debug.callback(
-            self._tqdm,
+        # jax.debug.callback(
+        #     self._tqdm,
+        #     iter_num == 0,
+        #     (iter_num + 1) % self.print_freq == 0,
+        #     iter_num == self.n - 1
+        # )
+
+        _ = jax.lax.cond(
             iter_num == 0,
-            (iter_num + 1) % self.print_freq == 0,
-            iter_num == self.n - 1
+            lambda: jax.debug.callback(self._define_tqdm),
+            lambda: None,
+        )
+        _ = jax.lax.cond(
+            iter_num % self.print_freq == (self.print_freq - 1),
+            lambda: jax.debug.callback(self._update_tqdm),
+            lambda: None,
+        )
+        _ = jax.lax.cond(
+            iter_num == self.n - 1,
+            lambda: jax.debug.callback(self._close_tqdm),
+            lambda: None,
         )
 
-        # _ = jax.lax.cond(
-        #     iter_num == 0,
-        #     lambda: jax.debug.callback(self._define_tqdm, ordered=True),
-        #     lambda: None,
-        # )
-        # _ = jax.lax.cond(
-        #     (iter_num + 1) % self.print_freq == 0,
-        #     lambda: jax.debug.callback(self._update_tqdm, ordered=True),
-        #     lambda: None,
-        # )
-        # _ = jax.lax.cond(
-        #     iter_num == self.n - 1,
-        #     lambda: jax.debug.callback(self._close_tqdm, ordered=True),
-        #     lambda: None,
-        # )


### PR DESCRIPTION
This pull request includes several changes to the `brainstate/compile` module, primarily focusing on removing the use of `jax.ensure_compile_time_eval()` and updating the progress bar logic. The most important changes are listed below:

### Removal of `jax.ensure_compile_time_eval()`:

* [`brainstate/compile/_conditions.py`](diffhunk://#diff-5979338a8c6fd1d94d3cb033744d03d284d38f465b292c3c0f9479ab867c78ecL97): Removed `jax.ensure_compile_time_eval()` from the `cond` and `switch` functions. [[1]](diffhunk://#diff-5979338a8c6fd1d94d3cb033744d03d284d38f465b292c3c0f9479ab867c78ecL97) [[2]](diffhunk://#diff-5979338a8c6fd1d94d3cb033744d03d284d38f465b292c3c0f9479ab867c78ecL178)
* [`brainstate/compile/_jit.py`](diffhunk://#diff-0eb3487b796f5aa8cd41009c62b7b223943f72676ee6de61d49d5e6578af735eL86-R88): Removed `jax.ensure_compile_time_eval()` from the `jitted_fun` function.
* [`brainstate/compile/_loop_collect_return.py`](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L205): Removed `jax.ensure_compile_time_eval()` from the `scan` function.
* [`brainstate/compile/_loop_no_collection.py`](diffhunk://#diff-4993ed4455be8d9d6aa69e22928d7a9a4186ff8c2f679e360a2a040d5b5b980aL106): Removed `jax.ensure_compile_time_eval()` from the `while_loop` function.

### Progress bar logic update:

* [`brainstate/compile/_progress_bar.py`](diffhunk://#diff-3087a1c2ffed5fa433321044effaa3dee679336d128ce7e5d1d1c60df220ea1eL108-R130): Updated the `_tqdm` function to use `jax.lax.cond` for conditional callbacks instead of `jax.debug.callback`.