### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     </a>
     <a href="https://badge.fury.io/py/brainstate"><img alt="PyPI version" src="https://badge.fury.io/py/brainstate.svg"></a>
     <a href="https://github.com/chaobrain/brainstate/actions/workflows/CI.yml"><img alt="Continuous Integration" src="https://github.com/chaobrain/brainstate/actions/workflows/CI.yml/badge.svg"></a>
+    <a href="https://pepy.tech/projects/brainstate"><img src="https://static.pepy.tech/badge/brainstate" alt="PyPI Downloads"></a>
 </p>
 
 

--- a/brainstate/compile/_loop_collect_return.py
+++ b/brainstate/compile/_loop_collect_return.py
@@ -63,7 +63,7 @@ def scan(
     length: int | None = None,
     reverse: bool = False,
     unroll: int | bool = 1,
-    pbar: ProgressBar | None = None,
+    pbar: ProgressBar | int | None = None,
 ) -> Tuple[Carry, Y]:
     """
     Scan a function over leading array axes while carrying along state.
@@ -177,7 +177,13 @@ def scan(
     has_pbar = False
     if pbar is not None:
         has_pbar = True
-        f = _wrap_fun_with_pbar(f, pbar.init(length))
+        if isinstance(pbar, ProgressBar):
+            pbar_runner = pbar.init(length)
+        elif isinstance(pbar, int):
+            pbar_runner = ProgressBar(freq=pbar).init(length)
+        else:
+            raise TypeError("pbar argument should be a ProgressBar instance or an integer.")
+        f = _wrap_fun_with_pbar(f, pbar_runner)
         init = (0, init) if pbar else init
 
     # not jit
@@ -230,7 +236,7 @@ def checkpointed_scan(
     xs: X,
     length: Optional[int] = None,
     base: int = 16,
-    pbar: Optional[ProgressBar] = None,
+    pbar: Optional[ProgressBar | int] = None,
 ) -> Tuple[Carry, Y]:
     """
     Scan a function over leading array axes while carrying along state.
@@ -288,8 +294,10 @@ def checkpointed_scan(
             length, = unique_lengths
 
     # function with progress bar
-    if pbar is not None:
+    if isinstance(pbar, ProgressBar):
         pbar_runner = pbar.init(length)
+    elif isinstance(pbar, int):
+        pbar_runner = ProgressBar(freq=pbar).init(length)
     else:
         pbar_runner = None
 
@@ -380,7 +388,7 @@ def for_loop(
     length: Optional[int] = None,
     reverse: bool = False,
     unroll: int | bool = 1,
-    pbar: Optional[ProgressBar] = None
+    pbar: Optional[ProgressBar | int] = None
 ) -> Y:
     """
     ``for-loop`` control flow with :py:class:`~.State`.
@@ -432,7 +440,7 @@ def checkpointed_for_loop(
     *xs: X,
     length: Optional[int] = None,
     base: int = 16,
-    pbar: Optional[ProgressBar] = None,
+    pbar: Optional[ProgressBar | int] = None,
 ) -> Y:
     """
     ``for-loop`` control flow with :py:class:`~.State` with a checkpointed version, similar to :py:func:`for_loop`.

--- a/brainstate/compile/_progress_bar.py
+++ b/brainstate/compile/_progress_bar.py
@@ -35,6 +35,8 @@ class ProgressBar(object):
 
     def __init__(self, freq: Optional[int] = None, count: Optional[int] = None, **kwargs):
         self.print_freq = freq
+        if isinstance(freq, int):
+            assert freq > 0, "Print rate should be > 0."
         self.print_count = count
         if self.print_freq is not None and self.print_count is not None:
             raise ValueError("Cannot specify both count and freq.")

--- a/brainstate/event/__init__.py
+++ b/brainstate/event/__init__.py
@@ -14,14 +14,16 @@
 # ==============================================================================
 
 
+from ._csr import *
 from ._csr_mv import *
-from ._csr_mv import __all__ as __all_csr
 from ._fixedprob_mv import *
-from ._fixedprob_mv import __all__ as __all_fixed_probability
 from ._linear_mv import *
 from ._xla_custom_op import *
-from ._xla_custom_op import __all__ as __all_xla_custom_op
-from ._linear_mv import __all__ as __all_linear
 
-__all__ = __all_fixed_probability + __all_linear + __all_csr + __all_xla_custom_op
-del __all_fixed_probability, __all_linear, __all_csr, __all_xla_custom_op
+__all__ = [
+    'CSRLinear',
+    'FixedProb',
+    'XLACustomOp',
+    'CSR',
+    'CSC',
+]

--- a/brainstate/event/_csr.py
+++ b/brainstate/event/_csr.py
@@ -1,0 +1,574 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import Callable
+
+import brainunit as u
+import jax
+import jax.numpy as jnp
+from brainunit.sparse.csr import _csr_matvec as csr_matvec, _csr_matmat as csr_matmat
+from brainunit.sparse.csr import _csr_to_coo as csr_to_coo
+from jax.experimental.sparse import JAXSparse
+from jax.interpreters import ad
+
+from brainstate.typing import Shape
+from ._xla_custom_op import XLACustomOp
+
+__all__ = [
+    'CSR',
+    'CSC',
+]
+
+
+class CSR(u.sparse.CSR):
+    """
+    Event-driven sparse matrix in CSR format.
+    """
+
+    def __matmul__(self, other):
+        if isinstance(other, JAXSparse):
+            raise NotImplementedError("matmul between two sparse objects.")
+        other = u.math.asarray(other)
+        data, other = u.math.promote_dtypes(self.data, other)
+        if other.ndim == 1:
+            return _csr_matvec(
+                data,
+                self.indices,
+                self.indptr,
+                other,
+                shape=self.shape
+            )
+        elif other.ndim == 2:
+            return _csr_matmat(
+                data,
+                self.indices,
+                self.indptr,
+                other,
+                shape=self.shape
+            )
+        else:
+            raise NotImplementedError(f"matmul with object of shape {other.shape}")
+
+    def __rmatmul__(self, other):
+        if isinstance(other, JAXSparse):
+            raise NotImplementedError("matmul between two sparse objects.")
+        other = u.math.asarray(other)
+        data, other = u.math.promote_dtypes(self.data, other)
+        if other.ndim == 1:
+            return _csr_matvec(
+                data,
+                self.indices,
+                self.indptr,
+                other,
+                shape=self.shape,
+                transpose=True
+            )
+        elif other.ndim == 2:
+            other = other.T
+            r = _csr_matmat(
+                data,
+                self.indices,
+                self.indptr,
+                other,
+                shape=self.shape,
+                transpose=True
+            )
+            return r.T
+        else:
+            raise NotImplementedError(f"matmul with object of shape {other.shape}")
+
+
+class CSC(u.sparse.CSC):
+    """
+    Event-driven sparse matrix in CSC format.
+    """
+
+    def __matmul__(self, other):
+        if isinstance(other, JAXSparse):
+            raise NotImplementedError("matmul between two sparse objects.")
+        other = u.math.asarray(other)
+        data, other = u.math.promote_dtypes(self.data, other)
+        if other.ndim == 1:
+            return _csr_matvec(
+                data,
+                self.indices,
+                self.indptr,
+                other,
+                shape=self.shape[::-1],
+                transpose=True
+            )
+        elif other.ndim == 2:
+            return _csr_matmat(
+                data,
+                self.indices,
+                self.indptr,
+                other,
+                shape=self.shape[::-1],
+                transpose=True
+            )
+        else:
+            raise NotImplementedError(f"matmul with object of shape {other.shape}")
+
+    def __rmatmul__(self, other):
+        if isinstance(other, JAXSparse):
+            raise NotImplementedError("matmul between two sparse objects.")
+        other = u.math.asarray(other)
+        data, other = u.math.promote_dtypes(self.data, other)
+        if other.ndim == 1:
+            return _csr_matvec(
+                data,
+                self.indices,
+                self.indptr,
+                other,
+                shape=self.shape[::-1],
+                transpose=False
+            )
+        elif other.ndim == 2:
+            other = other.T
+            r = _csr_matmat(
+                data,
+                self.indices,
+                self.indptr, other,
+                shape=self.shape[::-1],
+                transpose=False
+            )
+            return r.T
+        else:
+            raise NotImplementedError(f"matmul with object of shape {other.shape}")
+
+
+def _csr_matvec(
+    data: jax.Array | u.Quantity,
+    indices: jax.Array,
+    indptr: jax.Array,
+    v: jax.Array | u.Quantity,
+    *,
+    shape: Shape,
+    transpose: bool = False,
+    float_as_event: bool = True,
+) -> jax.Array | u.Quantity:
+    """Product of CSR sparse matrix and a dense vector.
+
+    Args:
+      data : array of shape ``(nse,)``.
+      indices : array of shape ``(nse,)``
+      indptr : array of shape ``(shape[0] + 1,)`` and dtype ``indices.dtype``
+      v : array of shape ``(shape[0] if transpose else shape[1],)``
+        and dtype ``data.dtype``
+      shape : length-2 tuple representing the matrix shape
+      transpose : boolean specifying whether to transpose the sparse matrix
+        before computing.
+
+    Returns:
+      y : array of shape ``(shape[1] if transpose else shape[0],)`` representing
+        the matrix vector product.
+    """
+    data, unitd = u.split_mantissa_unit(data)
+    v, unitv = u.split_mantissa_unit(v)
+    # res = csr_matvec_p.bind(data, indices, indptr, v, shape=shape, transpose=transpose)
+    res = event_csrmv_p_call(
+        data, indices, indptr, v,
+        shape=shape,
+        transpose=transpose,
+        float_as_event=float_as_event
+    )[0]
+    return u.maybe_decimal(res * (unitd * unitv))
+
+
+def _csr_matmat(
+    data: jax.Array | u.Quantity,
+    indices: jax.Array,
+    indptr: jax.Array,
+    B: jax.Array | u.Quantity,
+    *,
+    shape: Shape,
+    transpose: bool = False
+) -> jax.Array | u.Quantity:
+    """
+    Product of CSR sparse matrix and a dense matrix.
+
+    Args:
+      data : array of shape ``(nse,)``.
+      indices : array of shape ``(nse,)``
+      indptr : array of shape ``(shape[0] + 1,)`` and dtype ``indices.dtype``
+      B : array of shape ``(shape[0] if transpose else shape[1], cols)`` and
+        dtype ``data.dtype``
+      shape : length-2 tuple representing the matrix shape
+      transpose : boolean specifying whether to transpose the sparse matrix
+        before computing.
+
+    Returns:
+      C : array of shape ``(shape[1] if transpose else shape[0], cols)``
+        representing the matrix-matrix product.
+    """
+    data, unitd = u.split_mantissa_unit(data)
+    B, unitb = u.split_mantissa_unit(B)
+    res = csr_matmat_p.bind(data, indices, indptr, B, shape=shape, transpose=transpose)
+    return u.maybe_decimal(res * (unitd * unitb))
+
+
+Kernel = Callable
+
+
+def event_csrmv_cpu_kernel_generator(
+    float_as_event: bool,
+    weight_info: jax.ShapeDtypeStruct,
+    spike_info: jax.ShapeDtypeStruct,
+    transpose: bool,
+    **kwargs
+) -> Kernel:
+    import numba  # pylint: disable=import-outside-toplevel
+
+    if weight_info.size == 1:
+        if transpose:
+            if spike_info.dtype == jnp.bool_:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    posts[:] = 0.
+                    w = weights[()]
+                    for i in range(v.shape[0]):
+                        if v[i]:
+                            for j in range(indptr[i], indptr[i + 1]):
+                                posts[indices[j]] += w
+
+            elif float_as_event:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    posts[:] = 0.
+                    w = weights[()]
+                    for i in range(v.shape[0]):
+                        if v[i] != 0.:
+                            for j in range(indptr[i], indptr[i + 1]):
+                                posts[indices[j]] += w
+
+            else:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    posts[:] = 0.
+                    w = weights[()]
+                    for i in range(v.shape[0]):
+                        sp = v[i]
+                        if sp != 0.:
+                            wsp = w * sp
+                            for j in range(indptr[i], indptr[i + 1]):
+                                posts[indices[j]] += wsp
+
+        else:
+            if spike_info.dtype == jnp.bool_:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    w = weights[()]
+                    for i in range(indptr.shape[0] - 1):
+                        r = 0.
+                        for j in range(indptr[i], indptr[i + 1]):
+                            if v[indices[j]]:
+                                r += w
+                        posts[i] = r
+
+            elif float_as_event:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    w = weights[()]
+                    for i in range(indptr.shape[0] - 1):
+                        r = 0.
+                        for j in range(indptr[i], indptr[i + 1]):
+                            if v[indices[j]] != 0.:
+                                r += w
+                        posts[i] = r
+
+            else:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    w = weights[()]
+                    for i in range(indptr.shape[0] - 1):
+                        r = 0.
+                        for j in range(indptr[i], indptr[i + 1]):
+                            c = v[indices[j]]
+                            if c != 0.:
+                                r += w * c
+                        posts[i] = r
+
+    else:
+        if transpose:
+            if spike_info.dtype == jnp.bool_:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    posts[:] = 0.
+                    for i in range(v.shape[0]):
+                        if v[i]:
+                            for j in range(indptr[i], indptr[i + 1]):
+                                posts[indices[j]] += weights[j]
+
+            elif float_as_event:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    posts[:] = 0.
+                    for i in range(v.shape[0]):
+                        if v[i] != 0.:
+                            for j in range(indptr[i], indptr[i + 1]):
+                                posts[indices[j]] += weights[j]
+
+            else:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    posts[:] = 0.
+                    for i in range(v.shape[0]):
+                        sp = v[i]
+                        if sp != 0.:
+                            for j in range(indptr[i], indptr[i + 1]):
+                                posts[indices[j]] += weights[j] * sp
+
+        else:
+            if spike_info.dtype == jnp.bool_:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    for i in range(indptr.shape[0] - 1):
+                        r = 0.
+                        for j in range(indptr[i], indptr[i + 1]):
+                            if v[indices[j]]:
+                                r += weights[j]
+                        posts[i] = r
+
+            elif float_as_event:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    for i in range(indptr.shape[0] - 1):
+                        r = 0.
+                        for j in range(indptr[i], indptr[i + 1]):
+                            if v[indices[j]] != 0.:
+                                r += weights[j]
+                        posts[i] = r
+
+            else:
+                @numba.njit
+                def mv(weights, indices, indptr, v, posts):
+                    for i in range(indptr.shape[0] - 1):
+                        r = 0.
+                        for j in range(indptr[i], indptr[i + 1]):
+                            c = v[indices[j]]
+                            if c != 0.:
+                                r += weights[j] * c
+                        posts[i] = r
+
+    return mv
+
+
+def event_csrmv_jvp_v(
+    v_dot,
+    data,
+    indices,
+    indptr,
+    v,
+    *,
+    shape,
+    transpose,
+    **kwargs
+):
+    return [
+        csr_matvec(
+            data,
+            indices,
+            indptr,
+            v_dot,
+            shape=shape,
+            transpose=transpose
+        )
+    ]
+
+
+def event_csrmv_jvp_weights(
+    data_dot,
+    data,
+    indices,
+    indptr,
+    v,
+    *,
+    shape,
+    transpose,
+    float_as_event,
+    **kwargs
+):
+    return event_csrmv_p_call(
+        data_dot,
+        indices,
+        indptr,
+        v,
+        shape=shape,
+        transpose=transpose,
+        float_as_event=float_as_event,
+    )
+
+
+def event_csrmv_transpose_rule(
+    ct,
+    data,
+    indices,
+    indptr,
+    events,
+    *,
+    shape,
+    float_as_event,
+    transpose,
+    **kwargs
+):
+    if ad.is_undefined_primal(indices):
+        raise ValueError("Cannot transpose with respect to sparse indices.")
+
+    ct = ct[0]
+
+    if ad.is_undefined_primal(indices) or ad.is_undefined_primal(indptr):
+        raise ValueError("Cannot transpose with respect to sparse indices.")
+    if ad.is_undefined_primal(events):
+        ct_events = csr_matvec(
+            data,
+            indices,
+            indptr,
+            ct,
+            shape=shape,
+            transpose=not transpose
+        )[0]
+        return data, indices, indptr, (ad.Zero(events) if type(ct) is ad.Zero else ct_events)
+    else:
+        if type(ct[0]) is ad.Zero:
+            ct_values = ad.Zero(data)
+        else:
+            if data.aval.shape[0] == 1:  # scalar
+                ct_values = event_csrmv_p_call(
+                    jnp.ones(1, dtype=data.dtype),
+                    indices,
+                    indptr,
+                    events,
+                    shape=shape,
+                    transpose=transpose,
+                    float_as_event=float_as_event,
+                )[0]
+                ct_values = jnp.inner(ct, ct_values)
+            else:  # heterogeneous values
+                row, col = csr_to_coo(indices, indptr)
+                ct_values = events[row] * ct[col] if transpose else events[col] * ct[row]
+        return ct_values, indices, indptr, events
+
+
+def event_csrmv_batching(args, axes, **kwargs):
+    if tuple(axes) == (None, None, None, 0):
+        return 0, event_csrmm_p_call(*args, **kwargs)
+    else:
+        raise NotImplementedError(f"Batching axes {axes} not implemented for event-driven CSR matrix-vector product.")
+
+
+event_csrmv_p = XLACustomOp(
+    'event_csrmv',
+    cpu_kernel_or_generator=event_csrmv_cpu_kernel_generator,
+)
+event_csrmv_p.defjvp(event_csrmv_jvp_weights, None, None, event_csrmv_jvp_v)
+event_csrmv_p.def_transpose_rule(event_csrmv_transpose_rule)
+event_csrmv_p.def_batching_rule(event_csrmv_batching)
+
+
+def event_csrmv_p_call(
+    weights,
+    indices,
+    indptr,
+    v,
+    *,
+    shape,
+    transpose,
+    float_as_event,
+):
+    if jax.default_backend() == 'cpu':
+        return event_csrmv_p(
+            weights,
+            indices,
+            indptr,
+            v,
+            outs=[
+                jax.ShapeDtypeStruct([shape[1]], weights.dtype)
+                if transpose else
+                jax.ShapeDtypeStruct([shape[0]], weights.dtype),
+            ],
+            # block_size=block_size,
+            float_as_event=float_as_event,
+            shape=shape,
+            transpose=transpose,
+            weight_info=jax.ShapeDtypeStruct(weights.shape, weights.dtype),
+            spike_info=jax.ShapeDtypeStruct(v.shape, v.dtype),
+        )
+    else:
+        return [
+            csr_matvec(
+                weights,
+                indices,
+                indptr,
+                v,
+                shape=shape,
+                transpose=transpose
+            )
+        ]
+
+
+def event_csrmm_batching(args, axes, **kwargs):
+    if tuple(axes) == (None, None, None, 0):
+        batch_shape = args[3].shape[:-1]
+        B = jnp.reshape(args[3], (-1, args[3].shape[-1:]))
+        r = event_csrmm_p_call(args[0], args[1], args[2], B, **kwargs)
+        return 0, [jnp.reshape(r[0], batch_shape + r.shape[-1:])]
+    else:
+        raise NotImplementedError(f"Batching axes {axes} not implemented for event-driven CSR matrix-vector product.")
+
+
+event_csrmm_p = XLACustomOp(
+    'event_csrmm',
+    cpu_kernel_or_generator=event_csrmv_cpu_kernel_generator,
+)
+event_csrmm_p.def_batching_rule(event_csrmm_batching)
+
+
+def event_csrmm_p_call(
+    weights,
+    indices,
+    indptr,
+    B,
+    *,
+    shape,
+    transpose,
+    float_as_event,
+):
+    if jax.default_backend() == 'cpu':
+        return event_csrmm_p(
+            weights,
+            indices,
+            indptr,
+            B,
+            outs=[
+                jax.ShapeDtypeStruct([shape[0], B.shape[1]], weights.dtype)
+                if transpose else
+                jax.ShapeDtypeStruct([shape[1], B.shape[1]], weights.dtype),
+            ],
+            # block_size=block_size,
+            float_as_event=float_as_event,
+            weight_info=jax.ShapeDtypeStruct(weights.shape, weights.dtype),
+            spike_info=jax.ShapeDtypeStruct(B.shape, B.dtype),
+        )
+    else:
+        return [
+            csr_matmat(
+                weights,
+                indices,
+                indptr,
+                B,
+                shape=shape,
+                transpose=transpose
+            )
+        ]

--- a/brainstate/event/_csr_test.py
+++ b/brainstate/event/_csr_test.py
@@ -1,0 +1,90 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# -*- coding: utf-8 -*-
+
+
+import unittest
+
+import brainunit as u
+
+import brainstate as bst
+
+
+class TestCSR(unittest.TestCase):
+    def test_event_homo_bool(self):
+        for dat in [1., 2., 3.]:
+            mask = (bst.random.rand(10, 20) < 0.1).astype(float) * dat
+            csr = u.sparse.CSR.fromdense(mask)
+            csr = bst.event.CSR((dat, csr.indices, csr.indptr), shape=mask.shape)
+
+            v = bst.random.rand(20) < 0.5
+            self.assertTrue(
+                u.math.allclose(
+                    mask.astype(float) @ v.astype(float),
+                    csr @ v
+                )
+            )
+
+            v = bst.random.rand(10) < 0.5
+            self.assertTrue(
+                u.math.allclose(
+                    v.astype(float) @ mask.astype(float),
+                    v @ csr
+                )
+            )
+
+    def test_event_homo_heter(self):
+        mat = bst.random.rand(10, 20)
+        mask = (bst.random.rand(10, 20) < 0.1) * mat
+        csr = u.sparse.CSR.fromdense(mask)
+        csr = bst.event.CSR((csr.data, csr.indices, csr.indptr), shape=mask.shape)
+
+        v = bst.random.rand(20) < 0.5
+        self.assertTrue(
+            u.math.allclose(
+                mask.astype(float) @ v.astype(float),
+                csr @ v
+            )
+        )
+
+        v = bst.random.rand(10) < 0.5
+        self.assertTrue(
+            u.math.allclose(
+                v.astype(float) @ mask.astype(float),
+                v @ csr
+            )
+        )
+
+    def test_event_heter_float_as_bool(self):
+        mat = bst.random.rand(10, 20)
+        mask = (mat < 0.1).astype(float) * mat
+        csr = u.sparse.CSR.fromdense(mask)
+        csr = bst.event.CSR((csr.data, csr.indices, csr.indptr), shape=mask.shape)
+
+        v = (bst.random.rand(20) < 0.5).astype(float)
+        self.assertTrue(
+            u.math.allclose(
+                mask.astype(float) @ v.astype(float),
+                csr @ v
+            )
+        )
+
+        v = (bst.random.rand(10) < 0.5).astype(float)
+        self.assertTrue(
+            u.math.allclose(
+                v.astype(float) @ mask.astype(float),
+                v @ csr
+            )
+        )

--- a/brainstate/event/_fixedprob_mv.py
+++ b/brainstate/event/_fixedprob_mv.py
@@ -473,8 +473,8 @@ def transpose_rule(
 
 event_ellmv_p = XLACustomOp(
     'event_ell_mv',
-    cpu_kernel_generator=cpu_kernel_generator,
-    gpu_kernel_generator=gpu_kernel_generator,
+    cpu_kernel_or_generator=cpu_kernel_generator,
+    gpu_kernel_or_generator=gpu_kernel_generator,
 )
 event_ellmv_p.defjvp(jvp_spikes, jvp_weights, None)
 event_ellmv_p.def_transpose_rule(transpose_rule)
@@ -693,8 +693,8 @@ def transpose_rule_no_spk(
 
 ellmv_p = XLACustomOp(
     'ell_mv',
-    cpu_kernel_generator=ell_cpu_kernel_generator,
-    gpu_kernel_generator=ell_gpu_kernel_generator,
+    cpu_kernel_or_generator=ell_cpu_kernel_generator,
+    gpu_kernel_or_generator=ell_gpu_kernel_generator,
 )
 ellmv_p.defjvp(jvp_spikes, jvp_weights_no_spk, None)
 ellmv_p.def_transpose_rule(transpose_rule_no_spk)

--- a/brainstate/event/_linear_mv.py
+++ b/brainstate/event/_linear_mv.py
@@ -334,8 +334,8 @@ def transpose_rule(ct, spikes, weights, *, float_as_event, **kwargs):
 
 event_linear_p = XLACustomOp(
     'event_linear',
-    cpu_kernel_generator=cpu_kernel_generator,
-    gpu_kernel_generator=gpu_kernel_generator,
+    cpu_kernel_or_generator=cpu_kernel_generator,
+    gpu_kernel_or_generator=gpu_kernel_generator,
 )
 event_linear_p.defjvp(jvp_spikes, jvp_weights)
 event_linear_p.def_transpose_rule(transpose_rule)

--- a/brainstate/event/_xla_custom_op.py
+++ b/brainstate/event/_xla_custom_op.py
@@ -180,8 +180,8 @@ class XLACustomOp:
     """Creating a XLA custom call operator.
 
     Args:
-      cpu_kernel_generator: Callable. The function defines the computation on CPU backend.
-      gpu_kernel_generator: Callable. The function defines the computation on GPU backend.
+      cpu_kernel_or_generator: Callable. The function defines the computation on CPU backend.
+      gpu_kernel_or_generator: Callable. The function defines the computation on GPU backend.
       batching_translation: Callable. The batching translation rule of JAX.
       jvp_translation: Callable. The JVP translation rule of JAX.
       transpose_translation: Callable. The transpose translation rule of JAX.
@@ -191,15 +191,12 @@ class XLACustomOp:
     def __init__(
         self,
         name: str,
-        cpu_kernel_generator: Callable,
-        gpu_kernel_generator: Callable = None,
+        cpu_kernel_or_generator: Callable,
+        gpu_kernel_or_generator: Callable = None,
         batching_translation: Callable = None,
         jvp_translation: Callable = None,
         transpose_translation: Callable = None,
     ):
-        # set cpu_kernel and gpu_kernel
-        self.cpu_kernel = cpu_kernel_generator
-
         # primitive
         self.primitive = jax.core.Primitive(name)
         self.primitive.multiple_results = True
@@ -209,10 +206,10 @@ class XLACustomOp:
         self.primitive.def_abstract_eval(self._abstract_eval)
 
         # cpu kernel
-        if cpu_kernel_generator is not None:
-            self.def_cpu_kernel(cpu_kernel_generator)
-        if gpu_kernel_generator is not None:
-            self.def_gpu_kernel(gpu_kernel_generator)
+        if cpu_kernel_or_generator is not None:
+            self.def_cpu_kernel(cpu_kernel_or_generator)
+        if gpu_kernel_or_generator is not None:
+            self.def_gpu_kernel(gpu_kernel_or_generator)
 
         # batching rule
         if batching_translation is not None:

--- a/brainstate/graph/_graph_node.py
+++ b/brainstate/graph/_graph_node.py
@@ -173,8 +173,9 @@ def _to_shape_dtype(value):
 def _node_flatten(
     node: Node
 ) -> Tuple[Tuple[Tuple[str, Any], ...], Tuple[Type]]:
-    graph_invisible_attrs = getattr(node, 'graph_invisible_attrs', ())
-    graph_invisible_attrs = tuple(graph_invisible_attrs) + ('_trace_state',)
+    # graph_invisible_attrs = getattr(node, 'graph_invisible_attrs', ())
+    # graph_invisible_attrs = tuple(graph_invisible_attrs) + ('_trace_state',)
+    graph_invisible_attrs = ('_trace_state',)
     nodes = sorted(
         (key, value) for key, value in vars(node).items()
         if (key not in graph_invisible_attrs)

--- a/brainstate/graph/_graph_node.py
+++ b/brainstate/graph/_graph_node.py
@@ -61,6 +61,9 @@ class Node(PrettyRepr, metaclass=GraphNodeMeta):
     - Deepcopy the node.
 
     """
+
+    graph_invisible_attrs = ()
+
     if TYPE_CHECKING:
         _trace_state: StateJaxTracer
 
@@ -170,7 +173,12 @@ def _to_shape_dtype(value):
 def _node_flatten(
     node: Node
 ) -> Tuple[Tuple[Tuple[str, Any], ...], Tuple[Type]]:
-    nodes = sorted((key, value) for key, value in vars(node).items() if key != '_trace_state')
+    graph_invisible_attrs = getattr(node, 'graph_invisible_attrs', ())
+    graph_invisible_attrs = tuple(graph_invisible_attrs) + ('_trace_state',)
+    nodes = sorted(
+        (key, value) for key, value in vars(node).items()
+        if (key not in graph_invisible_attrs)
+    )
     return nodes, (type(node),)
 
 

--- a/brainstate/graph/_graph_operation.py
+++ b/brainstate/graph/_graph_operation.py
@@ -608,9 +608,9 @@ def _get_children(graph_def, state_mapping, index_ref, index_ref_cache):
                         if isinstance(value, TreefyState):
                             variable.update_from_ref(value)
                         elif isinstance(value, State):
-                             if value._been_writen:
+                            if value._been_writen:
                                 variable.write_value(value.value)
-                             else:
+                            else:
                                 variable.restore_value(value.value)
                         else:
                             raise ValueError(f'Expected a State type for {key!r}, but got {type(value)}.')
@@ -1600,10 +1600,12 @@ def iter_leaf(
             visited_.add(id(node_))
             node_dict = _get_node_impl(node_).node_dict(node_)
             for key, value in node_dict.items():
-                yield from _iter_graph_leaf(value,
-                                            visited_,
-                                            (*path_parts_, key),
-                                            level_ + 1 if _is_graph_node(value) else level_)
+                yield from _iter_graph_leaf(
+                    value,
+                    visited_,
+                    (*path_parts_, key),
+                    level_ + 1 if _is_graph_node(value) else level_
+                )
         else:
             if level_ >= allowed_hierarchy[0]:
                 yield path_parts_, node_

--- a/brainstate/nn/_dynamics/_dynamics_base.py
+++ b/brainstate/nn/_dynamics/_dynamics_base.py
@@ -107,6 +107,8 @@ class Dynamics(Module):
 
     __module__ = 'brainstate.nn'
 
+    graph_invisible_attrs = ('_before_updates', '_after_updates', '_current_inputs', '_delta_inputs')
+
     # before updates
     _before_updates: Optional[Dict[Hashable, Callable]]
 

--- a/brainstate/nn/_dynamics/_dynamics_base.py
+++ b/brainstate/nn/_dynamics/_dynamics_base.py
@@ -445,6 +445,16 @@ class Prefetch(Node):
         item = _get_prefetch_item(self)
         return item.value if isinstance(item, State) else item
 
+    def get_item_value(self):
+        item = _get_prefetch_item(self)
+        return item.value if isinstance(item, State) else item
+
+    def get_item(self):
+        """
+        Get
+        """
+        return _get_prefetch_item(self)
+
 
 class PrefetchDelay(Node):
     def __init__(self, module: Dynamics, item: str):

--- a/brainstate/random/_rand_funs.py
+++ b/brainstate/random/_rand_funs.py
@@ -959,9 +959,13 @@ def logistic(loc=None, scale=None, size: Optional[Size] = None,
     return DEFAULT.logistic(loc, scale, size, key=key, dtype=dtype)
 
 
-def normal(loc=None, scale=None, size: Optional[Size] = None,
-           key: Optional[SeedOrKey] = None,
-           dtype: DTypeLike = None):
+def normal(
+    loc=None,
+    scale=None,
+    size: Optional[Size] = None,
+    key: Optional[SeedOrKey] = None,
+    dtype: DTypeLike = None
+):
     r"""
     Draw random samples from a normal (Gaussian) distribution.
 

--- a/brainstate/typing.py
+++ b/brainstate/typing.py
@@ -32,6 +32,7 @@ __all__ = [
     'Filter',
     'PyTree',
     'Size',
+    'Shape',
     'Axes',
     'SeedOrKey',
     'ArrayLike',
@@ -257,6 +258,8 @@ f. A structure can end with a `...`, to denote that the PyTree must be a prefix 
 Size = tp.Union[int, tp.Sequence[int]]
 Axes = tp.Union[int, tp.Sequence[int]]
 SeedOrKey = tp.Union[int, jax.Array, np.ndarray]
+Shape = tp.Sequence[int]
+
 
 # --- Array --- #
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     'jax',
     'jaxlib',
     'numpy',
-    'brainunit>=0.0.3.post20241214',
+    'brainunit>=0.0.4',
 ]
 
 dynamic = ['version']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 jax
 jaxlib
-brainunit>=0.0.3
+brainunit>=0.0.4

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email='chao.brain@qq.com',
     packages=packages,
     python_requires='>=3.9',
-    install_requires=['numpy>=1.15', 'jax', 'tqdm', 'brainunit>=0.0.3.post20241214'],
+    install_requires=['numpy>=1.15', 'jax', 'tqdm', 'brainunit>=0.0.4'],
     url='https://github.com/chaobrain/brainstate',
     project_urls={
         "Bug Tracker": "https://github.com/chaobrain/brainstate/issues",


### PR DESCRIPTION
This pull request includes several changes aimed at enhancing functionality and improving code quality. The key changes include modifications to the `ProgressBar` handling, updates to `XLACustomOp`, and the addition of new classes and methods to support Poisson input functionality.

### Enhancements to `ProgressBar` handling:

* [`brainstate/compile/_loop_collect_return.py`](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L66-R66): Updated the `pbar` parameter to accept either a `ProgressBar` instance or an integer, and added type checks and initialization logic accordingly. [[1]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L66-R66) [[2]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L180-R186) [[3]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L233-R239) [[4]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L291-R300) [[5]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L383-R391) [[6]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L435-R443)
* [`brainstate/compile/_progress_bar.py`](diffhunk://#diff-3087a1c2ffed5fa433321044effaa3dee679336d128ce7e5d1d1c60df220ea1eR38-R39): Added an assertion to ensure that the `freq` parameter is greater than 0 when it is an integer.

### Updates to `XLACustomOp`:

* `brainstate/event/_fixedprob_mv.py`, `brainstate/event/_linear_mv.py`, `brainstate/event/_xla_custom_op.py`: Renamed `cpu_kernel_generator` and `gpu_kernel_generator` to `cpu_kernel_or_generator` and `gpu_kernel_or_generator` for clarity and consistency. [[1]](diffhunk://#diff-98724edef4a36d9fdc3f27b84fb077a87e808683e0f831a71c7d8d9fb0a78ea7L476-R477) [[2]](diffhunk://#diff-98724edef4a36d9fdc3f27b84fb077a87e808683e0f831a71c7d8d9fb0a78ea7L696-R697) [[3]](diffhunk://#diff-7a79c751122b9f7ed16239f7c090cdbb12422fa4fe8866b713c4552e75c839f7L337-R338) [[4]](diffhunk://#diff-0b394266de8e29cccab68e75201f103da71ca505959e94ae112cb51a7e926a25L183-R184) [[5]](diffhunk://#diff-0b394266de8e29cccab68e75201f103da71ca505959e94ae112cb51a7e926a25L194-L202) [[6]](diffhunk://#diff-0b394266de8e29cccab68e75201f103da71ca505959e94ae112cb51a7e926a25L212-R212)

### Addition of Poisson input functionality:

* [`brainstate/nn/_dyn_impl/_inputs.py`](diffhunk://#diff-e0162f3b9e2e16156007165f540c6931e6dbacdbc9ab44f7e66579250b6779efR20-R36): Introduced the `PoissonInput` class and `poisson_input` function to generate Poisson input for a given `brainstate.State`. [[1]](diffhunk://#diff-e0162f3b9e2e16156007165f540c6931e6dbacdbc9ab44f7e66579250b6779efR20-R36) [[2]](diffhunk://#diff-e0162f3b9e2e16156007165f540c6931e6dbacdbc9ab44f7e66579250b6779efR161-R279)

### Other notable changes:

* [`brainstate/event/__init__.py`](diffhunk://#diff-eede0eca4838448948250825441c055750079da88f99f922312d38d11868f220R17-R29): Refactored imports and updated the `__all__` list for better module organization.
* [`brainstate/event/_csr_test.py`](diffhunk://#diff-09044b1ce1dbfacca993ed5daf9d786d5b8e632335cfa1a604a3d645016bbb68R1-R90): Added a new test file with unit tests for the `CSR` class.
* [`brainstate/graph/_graph_node.py`](diffhunk://#diff-fd0d2ef6f05960953584d77c43172dc032407dc06e5e650fc0ae56dd93bedd73R64-R66): Introduced `graph_invisible_attrs` to manage node attributes that should be ignored during graph operations. [[1]](diffhunk://#diff-fd0d2ef6f05960953584d77c43172dc032407dc06e5e650fc0ae56dd93bedd73R64-R66) [[2]](diffhunk://#diff-fd0d2ef6f05960953584d77c43172dc032407dc06e5e650fc0ae56dd93bedd73L173-R182)
* [`brainstate/nn/_dynamics/_dynamics_base.py`](diffhunk://#diff-400255234e32862f25354ef61dc20060ad0f9fa406eb0e004f71f8036967a67eR110-R111): Added `graph_invisible_attrs` and new methods `get_item_value` and `get_item` to the `Dynamics` class. [[1]](diffhunk://#diff-400255234e32862f25354ef61dc20060ad0f9fa406eb0e004f71f8036967a67eR110-R111) [[2]](diffhunk://#diff-400255234e32862f25354ef61dc20060ad0f9fa406eb0e004f71f8036967a67eR448-R457)