### PR TITLE
Several updates

### DIFF
--- a/brainstate/__init__.py
+++ b/brainstate/__init__.py
@@ -49,18 +49,4 @@ __all__ = (
 )
 
 # ----------------------- #
-# deprecations
-# ----------------------- #
-
-from ._utils import deprecation_getattr
-
-transform._deprecations = dict()
-for key in compile.__all__:
-    transform._deprecations[key] = (f'brainstate.transform.{key}', f'brainstate.compile.{key}', getattr(compile, key))
-for key in augment.__all__:
-    transform._deprecations[key] = (f'brainstate.transform.{key}', f'brainstate.augment.{key}', getattr(augment, key))
-transform.__getattr__ = deprecation_getattr('brainstate.transform', transform._deprecations)
-del deprecation_getattr
-
-# ----------------------- #
 del _state_all

--- a/brainstate/nn/_dynamics/_state_delay.py
+++ b/brainstate/nn/_dynamics/_state_delay.py
@@ -51,11 +51,14 @@ def _get_delay(delay_time, delay_step):
             assert isinstance(delay_step, int), '"delay_step" should be an integer.'
             if delay_step == 0:
                 return 0., 0
-            delay_time = delay_step * environ.get_dt()
+            with jax.ensure_compile_time_eval():
+                delay_time = delay_step * environ.get_dt()
     else:
         assert delay_step is None, '"delay_step" should be None if "delay_time" is given.'
         # assert isinstance(delay_time, (int, float))
-        delay_step = math.ceil(delay_time / environ.get_dt())
+        with jax.ensure_compile_time_eval():
+            delay_step = delay_time / environ.get_dt()
+        delay_step = math.ceil(float(delay_step))
     return delay_time, delay_step
 
 

--- a/brainstate/transform.py
+++ b/brainstate/transform.py
@@ -13,4 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
-# This module is going to be deleted in the future (near 2025-06).
+# alias for compilation and augmentation functions
+
+from .compile import *
+from .augment import *
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,41 +14,29 @@ Features
 
 .. grid::
 
-   .. grid-item::
-      :columns: 12 12 12 6
-
-      .. card:: Pythonic
-         :class-card: sd-border-0
-         :shadow: none
-         :class-title: sd-fs-5
-
-         .. div:: sd-font-normal
-
-            ``BrainState`` provides a Pythonic interface to brain dynamics programming.
-
 
    .. grid-item::
-      :columns: 12 12 12 6
+      :columns: 12 12 12 4
 
       .. card:: Event-driven Computation
          :class-card: sd-border-0
          :shadow: none
-         :class-title: sd-fs-5
+         :class-title: sd-fs-6
 
          .. div:: sd-font-normal
 
-            ``BrainState`` enables `event-driven computation <./apis/event.html>`__ for spiking neural networks,
-            and thus obtains unprecedented performance on CPU and GPU devices.
+            ``BrainState`` enables `event-driven computation <./apis/event.html>`__ for spiking neural networks
+            on CPU and GPU devices.
 
 
 
    .. grid-item::
-      :columns: 12 12 12 6
+      :columns: 12 12 12 4
 
       .. card:: Program Compilation
          :class-card: sd-border-0
          :shadow: none
-         :class-title: sd-fs-5
+         :class-title: sd-fs-6
 
          .. div:: sd-font-normal
 
@@ -57,12 +45,12 @@ Features
 
 
    .. grid-item::
-      :columns: 12 12 12 6
+      :columns: 12 12 12 4
 
       .. card:: Program Augmentation
          :class-card: sd-border-0
          :shadow: none
-         :class-title: sd-fs-5
+         :class-title: sd-fs-6
 
          .. div:: sd-font-normal
 


### PR DESCRIPTION
This pull request includes several changes to the `brainstate` package, focusing on deprecations, new synapse models, delay calculation updates, module aliasing, and documentation improvements. The most important changes are summarized below:

Deprecations:

* Removed deprecation handling code from `brainstate/__init__.py` to clean up the module.

New synapse models:

* Added `DualExpon` and `Alpha` synapse models to `brainstate/nn/_dyn_impl/_dynamics_synapse.py`, including their initialization, state management, and update methods.

Delay calculation updates:

* Updated `_get_delay` function in `brainstate/nn/_dynamics/_state_delay.py` to use `jax.ensure_compile_time_eval()` for delay time and step calculations.

Module aliasing:

* Added aliasing for compilation and augmentation functions in `brainstate/transform.py` by importing all from `compile` and `augment` modules.

Documentation improvements:

* Modified the layout and styling of feature cards in `docs/index.rst` for better readability and presentation. [[1]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L17-R39) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L60-R53)

## Summary by Sourcery

Add two new synapse models (`DualExpon`, `Alpha`), update delay calculation in `_get_delay` to use compile-time evaluation, remove deprecation handling code, and improve documentation layout.

New Features:
- Add `DualExpon` synapse model.
- Add `Alpha` synapse model.