### PR TITLE
Enable to set `bf16` precision in `brainstate.environ` module

### DIFF
--- a/brainstate/compile/_error_if_test.py
+++ b/brainstate/compile/_error_if_test.py
@@ -32,6 +32,7 @@ class TestJitError(unittest.TestCase):
         def err_f(x):
             raise ValueError(f'error: {x}')
 
+        bst.compile.jit_error_if(False, err_f, 1.)
         with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
             bst.compile.jit_error_if(True, err_f, 1.)
 

--- a/brainstate/compile/_loop_collect_return.py
+++ b/brainstate/compile/_loop_collect_return.py
@@ -206,7 +206,7 @@ def scan(
 
     # evaluate jaxpr, get all states #
     # ------------------------------ #
-    xs_avals = [jax.core.raise_to_shaped(jax.core.get_aval(x)) for x in xs_flat]
+    xs_avals = [jax.core.get_aval(x) for x in xs_flat]
     x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
     stateful_fun = StatefulFunction(f).make_jaxpr(init, xs_tree.unflatten(x_avals))
     state_trace = stateful_fun.get_state_trace()
@@ -302,7 +302,7 @@ def checkpointed_scan(
         pbar_runner = None
 
     # evaluate jaxpr
-    xs_avals = [jax.core.raise_to_shaped(jax.core.get_aval(x)) for x in xs_flat]
+    xs_avals = [jax.core.get_aval(x) for x in xs_flat]
     x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
     stateful_fun = StatefulFunction(f).make_jaxpr(init, xs_tree.unflatten(x_avals))
     state_trace = stateful_fun.get_state_trace()

--- a/brainstate/compile/_make_jaxpr_test.py
+++ b/brainstate/compile/_make_jaxpr_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import unittest
 
 import jax
+import jax.extend as je
 import jax.numpy as jnp
 import pytest
 
@@ -84,7 +85,7 @@ class TestMakeJaxpr(unittest.TestCase):
         print(jaxpr)
         jaxpr, _ = bst.compile.make_jaxpr(f3)(jnp.zeros(1))
         print(jaxpr)
-        self.assertTrue(jnp.allclose(jax.core.jaxpr_as_fun(jaxpr)(jnp.zeros(1), st1.value)[0],
+        self.assertTrue(jnp.allclose(je.core.jaxpr_as_fun(jaxpr)(jnp.zeros(1), st1.value)[0],
                                      f3(jnp.zeros(1))))
 
     def test_compar_jax_make_jaxpr2(self):

--- a/brainstate/compile/_unvmap.py
+++ b/brainstate/compile/_unvmap.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import jax
 import jax.core
+import jax.extend as je
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
 import jax.numpy as jnp
@@ -43,7 +44,7 @@ def unvmap(x, op: str = 'any'):
 
 # unvmap_all
 
-unvmap_all_p = jax.core.Primitive("unvmap_all")
+unvmap_all_p = je.core.Primitive("unvmap_all")
 
 
 def unvmap_all(x):

--- a/brainstate/environ.py
+++ b/brainstate/environ.py
@@ -390,6 +390,8 @@ def _get_float(precision: int):
         return np.float16
     elif precision == 'bf16':
         return jnp.bfloat16
+    elif precision == 8:
+        return jnp.float8_e5m2
     else:
         raise ValueError(f'Unsupported precision: {precision}')
 
@@ -401,6 +403,8 @@ def _get_complex(precision: int):
     elif precision == 32:
         return np.complex64
     elif precision in [16, 'bf16']:
+        return np.complex64
+    elif precision == 8:
         return np.complex64
     else:
         raise ValueError(f'Unsupported precision: {precision}')

--- a/brainstate/environ.py
+++ b/brainstate/environ.py
@@ -249,7 +249,13 @@ def get_precision() -> int:
       The default precision.
     """
     precision = get('precision')
-    return 16 if precision == 'bf16' else precision
+    if precision == 'bf16':
+        return 16
+    if isinstance(precision, int):
+        return precision
+    if isinstance(precision, str):
+        return int(precision)
+    raise ValueError(f'Unsupported precision: {precision}')
 
 
 def set(
@@ -345,8 +351,8 @@ def _set_jax_precision(precision: int | str):
     Args:
       precision: int. The default precision.
     """
-    assert precision in [64, 32, 16, 'bf16', 8], f'Precision must be in [64, 32, 16, "bf16", 8]. But got {precision}.'
-    if precision == 64:
+    # assert precision in [64, 32, 16, 'bf16', 8], f'Precision must be in [64, 32, 16, "bf16", 8]. But got {precision}.'
+    if precision in [64, '64']:
         config.update("jax_enable_x64", True)
     else:
         config.update("jax_enable_x64", False)
@@ -354,13 +360,13 @@ def _set_jax_precision(precision: int | str):
 
 @functools.lru_cache()
 def _get_uint(precision: int):
-    if precision == 64:
+    if precision in [64, '64']:
         return np.uint64
-    elif precision == 32:
+    elif precision in [32, '32']:
         return np.uint32
-    elif precision in [16, 'bf16']:
+    elif precision in [16, '16', 'bf16']:
         return np.uint16
-    elif precision == 8:
+    elif precision in [8, '8']:
         return np.uint8
     else:
         raise ValueError(f'Unsupported precision: {precision}')
@@ -368,13 +374,13 @@ def _get_uint(precision: int):
 
 @functools.lru_cache()
 def _get_int(precision: int):
-    if precision == 64:
+    if precision in [64, '64']:
         return np.int64
-    elif precision == 32:
+    elif precision in [32, '32']:
         return np.int32
-    elif precision in [16, 'bf16']:
+    elif precision in [16, '16', 'bf16']:
         return np.int16
-    elif precision == 8:
+    elif precision in [8, '8']:
         return np.int8
     else:
         raise ValueError(f'Unsupported precision: {precision}')
@@ -382,15 +388,15 @@ def _get_int(precision: int):
 
 @functools.lru_cache()
 def _get_float(precision: int):
-    if precision == 64:
+    if precision in [64, '64']:
         return np.float64
-    elif precision == 32:
+    elif precision in [32, '32']:
         return np.float32
-    elif precision == 16:
+    elif precision in [16, '16']:
         return np.float16
-    elif precision == 'bf16':
+    elif precision in ['bf16']:
         return jnp.bfloat16
-    elif precision == 8:
+    elif precision in [8, '8']:
         return jnp.float8_e5m2
     else:
         raise ValueError(f'Unsupported precision: {precision}')
@@ -398,13 +404,13 @@ def _get_float(precision: int):
 
 @functools.lru_cache()
 def _get_complex(precision: int):
-    if precision == 64:
+    if precision == [64, '64']:
         return np.complex128
-    elif precision == 32:
+    elif precision == [32, '32']:
         return np.complex64
-    elif precision in [16, 'bf16']:
+    elif precision in [16, '16', 'bf16']:
         return np.complex64
-    elif precision == 8:
+    elif precision == [8, '8']:
         return np.complex64
     else:
         raise ValueError(f'Unsupported precision: {precision}')

--- a/brainstate/environ.py
+++ b/brainstate/environ.py
@@ -31,13 +31,12 @@ from jax import config, devices, numpy as jnp
 from jax.typing import DTypeLike
 
 from .mixin import Mode
-from .util import MemScaling
 
 __all__ = [
     # functions for environment settings
     'set', 'context', 'get', 'all', 'set_host_device_count', 'set_platform',
     # functions for getting default behaviors
-    'get_host_device_count', 'get_platform', 'get_dt', 'get_mode', 'get_mem_scaling', 'get_precision',
+    'get_host_device_count', 'get_platform', 'get_dt', 'get_mode', 'get_precision',
     # functions for default data types
     'dftype', 'ditype', 'dutype', 'dctype',
     # others
@@ -94,7 +93,7 @@ def context(**kwargs):
                          'Please use set_host_device_count() or set() for the global setting.')
 
     if 'precision' in kwargs:
-        last_precision = get_precision()
+        last_precision = _get_precision()
         _set_jax_precision(kwargs['precision'])
 
     try:
@@ -203,17 +202,6 @@ def get_mode() -> Mode:
     return get('mode')
 
 
-def get_mem_scaling() -> MemScaling:
-    """Get the default computing membrane_scaling.
-
-    Returns
-    -------
-    membrane_scaling: MemScaling
-      The default computing membrane_scaling.
-    """
-    return get('mem_scaling')
-
-
 def get_platform() -> str:
     """Get the computing platform.
 
@@ -239,7 +227,7 @@ def get_host_device_count():
     return int(match.group(1)) if match else 1
 
 
-def get_precision() -> int:
+def _get_precision() -> int | str:
     """
     Get the default precision.
 
@@ -251,11 +239,23 @@ def get_precision() -> int:
     return get('precision')
 
 
+def get_precision() -> int:
+    """
+    Get the default precision.
+
+    Returns
+    -------
+    precision: int
+      The default precision.
+    """
+    precision = get('precision')
+    return 16 if precision == 'bf16' else precision
+
+
 def set(
     platform: str = None,
     host_device_count: int = None,
-    mem_scaling: MemScaling = None,
-    precision: int = None,
+    precision: int | str = None,
     mode: Mode = None,
     **kwargs
 ):
@@ -267,8 +267,7 @@ def set(
     Args:
       platform: str. The computing platform. Either 'cpu', 'gpu' or 'tpu'.
       host_device_count: int. The number of host devices.
-      mem_scaling: MemScaling. The membrane scaling.
-      precision: int. The default precision.
+      precision: int, str. The default precision.
       mode: Mode. The computing mode.
       **kwargs: dict. Other environment settings.
     """
@@ -276,9 +275,6 @@ def set(
         set_platform(platform)
     if host_device_count is not None:
         set_host_device_count(host_device_count)
-    if mem_scaling is not None:
-        assert isinstance(mem_scaling, MemScaling), 'mem_scaling must be a MemScaling instance.'
-        kwargs['mem_scaling'] = mem_scaling
     if precision is not None:
         _set_jax_precision(precision)
         kwargs['precision'] = precision
@@ -342,14 +338,14 @@ def set_platform(platform: str):
         DFAULT.functions['platform'](platform)
 
 
-def _set_jax_precision(precision: int):
+def _set_jax_precision(precision: int | str):
     """
     Set the default precision.
 
     Args:
       precision: int. The default precision.
     """
-    assert precision in [64, 32, 16, 8], f'Precision must be in [64, 32, 16, 8]. But got {precision}.'
+    assert precision in [64, 32, 16, 'bf16', 8], f'Precision must be in [64, 32, 16, "bf16", 8]. But got {precision}.'
     if precision == 64:
         config.update("jax_enable_x64", True)
     else:
@@ -362,7 +358,7 @@ def _get_uint(precision: int):
         return np.uint64
     elif precision == 32:
         return np.uint32
-    elif precision == 16:
+    elif precision in [16, 'bf16']:
         return np.uint16
     elif precision == 8:
         return np.uint8
@@ -376,7 +372,7 @@ def _get_int(precision: int):
         return np.int64
     elif precision == 32:
         return np.int32
-    elif precision == 16:
+    elif precision in [16, 'bf16']:
         return np.int16
     elif precision == 8:
         return np.int8
@@ -391,8 +387,9 @@ def _get_float(precision: int):
     elif precision == 32:
         return np.float32
     elif precision == 16:
+        return np.float16
+    elif precision == 'bf16':
         return jnp.bfloat16
-        # return np.float16
     else:
         raise ValueError(f'Unsupported precision: {precision}')
 
@@ -403,8 +400,8 @@ def _get_complex(precision: int):
         return np.complex128
     elif precision == 32:
         return np.complex64
-    elif precision == 16:
-        return np.complex32
+    elif precision in [16, 'bf16']:
+        return np.complex64
     else:
         raise ValueError(f'Unsupported precision: {precision}')
 
@@ -430,7 +427,7 @@ def dftype() -> DTypeLike:
     float_dtype: DTypeLike
       The default floating data type.
     """
-    return _get_float(get_precision())
+    return _get_float(_get_precision())
 
 
 def ditype() -> DTypeLike:
@@ -455,7 +452,7 @@ def ditype() -> DTypeLike:
     int_dtype: DTypeLike
       The default integer data type.
     """
-    return _get_int(get_precision())
+    return _get_int(_get_precision())
 
 
 def dutype() -> DTypeLike:
@@ -481,7 +478,7 @@ def dutype() -> DTypeLike:
     uint_dtype: DTypeLike
       The default unsigned integer data type.
     """
-    return _get_uint(get_precision())
+    return _get_uint(_get_precision())
 
 
 def dctype() -> DTypeLike:
@@ -506,7 +503,7 @@ def dctype() -> DTypeLike:
     complex_dtype: DTypeLike
       The default complex data type.
     """
-    return _get_complex(get_precision())
+    return _get_complex(_get_precision())
 
 
 def tolerance():

--- a/brainstate/environ_test.py
+++ b/brainstate/environ_test.py
@@ -33,6 +33,10 @@ class TestEnviron(unittest.TestCase):
 
         with bst.environ.context(precision=16):
             a = bst.random.randn(1)
+            self.assertEqual(a.dtype, jnp.float16)
+
+        with bst.environ.context(precision='bf16'):
+            a = bst.random.randn(1)
             self.assertEqual(a.dtype, jnp.bfloat16)
 
     def test_platform(self):

--- a/brainstate/event/_fixedprob_mv.py
+++ b/brainstate/event/_fixedprob_mv.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax.interpreters import ad
 
+from brainstate import environ
 from brainstate._state import ParamState
 from brainstate.augment import vmap
 from brainstate.init import param
@@ -111,7 +112,7 @@ class FixedProb(Module):
 
     def update(self, spk: jax.Array) -> Union[jax.Array, u.Quantity]:
         if self.n_conn > 1:
-            return event_fixed_prob(
+            r = event_fixed_prob(
                 spk,
                 self.weight.value,
                 self.indices,
@@ -123,7 +124,8 @@ class FixedProb(Module):
             weight = self.weight.value
             unit = u.get_unit(weight)
             r = jnp.zeros(spk.shape[:-1] + (self.out_size[-1],), dtype=weight.dtype)
-            return u.maybe_decimal(u.Quantity(r, unit=unit))
+            r = u.maybe_decimal(u.Quantity(r, unit=unit))
+        return u.math.asarray(r, dtype=environ.dftype())
 
 
 def event_fixed_prob(

--- a/brainstate/event/_xla_custom_op.py
+++ b/brainstate/event/_xla_custom_op.py
@@ -7,12 +7,12 @@ from functools import partial
 from typing import Callable, Sequence, Tuple, Protocol
 
 import jax
+import jax.extend as je
 import numpy as np
 from jax import tree_util
 from jax.core import Primitive
 from jax.interpreters import batching, ad
 from jax.interpreters import xla, mlir
-from jax.lib import xla_client
 from jaxlib.hlo_helpers import custom_call
 
 numba_installed = importlib.util.find_spec('numba') is not None
@@ -143,7 +143,7 @@ def numba_cpu_custom_call_target(output_ptrs, input_ptrs):
     xla_c_rule = cfunc(sig)(new_f)
     target_name = f'numba_custom_call_{str(xla_c_rule.address)}'
     capsule = ctypes.pythonapi.PyCapsule_New(xla_c_rule.address, b"xla._CUSTOM_CALL_TARGET", None)
-    xla_client.register_custom_call_target(target_name, capsule, "cpu")
+    je.ffi.register_ffi_target(target_name, capsule, "cpu", api_version=0)
 
     # call
     return custom_call(

--- a/brainstate/nn/_dyn_impl/_dynamics_synapse.py
+++ b/brainstate/nn/_dyn_impl/_dynamics_synapse.py
@@ -29,7 +29,7 @@ from brainstate.nn._exp_euler import exp_euler_step
 from brainstate.typing import ArrayLike, Size
 
 __all__ = [
-    'Synapse', 'Expon', 'STP', 'STD', 'AMPA', 'GABAa',
+    'Synapse', 'Expon', 'DualExpon', 'Alpha', 'STP', 'STD', 'AMPA', 'GABAa',
 ]
 
 


### PR DESCRIPTION
This pull request includes various changes to improve precision handling, simplify the code, and update imports across multiple files. The most important changes include updating precision handling in the `brainstate/environ.py` file, simplifying the `scan` and `checkpointed_scan` functions, and modifying the imports to use `jax.extend` consistently.

### Precision Handling Improvements:
* [`brainstate/environ.py`](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL34-R39): Refactored precision handling by introducing `_get_precision` and updating the `get_precision` function to support both integer and string types for precision values. Removed the `get_mem_scaling` function and updated related functions to use `_get_precision`. [[1]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL34-R39) [[2]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL97-R96) [[3]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL206-L216) [[4]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL242-R230) [[5]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bR242-R264) [[6]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL270-L281) [[7]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL345-L407) [[8]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL433-R440) [[9]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL458-R465) [[10]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL484-R491) [[11]](diffhunk://#diff-e502eb883a45cb8662340610f940a3417964f57f5dd88778b78398a3e6e75d6bL509-R516)

### Code Simplification:
* [`brainstate/compile/_loop_collect_return.py`](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L209-R209): Simplified `scan` and `checkpointed_scan` functions by removing the `raise_to_shaped` call, which is no longer necessary. [[1]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L209-R209) [[2]](diffhunk://#diff-aa6aa32aad7e7b5cb6c4831a5230a6283fa7945e8360f826734b9b112d4e1839L305-R305)

### Import Updates:
* Updated multiple files to use `jax.extend` for importing `core` and `Primitive` to ensure consistency and clarity in the codebase. [[1]](diffhunk://#diff-c2c3bfe92914407be6b292bf4a82ac69b5394d9dbcf95f3434e2255a4f7e8544R21) [[2]](diffhunk://#diff-e0c9a8dbbc2c5942a2e3cba91aebee2965a3ed63f9430dcebdbbd87ca71ab667R19) [[3]](diffhunk://#diff-0b394266de8e29cccab68e75201f103da71ca505959e94ae112cb51a7e926a25R10-L15)

### Test and Example Updates:
* [`brainstate/environ_test.py`](diffhunk://#diff-35228eb86459064c67823b6b38e43fad66335da2cf64d605b16c9a41e38d9266R35-R38): Added new test cases to check for `float16` and `bfloat16` precision settings.
* [`examples/106_COBA_HH_2007.py`](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcR25-R30): Updated example to set precision to `bf16` and adjusted various computations to use the default data type from the environment settings. [[1]](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcR25-R30) [[2]](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcL71-R76) [[3]](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcL83-R121) [[4]](diffhunk://#diff-7c6f7977fc273f22384e768ea723b6f842e872920e72d0d84c8c4b7d6507b5dcL154-R172)

### Other Changes:
* [`brainstate/event/_fixedprob_mv.py`](diffhunk://#diff-98724edef4a36d9fdc3f27b84fb077a87e808683e0f831a71c7d8d9fb0a78ea7L126-R128): Updated the `update` function to ensure the return type matches the default floating data type from the environment settings.

## Summary by Sourcery

Add support for bf16 precision in the `brainstate.environ` module. Update the example to use bf16 precision and adjust computations to use the default data type from environment settings. Simplify `scan` and `checkpointed_scan` functions by removing unnecessary code. Update imports to use `jax.extend` for consistency.

New Features:
- Support for bf16 precision in the `brainstate.environ` module.

Tests:
- Add test cases for `float16` and `bfloat16` precision settings.