### PR TITLE
Standardize state value reading and writing

### DIFF
--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -272,12 +272,14 @@ class State(Generic[A], PrettyRepr):
         Args:
           v: The value.
         """
+        # NOTE: the following order is important
+
         if isinstance(v, State):  # value checking
             raise ValueError('Cannot set value to a State, ' 'use `copy_from` method instead')
         self._check_value_tree(v)  # check the tree structure
-        self._write_value(v)  # write the value
-        self._been_writen = True  # set the flag
         record_state_value_write(self)  # record the value by the stack (>= level)
+        self._been_writen = True  # set the flag
+        self._write_value(v)  # write the value
 
     @property
     def stack_level(self):

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -261,9 +261,8 @@ class State(Generic[A], PrettyRepr):
         """
         The data and its value.
         """
-        self.check_if_deleted()
         record_state_value_read(self)
-        return self._value
+        return self._read_value()
 
     @value.setter
     def value(self, v) -> None:
@@ -273,7 +272,9 @@ class State(Generic[A], PrettyRepr):
         Args:
           v: The value.
         """
-        self.write_value(v)
+        self._write_value(v)
+        self._been_writen = True
+        record_state_value_write(self)
 
     @property
     def stack_level(self):
@@ -295,17 +296,23 @@ class State(Generic[A], PrettyRepr):
         """
         self._level = level
 
-    def write_value(self, v) -> None:
+    def _read_value(self) -> PyTree[ArrayLike]:
+        """
+        The interface to customize the value reading.
+        """
+        self.check_if_deleted()
+        return self._value
+
+    def _write_value(self, v) -> None:
+        """
+        The interface to customize the value writing.
+        """
         # value checking
         if isinstance(v, State):
             raise ValueError('Cannot set value to a State, ' 'use `copy_from` method instead')
         self._check_value_tree(v)
-        # write the value by the stack (>= level)
-        record_state_value_write(self)
         # set the value
         self._value = v
-        # set flag
-        self._been_writen = True
 
     def restore_value(self, v) -> None:
         """

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -272,9 +272,12 @@ class State(Generic[A], PrettyRepr):
         Args:
           v: The value.
         """
-        self._write_value(v)
-        self._been_writen = True
-        record_state_value_write(self)
+        if isinstance(v, State):  # value checking
+            raise ValueError('Cannot set value to a State, ' 'use `copy_from` method instead')
+        self._check_value_tree(v)  # check the tree structure
+        self._write_value(v)  # write the value
+        self._been_writen = True  # set the flag
+        record_state_value_write(self)  # record the value by the stack (>= level)
 
     @property
     def stack_level(self):
@@ -307,11 +310,6 @@ class State(Generic[A], PrettyRepr):
         """
         The interface to customize the value writing.
         """
-        # value checking
-        if isinstance(v, State):
-            raise ValueError('Cannot set value to a State, ' 'use `copy_from` method instead')
-        self._check_value_tree(v)
-        # set the value
         self._value = v
 
     def restore_value(self, v) -> None:

--- a/brainstate/compile/_jit.py
+++ b/brainstate/compile/_jit.py
@@ -82,7 +82,6 @@ def _get_jitted_fun(
             return fun.fun(*args, **params)
 
         # compile the function and get the state trace
-        # print('Compiling ...')
         state_trace = fun.compile_function_and_get_state_trace(*args, **params, return_only_write=True)
         read_state_vals = state_trace.get_read_state_values(True)
 

--- a/brainstate/compile/_make_jaxpr.py
+++ b/brainstate/compile/_make_jaxpr.py
@@ -499,7 +499,7 @@ class StatefulFunction(object):
         state_vals, out = self.jaxpr_call([st.value for st in state_trace.states], *args, **kwargs)
         for st, written, val in zip(state_trace.states, state_trace.been_writen, state_vals):
             if written:
-                st.write_value(val)
+                st.value = val
             else:
                 st.restore_value(val)
         return out

--- a/brainstate/compile/_util.py
+++ b/brainstate/compile/_util.py
@@ -31,7 +31,7 @@ def write_back_state_values(
     assert len(state_trace.states) == len(state_trace.been_writen) == len(read_state_vals) == len(write_state_vals)
     for st, write, val_r, val_w in zip(state_trace.states, state_trace.been_writen, read_state_vals, write_state_vals):
         if write:
-            st.write_value(val_w)
+            st.value = val_w
         else:
             st.restore_value(val_r)
 

--- a/brainstate/graph/_graph_operation.py
+++ b/brainstate/graph/_graph_operation.py
@@ -609,7 +609,7 @@ def _get_children(graph_def, state_mapping, index_ref, index_ref_cache):
                             variable.update_from_ref(value)
                         elif isinstance(value, State):
                             if value._been_writen:
-                                variable.write_value(value.value)
+                                variable.value = value.value
                             else:
                                 variable.restore_value(value.value)
                         else:


### PR DESCRIPTION
This pull request includes several changes to the `brainstate` module to improve value setting and reading mechanisms, and to simplify the codebase. The most important changes are the introduction of `_read_value` and `_write_value` methods and the removal of the `write_value` method.

Improvements to value setting and reading:

* [`brainstate/_state.py`](diffhunk://#diff-1678a09796fe32937a594146fd1e78201827f3456dfcfed9a3c82f1e65f16a44L264-R265): Introduced `_read_value` and `_write_value` methods to customize value reading and writing, replacing the direct access to `_value`. [[1]](diffhunk://#diff-1678a09796fe32937a594146fd1e78201827f3456dfcfed9a3c82f1e65f16a44L264-R265) [[2]](diffhunk://#diff-1678a09796fe32937a594146fd1e78201827f3456dfcfed9a3c82f1e65f16a44L298-L308)
* [`brainstate/_state.py`](diffhunk://#diff-1678a09796fe32937a594146fd1e78201827f3456dfcfed9a3c82f1e65f16a44L276-R280): Modified the `value` setter to include value checking and tree structure validation before writing the value.

Codebase simplification:

* [`brainstate/compile/_make_jaxpr.py`](diffhunk://#diff-3b05e5bec9c3bff8277ee464c225664461a9ca5288f235982df160f3ac8c2bc9L502-R502): Replaced the `write_value` method with direct setting of the `value` property.
* [`brainstate/compile/_util.py`](diffhunk://#diff-6c0bcea6972c10e2afdedb50ab19ebd456a3afa7c37caaabbc5eb3c763f37535L34-R34): Simplified state value writing by using the `value` property instead of the `write_value` method.
* [`brainstate/graph/_graph_operation.py`](diffhunk://#diff-42aaec0868f76e055e55342e2321885e6d2d62bf03b212b6927b3f87ffb51925L612-R612): Updated the code to use the `value` property instead of the `write_value` method for state objects.


Downstream classes can customize its own read and write value interface by:

```python

class MyState(brainstate.State):
  def _read_value(self): ...
  def _write_value(self, v):  ...
```

## Summary by Sourcery

Enhancements:
- Allow downstream classes to customize value reading and writing by overriding the `_read_value` and `_write_value` methods.