### PR TITLE
update pretty representation

### DIFF
--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -813,7 +813,7 @@ class TreefyState(Generic[A], PrettyReprTree):
             return 'value', v
 
         if k == '_name':
-            return (None, None) if self.name is None else ('name', v)
+            return (None, None) if v is None else ('name', v)
         return k, v
 
     def replace(self, value: B) -> TreefyState[B]:

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -813,11 +813,7 @@ class TreefyState(Generic[A], PrettyReprTree):
             return 'value', v
 
         if k == '_name':
-            if self.name is None:
-                return None, None
-            else:
-                return 'name', v
-
+            return (None, None) if self.name is None else ('name', v)
         return k, v
 
     def replace(self, value: B) -> TreefyState[B]:

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -19,8 +19,10 @@ import contextlib
 import dataclasses
 import threading
 from functools import wraps, partial
-from typing import (Any, Union, Callable, Generic, Mapping,
-                    TypeVar, Optional, TYPE_CHECKING, Tuple, Dict, List, Sequence)
+from typing import (
+    Any, Union, Callable, Generic, Mapping,
+    TypeVar, Optional, TYPE_CHECKING, Tuple, Dict, List, Sequence
+)
 
 import jax
 import numpy as np
@@ -28,7 +30,7 @@ from jax.api_util import shaped_abstractify
 from jax.extend import source_info_util
 
 from brainstate.typing import ArrayLike, PyTree, Missing
-from brainstate.util import DictManager, PrettyRepr, PrettyType, PrettyAttr
+from brainstate.util import DictManager, PrettyReprTree
 
 __all__ = [
     'State', 'ShortTermState', 'LongTermState', 'HiddenState', 'ParamState', 'TreefyState',
@@ -184,7 +186,7 @@ def _get_trace_stack_level() -> int:
     return len(TRACE_CONTEXT.state_stack)
 
 
-class State(Generic[A], PrettyRepr):
+class State(Generic[A], PrettyReprTree):
     """
     The pointer to specify the dynamical data.
 
@@ -427,45 +429,25 @@ class State(Generic[A], PrettyRepr):
         del metadata['_value']
         return TreefyState(type(self), self._value, **metadata)
 
-    def __pretty_repr__(self):
-        yield PrettyType(type=type(self))
-        for name, value in vars(self).items():
-            if name == '_value':
-                name = 'value'
-            if name == '_name':
-                if value is None:
-                    continue
-                else:
-                    name = 'name'
-            if name == 'tag' and value is None:
-                continue
-            if name in ['_level', '_source_info', '_been_writen']:
-                continue
-            yield PrettyAttr(name, repr(value))
+    def __pretty_repr_item__(self, k, v):
+        if k in ['_level', '_source_info', '_been_writen']:
+            return None, None
+        if k == '_value':
+            return 'value', v
 
-    def __treescope_repr__(self, path, subtree_renderer):
-        children = {}
-        for name, value in vars(self).items():
-            if name == '_value':
-                name = 'value'
-            if name == '_name':
-                if value is None:
-                    continue
-                else:
-                    name = 'name'
-            if name == 'tag' and value is None:
-                continue
-            if name in ['_level', '_source_info', '_been_writen']:
-                continue
-            children[name] = value
+        if k == '_name':
+            if self.name is None:
+                return None, None
+            else:
+                return 'name', v
 
-        import treescope  # type: ignore[import-not-found,import-untyped]
-        return treescope.repr_lib.render_object_constructor(
-            object_type=type(self),
-            attributes=children,
-            path=path,
-            subtree_renderer=subtree_renderer,
-        )
+        if k == 'tag':
+            if self.tag is None:
+                return None, None
+            else:
+                return 'tag', v
+
+        return k, v
 
     def __eq__(self, other: object) -> bool:
         return type(self) is type(other) and vars(other) == vars(self)
@@ -802,7 +784,7 @@ class StateTraceStack(Generic[A]):
         return StateTraceStack().merge(self, other)
 
 
-class TreefyState(Generic[A], PrettyRepr):
+class TreefyState(Generic[A], PrettyReprTree):
     """
     The state as a pytree.
     """
@@ -824,35 +806,19 @@ class TreefyState(Generic[A], PrettyRepr):
 
         def __delattr__(self, name: str) -> None: ...
 
-    def __pretty_repr__(self):
-        yield PrettyType(type=type(self))
-        yield PrettyAttr('type', self.type.__name__)
-        for name, value in vars(self).items():
-            if name == '_value':
-                name = 'value'
-            if name == '_name':
-                if value is None:
-                    continue
-                else:
-                    name = 'name'
-            if name in ['_level', '_source_info', 'type']:
-                continue
-            yield PrettyAttr(name, repr(value))
+    def __pretty_repr_item__(self, k, v):
+        if k in ['_level', '_source_info', '_been_writen']:
+            return None, None
+        if k == '_value':
+            return 'value', v
 
-    def __treescope_repr__(self, path, subtree_renderer):
-        children = {'type': self.type}
-        for name, value in vars(self).items():
-            if name == 'type':
-                continue
-            children[name] = value
+        if k == '_name':
+            if self.name is None:
+                return None, None
+            else:
+                return 'name', v
 
-        import treescope  # type: ignore[import-not-found,import-untyped]
-        return treescope.repr_lib.render_object_constructor(
-            object_type=type(self),
-            attributes=children,
-            path=path,
-            subtree_renderer=subtree_renderer,
-        )
+        return k, v
 
     def replace(self, value: B) -> TreefyState[B]:
         """

--- a/brainstate/compile/_make_jaxpr.py
+++ b/brainstate/compile/_make_jaxpr.py
@@ -206,7 +206,7 @@ class StatefulFunction(object):
         self._cached_state_trace: Dict[Any, StateTraceStack] = dict()
 
     def __repr__(self) -> str:
-        return (f"{self.__class__.__name__}({self.fun}, "
+        return (f"{self.__class__.__name__}("
                 f"static_argnums={self.static_argnums}, "
                 f"axis_env={self.axis_env}, "
                 f"abstracted_axes={self.abstracted_axes}, "

--- a/brainstate/graph/_graph_node.py
+++ b/brainstate/graph/_graph_node.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from brainstate._state import State, TreefyState
 from brainstate.typing import Key
-from brainstate.util._pretty_repr import PrettyRepr, pretty_repr_avoid_duplicate, PrettyType, PrettyAttr
+from brainstate.util._pretty_repr import PrettyRepr, yield_unique_pretty_repr_items, PrettyType, PrettyAttr
 from ._graph_operation import register_graph_node_type
 
 __all__ = [
@@ -88,7 +88,7 @@ class Node(PrettyRepr, metaclass=GraphNodeMeta):
         """
         Pretty repr for the object.
         """
-        yield from pretty_repr_avoid_duplicate(self, _default_repr_object, _default_repr_attr)
+        yield from yield_unique_pretty_repr_items(self, _default_repr_object, _default_repr_attr)
 
     def __treescope_repr__(self, path, subtree_renderer):
         """

--- a/brainstate/nn/_interaction/_conv.py
+++ b/brainstate/nn/_interaction/_conv.py
@@ -193,16 +193,18 @@ class _Conv(_BaseConv):
         name: str = None,
         param_type: type = ParamState,
     ):
-        super().__init__(in_size=in_size,
-                         out_channels=out_channels,
-                         kernel_size=kernel_size,
-                         stride=stride,
-                         padding=padding,
-                         lhs_dilation=lhs_dilation,
-                         rhs_dilation=rhs_dilation,
-                         groups=groups,
-                         w_mask=w_mask,
-                         name=name)
+        super().__init__(
+            in_size=in_size,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            lhs_dilation=lhs_dilation,
+            rhs_dilation=rhs_dilation,
+            groups=groups,
+            w_mask=w_mask,
+            name=name
+        )
 
         self.w_initializer = w_init
         self.b_initializer = b_init

--- a/brainstate/nn/_module.py
+++ b/brainstate/nn/_module.py
@@ -294,7 +294,8 @@ class Sequential(Module):
         # the input and output shape
         if first.in_size is not None:
             self.in_size = first.in_size
-        self.out_size = tuple(in_size)
+        if in_size is not None:
+            self.out_size = tuple(in_size)
 
     def update(self, x):
         """Update function of a sequential model.

--- a/brainstate/util/_pretty_repr.py
+++ b/brainstate/util/_pretty_repr.py
@@ -21,9 +21,11 @@ import dataclasses
 import threading
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import Any, Iterator, Mapping, TypeVar, Union, Callable, Optional
+from typing import Any, Iterator, Mapping, TypeVar, Union, Callable, Optional, Sequence
 
 __all__ = [
+    'yield_unique_pretty_repr_items',
+    'pretty_repr',
     'PrettyType',
     'PrettyAttr',
     'PrettyRepr',
@@ -80,7 +82,7 @@ class PrettyRepr(ABC):
 
     def __repr__(self) -> str:
         # repr the individual object with the pretty representation
-        return get_repr(self)
+        return pretty_repr(self)
 
 
 def _repr_elem(obj: PrettyType, elem: Any) -> str:
@@ -93,7 +95,7 @@ def _repr_elem(obj: PrettyType, elem: Any) -> str:
     return f'{obj.elem_indent}{elem.start}{elem.key}{obj.value_sep}{value}{elem.end}'
 
 
-def get_repr(obj: PrettyRepr) -> str:
+def pretty_repr(obj: PrettyRepr) -> str:
     """
     Get the pretty representation of an object.
     """
@@ -140,9 +142,10 @@ class PrettyMapping(PrettyRepr):
     Pretty representation of a mapping.
     """
     mapping: Mapping
+    type_name: str = ''
 
     def __pretty_repr__(self):
-        yield PrettyType(type='', value_sep=': ', start='{', end='}')
+        yield PrettyType(type=self.type_name, value_sep=': ', start='{', end='}')
 
         for key, value in self.mapping.items():
             yield PrettyAttr(repr(key), value)
@@ -168,7 +171,7 @@ def _default_repr_attr(node):
         yield PrettyAttr(name, repr(value))
 
 
-def pretty_repr_avoid_duplicate(
+def yield_unique_pretty_repr_items(
     node,
     repr_object: Optional[Callable] = None,
     repr_attr: Optional[Callable] = None
@@ -206,3 +209,4 @@ def pretty_repr_avoid_duplicate(
     finally:
         if clear_seen:
             CONTEXT.seen_modules_repr = None
+


### PR DESCRIPTION
This pull request includes several changes to the `brainstate` package, primarily focusing on improving the pretty representation functionality and refactoring the code for better readability and maintainability. The most important changes include the introduction of the `PrettyReprTree` class, modifications to existing classes to use `PrettyReprTree`, and updates to the pretty representation methods.

### Improvements to pretty representation functionality:
* Introduced the `PrettyReprTree` class for a more structured and tree-like pretty representation. (`brainstate/util/_dict.py`, `[[1]](diffhunk://#diff-b434c28c1cd03bdfc50c73595d931666c07744be759d3bb741b564d1a8bdd327L24-R28)`, `[[2]](diffhunk://#diff-b434c28c1cd03bdfc50c73595d931666c07744be759d3bb741b564d1a8bdd327R145-R148)`)
* Replaced `pretty_repr_avoid_duplicate` with `yield_unique_pretty_repr_items` for yielding unique pretty representation items. (`brainstate/util/_pretty_repr.py`, `[[1]](diffhunk://#diff-b434c28c1cd03bdfc50c73595d931666c07744be759d3bb741b564d1a8bdd327L171-R174)`, `[[2]](diffhunk://#diff-b434c28c1cd03bdfc50c73595d931666c07744be759d3bb741b564d1a8bdd327R212)`)
* Updated pretty representation methods in various classes to use `PrettyReprTree` and `yield_unique_pretty_repr_items`. (`brainstate/_state.py`, `brainstate/graph/_graph_node.py`, `brainstate/util/_dict.py`)

### Code refactoring:
* Refactored import statements for better readability and organization. (`brainstate/_state.py`, `[brainstate/_state.pyL22-R33](diffhunk://#diff-1678a09796fe32937a594146fd1e78201827f3456dfcfed9a3c82f1e65f16a44L22-R33)`)
* Simplified the `__repr__` method in `brainstate/compile/_make_jaxpr.py` by removing redundant information. (`[brainstate/compile/_make_jaxpr.pyL209-R209](diffhunk://#diff-3b05e5bec9c3bff8277ee464c225664461a9ca5288f235982df160f3ac8c2bc9L209-R209)`)
* Improved the constructor formatting in `brainstate/nn/_interaction/_conv.py` for better readability. (`[[1]](diffhunk://#diff-05aa2a101ed018aa82b2b6fb1e547abde861334cb5654f8ff85b7c935f57a7a6L196-R197)`, `[[2]](diffhunk://#diff-05aa2a101ed018aa82b2b6fb1e547abde861334cb5654f8ff85b7c935f57a7a6L205-R207)`)

### Additional changes:
* Added `PrettyList` class for pretty representation of lists. (`brainstate/util/_dict.py`, `[brainstate/util/_dict.pyR782-R815](diffhunk://#diff-e9949f18820303d6567c0659bbd1c9a387e9925aa7e2e2a41ab66d60236dab80R782-R815)`)
* Updated `State` and `TreefyState` classes to use `PrettyReprTree` instead of `PrettyRepr`. (`brainstate/_state.py`, `[[1]](diffhunk://#diff-1678a09796fe32937a594146fd1e78201827f3456dfcfed9a3c82f1e65f16a44L187-R189)`, `[[2]](diffhunk://#diff-1678a09796fe32937a594146fd1e78201827f3456dfcfed9a3c82f1e65f16a44L805-R787)`)

## Summary by Sourcery

Improve the pretty representation functionality by introducing the `PrettyReprTree` class and refactoring existing classes to use it. Replace `pretty_repr_avoid_duplicate` with `yield_unique_pretty_repr_items` for yielding unique pretty representation items.  Add the `PrettyList` class for pretty representation of lists.

New Features:
- Introduce the `PrettyReprTree` class for a more structured and tree-like pretty representation.
- Add `PrettyList` class for pretty representation of lists.

Enhancements:
- Refactor import statements for better readability and organization.
- Simplify the `__repr__` method in `brainstate/compile/_make_jaxpr.py` by removing redundant information.
- Improve the constructor formatting in `brainstate/nn/_interaction/_conv.py` for better readability.