### PR TITLE
Fix bugs

### DIFF
--- a/brainstate/augment/_mapping.py
+++ b/brainstate/augment/_mapping.py
@@ -918,11 +918,11 @@ def map(
         g = lambda _, x: ((), vmap(f)(*x))
         _, scan_ys = scan(g, (), scan_xs)
         if remainder_xs is None:
-            ys = jax.tree.map(lambda x: flatten_(x), scan_ys)
+            ys = jax.tree.map(lambda x: _flatten(x), scan_ys)
         else:
             remainder_ys = vmap(f)(*remainder_xs)
             ys = jax.tree.map(
-                lambda x, y: jax.lax.concatenate([flatten_(x), y], dimension=0),
+                lambda x, y: jax.lax.concatenate([_flatten(x), y], dimension=0),
                 scan_ys,
                 remainder_ys,
             )
@@ -932,7 +932,7 @@ def map(
     return ys
 
 
-def flatten_(x):
+def _flatten(x):
     return x.reshape(-1, *x.shape[2:])
 
 
@@ -948,6 +948,8 @@ def _vmap_new_states_transform(
     # -- brainstate specific arguments -- #
     state_tag: str | None = None,
     state_to_exclude: Filter | None = None,
+    in_states: Dict[int, Dict] | Any | None = None,
+    out_states: Dict[int, Dict] | Any | None = None,
 ):
     # TODO: How about nested call ``vmap_new_states``?
 
@@ -957,6 +959,8 @@ def _vmap_new_states_transform(
         axis_name=axis_name,
         axis_size=axis_size,
         spmd_axis_name=spmd_axis_name,
+        in_states=in_states,
+        out_states=out_states,
     )
     def new_fun(args):
         # call the function
@@ -999,6 +1003,8 @@ def vmap_new_states(
     # -- brainstate specific arguments -- #
     state_tag: str | None = None,
     state_to_exclude: Filter = None,
+    in_states: Dict[int, Dict] | Any | None = None,
+    out_states: Dict[int, Dict] | Any | None = None,
 ):
     """
     Vectorize a function over new states created within it.
@@ -1030,6 +1036,8 @@ def vmap_new_states(
             spmd_axis_name=spmd_axis_name,
             state_tag=state_tag,
             state_to_exclude=state_to_exclude,
+            in_states=in_states,
+            out_states=out_states,
         )
     else:
         return _vmap_new_states_transform(
@@ -1041,4 +1049,6 @@ def vmap_new_states(
             spmd_axis_name=spmd_axis_name,
             state_tag=state_tag,
             state_to_exclude=state_to_exclude,
+            in_states=in_states,
+            out_states=out_states,
         )

--- a/brainstate/augment/_mapping.py
+++ b/brainstate/augment/_mapping.py
@@ -952,6 +952,9 @@ def _vmap_new_states_transform(
     out_states: Dict[int, Dict] | Any | None = None,
 ):
     # TODO: How about nested call ``vmap_new_states``?
+    if isinstance(axis_size, int) and axis_size <= 0:
+        raise ValueError(f"axis_size must be greater than 0, got {axis_size}.")
+
 
     @vmap(
         in_axes=in_axes,

--- a/brainstate/nn/_collective_ops.py
+++ b/brainstate/nn/_collective_ops.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 from collections import namedtuple
 
 import jax
-from typing import (
-    Callable, TypeVar, Tuple, Any, Dict
-)
+from typing import Callable, TypeVar, Tuple, Any, Dict
 
 from brainstate._state import catch_new_states
 from brainstate._utils import set_module_as
@@ -103,7 +101,7 @@ def call_all_functions(
     on each node. It respects the call order of functions if defined, and provides options for
     handling cases where the specified function does not exist on a node.
 
-    Parameters:
+    Parameters
     -----------
     target : T
         The target module on which to call functions.
@@ -121,12 +119,12 @@ def call_all_functions(
         - 'raise': Raise an exception (default)
         - 'pass' or 'none': Skip the node and continue
         
-    Returns:
+    Returns
     --------
     T
         The target module after calling the specified function on all applicable nodes.
 
-    Raises:
+    Raises
     -------
     AssertionError
         If fun_name is not a string or kwargs is not a dictionary.
@@ -186,7 +184,7 @@ def vmap_call_all_functions(
     This function vectorizes the process of calling a specified function across multiple instances
     of the target module, effectively batching the operation.
 
-    Parameters:
+    Parameters
     -----------
     target : T
         The target module on which to call functions.
@@ -208,12 +206,12 @@ def vmap_call_all_functions(
         - 'raise': Raise an exception (default)
         - 'pass' or 'none': Skip the node and continue
 
-    Returns:
+    Returns
     --------
     T
         The target module after applying the vectorized function call on all applicable nodes.
 
-    Raises:
+    Raises
     -------
     AssertionError
         If axis_size is not specified or is not a positive integer.
@@ -304,7 +302,7 @@ def vmap_init_all_states(
     This function applies vectorized mapping (vmap) to initialize states across multiple
     instances of the target module, effectively batching the initialization process.
 
-    Parameters:
+    Parameters
     -----------
     target : T
         The target module whose states are to be initialized.
@@ -319,12 +317,12 @@ def vmap_init_all_states(
     state_tag : str | None, optional
         A tag to be used for catching new states.
 
-    Returns:
+    Returns
     --------
     T
         The target module with initialized states.
 
-    Raises:
+    Raises
     -------
     AssertionError
         If axis_size is not specified or is not greater than 0.
@@ -413,7 +411,7 @@ def vmap_reset_all_states(
     This function applies vectorized mapping (vmap) to reset states across multiple
     instances of the target module, effectively batching the reset process.
 
-    Parameters:
+    Parameters
     -----------
     target : T
         The target module whose states are to be reset.
@@ -428,12 +426,12 @@ def vmap_reset_all_states(
     tag : str | None, optional
         A tag to be used for catching new states.
 
-    Returns:
+    Returns
     --------
     T
         The target module with reset states.
 
-    Raises:
+    Raises
     -------
     AssertionError
         If axis_size is not specified or is not greater than 0.
@@ -486,7 +484,7 @@ def save_all_states(target: Module, **kwargs) -> Dict:
     Args:
       target: Module. The node to save its states.
 
-    Returns:
+    Returns
       Dict. The state dict for serialization.
     """
     return {key: node.save_state(**kwargs) for key, node in target.nodes().items()}

--- a/brainstate/nn/_collective_ops.py
+++ b/brainstate/nn/_collective_ops.py
@@ -250,9 +250,9 @@ def vmap_call_all_functions(
 @set_module_as('brainstate.nn')
 def init_all_states(
     target: T,
-    init_args: Tuple[Any, ...] | Any = (),
-    init_kwargs: Dict[str, Any] | None = None,
+    *init_args,
     node_to_exclude: Filter = None,
+    **init_kwargs,
 ) -> T:
     """
     Initialize all states for the given target module and its submodules.

--- a/brainstate/nn/_collective_ops_test.py
+++ b/brainstate/nn/_collective_ops_test.py
@@ -34,3 +34,14 @@ class Test_vmap_init_all_states:
             print(gru)
 
         init()
+
+
+class Test_init_all_states:
+    def test_init_all_states(self):
+        gru = bst.nn.GRUCell(1, 2)
+        bst.nn.init_all_states(gru, batch_size=10)
+        print(gru)
+
+
+
+

--- a/brainstate/nn/_dyn_impl/_dynamics_synapse.py
+++ b/brainstate/nn/_dyn_impl/_dynamics_synapse.py
@@ -17,8 +17,9 @@
 
 from __future__ import annotations
 
+from typing import Optional, Callable
+
 import brainunit as u
-from typing import Optional
 
 from brainstate import init, environ
 from brainstate._state import ShortTermState, HiddenState
@@ -54,7 +55,7 @@ class Expon(Synapse, AlignPost):
         in_size: Size,
         name: Optional[str] = None,
         tau: ArrayLike = 8.0 * u.ms,
-        g_initializer: ArrayLike = init.ZeroInit(unit=u.mS),
+        g_initializer: ArrayLike | Callable = init.ZeroInit(unit=u.mS),
     ):
         super().__init__(name=name, in_size=in_size)
 
@@ -85,7 +86,7 @@ class DualExpon(Synapse, AlignPost):
         tau_decay: ArrayLike = 10.0 * u.ms,
         tau_rise: ArrayLike = 1.0 * u.ms,
         A: Optional[ArrayLike] = None,
-        g_initializer: ArrayLike = init.ZeroInit(unit=u.mS),
+        g_initializer: ArrayLike | Callable = init.ZeroInit(unit=u.mS),
     ):
         super().__init__(name=name, in_size=in_size)
 
@@ -133,7 +134,7 @@ class Alpha(Synapse):
         in_size: Size,
         name: Optional[str] = None,
         tau: ArrayLike = 8.0 * u.ms,
-        g_initializer: ArrayLike = init.ZeroInit(unit=u.mS),
+        g_initializer: ArrayLike | Callable = init.ZeroInit(unit=u.mS),
     ):
         super().__init__(name=name, in_size=in_size)
 
@@ -321,7 +322,7 @@ class AMPA(Synapse):
         beta: ArrayLike = 0.18 / u.ms,
         T: ArrayLike = 0.5 * u.mM,
         T_dur: ArrayLike = 0.5 * u.ms,
-        g_initializer: ArrayLike = init.ZeroInit(),
+        g_initializer: ArrayLike | Callable = init.ZeroInit(),
     ):
         super().__init__(name=name, in_size=in_size)
 
@@ -394,5 +395,14 @@ class GABAa(AMPA):
         beta: ArrayLike = 0.18 / u.ms,
         T: ArrayLike = 1.0 * u.mM,
         T_dur: ArrayLike = 1.0 * u.ms,
+        g_initializer: ArrayLike | Callable = init.ZeroInit(),
     ):
-        super().__init__(alpha=alpha, beta=beta, T=T, T_dur=T_dur, name=name, in_size=in_size)
+        super().__init__(
+            alpha=alpha,
+            beta=beta,
+            T=T,
+            T_dur=T_dur,
+            name=name,
+            in_size=in_size,
+            g_initializer=g_initializer
+        )

--- a/brainstate/nn/_exp_euler.py
+++ b/brainstate/nn/_exp_euler.py
@@ -49,13 +49,13 @@ def exp_euler_step(
     should have units of ( [X]/\sqrt{[T]} ).
 
     Args:
-      fun: Callable. The function to be solved.
-      diffusion: Callable. The diffusion function.
-      *args: The input arguments.
-      drift: Callable. The drift function.
+        fun: Callable. The function to be solved.
+        diffusion: Callable. The diffusion function.
+        *args: The input arguments.
+        drift: Callable. The drift function.
 
     Returns:
-      The one-step solution of the ODE.
+        The one-step solution of the ODE.
     """
     assert callable(fn), 'The input function should be callable.'
     assert len(args) > 0, 'The input arguments should not be empty.'


### PR DESCRIPTION
This pull request includes multiple changes across several files to improve the functionality and flexibility of the `brainstate` package. The most important changes include renaming a function for clarity, adding new parameters to existing methods, and updating tests to cover new functionalities.

Function renaming for clarity:

* [`brainstate/augment/_mapping.py`](diffhunk://#diff-8990a4727b68538520b7f1c89b9bc1b203ac1a6f80a7757b30046e8cf7f2984bL935-R935): Renamed the `flatten_` function to `_flatten` to better indicate its intended private use.

Enhancements to state management:

* [`brainstate/augment/_mapping.py`](diffhunk://#diff-8990a4727b68538520b7f1c89b9bc1b203ac1a6f80a7757b30046e8cf7f2984bR951-R952): Added `in_states` and `out_states` parameters to the `_vmap_new_states_transform` and `vmap_new_states` functions to allow more flexible state handling. [[1]](diffhunk://#diff-8990a4727b68538520b7f1c89b9bc1b203ac1a6f80a7757b30046e8cf7f2984bR951-R952) [[2]](diffhunk://#diff-8990a4727b68538520b7f1c89b9bc1b203ac1a6f80a7757b30046e8cf7f2984bR1006-R1007)

Test improvements:

* [`brainstate/augment/_mapping_test.py`](diffhunk://#diff-ebcf2ff107177cc333f94c73d81335ecaec72ad06363f7cbdac3a0e35edc4982R272-R316): Added a new test `test_vmap_init` to cover the initialization of states using the `vmap_new_states` function.

Documentation improvements:

* [`brainstate/nn/_collective_ops.py`](diffhunk://#diff-233530d7151591453e6dd2e53307aba1407b00c6f5b39725ed634a57b08dafb8L106-R104): Updated the docstrings for several functions to follow a consistent format and improve clarity. [[1]](diffhunk://#diff-233530d7151591453e6dd2e53307aba1407b00c6f5b39725ed634a57b08dafb8L106-R104) [[2]](diffhunk://#diff-233530d7151591453e6dd2e53307aba1407b00c6f5b39725ed634a57b08dafb8L124-R127) [[3]](diffhunk://#diff-233530d7151591453e6dd2e53307aba1407b00c6f5b39725ed634a57b08dafb8L189-R187) [[4]](diffhunk://#diff-233530d7151591453e6dd2e53307aba1407b00c6f5b39725ed634a57b08dafb8L211-R214) [[5]](diffhunk://#diff-233530d7151591453e6dd2e53307aba1407b00c6f5b39725ed634a57b08dafb8L322-R325)

Type hint enhancements:

* [`brainstate/nn/_dyn_impl/_dynamics_synapse.py`](diffhunk://#diff-1ecbe975d2295d0e9839e6b2adeda5ccfebbc55d5cf2fb04ed4925e8427c4d84L57-R58): Updated the `g_initializer` parameter to accept both `ArrayLike` and `Callable` types for more flexibility in initialization. [[1]](diffhunk://#diff-1ecbe975d2295d0e9839e6b2adeda5ccfebbc55d5cf2fb04ed4925e8427c4d84L57-R58) [[2]](diffhunk://#diff-1ecbe975d2295d0e9839e6b2adeda5ccfebbc55d5cf2fb04ed4925e8427c4d84L88-R89) [[3]](diffhunk://#diff-1ecbe975d2295d0e9839e6b2adeda5ccfebbc55d5cf2fb04ed4925e8427c4d84L136-R137) [[4]](diffhunk://#diff-1ecbe975d2295d0e9839e6b2adeda5ccfebbc55d5cf2fb04ed4925e8427c4d84L324-R325) [[5]](diffhunk://#diff-1ecbe975d2295d0e9839e6b2adeda5ccfebbc55d5cf2fb04ed4925e8427c4d84R398-R408)

## Summary by Sourcery

Improves the functionality and flexibility of the `brainstate` package by renaming a function for clarity, adding new parameters to existing methods for more flexible state handling, updating tests to cover new functionalities, updating docstrings for clarity, and enhancing type hints for more flexibility in initialization.

Enhancements:
- Renames the `flatten_` function to `_flatten` to better indicate its intended private use.
- Adds `in_states` and `out_states` parameters to the `_vmap_new_states_transform` and `vmap_new_states` functions to allow more flexible state handling.
- Updates the `g_initializer` parameter to accept both `ArrayLike` and `Callable` types for more flexibility in initialization.
- Updates the docstrings for several functions to follow a consistent format and improve clarity.
- Adds a new test `test_vmap_init` to cover the initialization of states using the `vmap_new_states` function.
- Adds a test for `init_all_states` function in `Test_init_all_states`.