### PR TITLE
compatible with jax>=0.6.0

### DIFF
--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -16,15 +16,27 @@
 # -*- coding: utf-8 -*-
 
 
-import jax
 from contextlib import contextmanager
 from typing import Iterable, Hashable
 
+import jax
+
+__all__ = [
+    'ClosedJaxpr',
+    'Primitive',
+    'extend_axis_env_nd',
+    'jaxpr_as_fun',
+    'get_aval',
+    'Tracer',
+    'to_concrete_aval',
+]
+
+from jax.core import get_aval, Tracer
 
 if jax.__version_info__ < (0, 4, 38):
-    from jax.core import ClosedJaxpr, extend_axis_env_nd, Primitive
+    from jax.core import ClosedJaxpr, extend_axis_env_nd, Primitive, jaxpr_as_fun
 else:
-    from jax.extend.core import ClosedJaxpr, Primitive
+    from jax.extend.core import ClosedJaxpr, Primitive, jaxpr_as_fun
     from jax.core import trace_ctx
 
 
@@ -38,4 +50,9 @@ else:
             trace_ctx.set_axis_env(prev)
 
 
+def to_concrete_aval(aval):
+    aval = get_aval(aval)
+    if isinstance(aval, Tracer):
+        return aval.to_concrete_value()
+    return aval
 

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -1,0 +1,41 @@
+# Copyright 2025 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+
+import jax
+from contextlib import contextmanager
+from typing import Iterable, Hashable
+
+
+if jax.__version_info__ < (0, 4, 38):
+    from jax.core import ClosedJaxpr, extend_axis_env_nd, Primitive
+else:
+    from jax.extend.core import ClosedJaxpr, Primitive
+    from jax.core import trace_ctx
+
+
+    @contextmanager
+    def extend_axis_env_nd(name_size_pairs: Iterable[tuple[Hashable, int]]):
+        prev = trace_ctx.axis_env
+        try:
+            trace_ctx.set_axis_env(prev.extend_pure(name_size_pairs))
+            yield
+        finally:
+            trace_ctx.set_axis_env(prev)
+
+
+

--- a/brainstate/compile/_conditions.py
+++ b/brainstate/compile/_conditions.py
@@ -24,6 +24,8 @@ from brainstate._utils import set_module_as
 from ._error_if import jit_error_if
 from ._make_jaxpr import StatefulFunction
 from ._util import wrap_single_fun_in_multi_branches, write_back_state_values
+from brainstate._compatible_import import to_concrete_aval, Tracer
+
 
 __all__ = [
     'cond', 'switch', 'ifelse',
@@ -86,7 +88,7 @@ def cond(pred, true_fun: Callable, false_fun: Callable, *operands):
             raise TypeError("Pred type must be either boolean or number, got {}.".format(pred_dtype))
 
     # not jit
-    if jax.config.jax_disable_jit and isinstance(jax.core.get_aval(pred), jax.core.ConcreteArray):
+    if jax.config.jax_disable_jit and not isinstance(to_concrete_aval(pred), Tracer):
         if pred:
             return true_fun(*operands)
         else:

--- a/brainstate/compile/_make_jaxpr.py
+++ b/brainstate/compile/_make_jaxpr.py
@@ -65,7 +65,6 @@ from jax._src import source_info_util
 from jax._src.linear_util import annotate
 from jax._src.traceback_util import api_boundary
 from jax.api_util import shaped_abstractify
-from jax.core import trace_ctx
 from jax.extend.linear_util import transformation_with_aux, wrap_init
 from jax.interpreters import partial_eval as pe
 from jax.util import wraps
@@ -74,11 +73,7 @@ from brainstate._state import State, StateTraceStack
 from brainstate._utils import set_module_as
 from brainstate.typing import PyTree
 from brainstate.util import PrettyObject
-
-if jax.__version_info__ < (0, 4, 38):
-    from jax.core import ClosedJaxpr
-else:
-    from jax.extend.core import ClosedJaxpr
+from brainstate._compatible_import import ClosedJaxpr, extend_axis_env_nd
 
 AxisName = Hashable
 
@@ -774,13 +769,3 @@ def _make_jaxpr(
     if hasattr(fun, "__name__"):
         make_jaxpr_f.__name__ = f"make_jaxpr({fun.__name__})"
     return make_jaxpr_f
-
-
-@contextmanager
-def extend_axis_env_nd(name_size_pairs: Iterable[tuple[AxisName, int]]):
-    prev = trace_ctx.axis_env
-    try:
-        trace_ctx.set_axis_env(prev.extend_pure(name_size_pairs))
-        yield
-    finally:
-        trace_ctx.set_axis_env(prev)

--- a/brainstate/compile/_make_jaxpr.py
+++ b/brainstate/compile/_make_jaxpr.py
@@ -200,7 +200,7 @@ class StatefulFunction(PrettyObject):
 
         # implicit parameters
         self.cache_type = cache_type
-        self._cached_jaxpr: Dict[Any, jax.core.ClosedJaxpr] = dict()
+        self._cached_jaxpr: Dict[Any, ClosedJaxpr] = dict()
         self._cached_out_shapes: Dict[Any, PyTree] = dict()
         self._cached_jaxpr_out_tree: Dict[Any, PyTree] = dict()
         self._cached_state_trace: Dict[Any, StateTraceStack] = dict()
@@ -210,7 +210,7 @@ class StatefulFunction(PrettyObject):
             return None
         return k, v
 
-    def get_jaxpr(self, cache_key: Hashable = ()) -> jax.core.ClosedJaxpr:
+    def get_jaxpr(self, cache_key: Hashable = ()) -> ClosedJaxpr:
         """
         Read the JAX Jaxpr representation of the function.
 
@@ -507,8 +507,8 @@ def make_jaxpr(
     return_shape: bool = False,
     abstracted_axes: Optional[Any] = None,
     state_returns: Union[str, Tuple[str, ...]] = ('read', 'write')
-) -> Callable[..., (Tuple[jax.core.ClosedJaxpr, Tuple[State, ...]] |
-                    Tuple[jax.core.ClosedJaxpr, Tuple[State, ...], PyTree])]:
+) -> Callable[..., (Tuple[ClosedJaxpr, Tuple[State, ...]] |
+                    Tuple[ClosedJaxpr, Tuple[State, ...], PyTree])]:
     """
     Creates a function that produces its jaxpr given example args.
 
@@ -759,7 +759,7 @@ def _make_jaxpr(
                 jaxpr, out_type, consts = pe.trace_to_jaxpr_dynamic2(f, debug_info=debug_info)
             else:
                 jaxpr, out_type, consts = pe.trace_to_jaxpr_dynamic2(f)
-        closed_jaxpr = jax.core.ClosedJaxpr(jaxpr, consts)
+        closed_jaxpr = ClosedJaxpr(jaxpr, consts)
         if return_shape:
             out_avals, _ = jax.util.unzip2(out_type)
             out_shapes_flat = [jax.ShapeDtypeStruct(a.shape, a.dtype) for a in out_avals]

--- a/brainstate/compile/_make_jaxpr_test.py
+++ b/brainstate/compile/_make_jaxpr_test.py
@@ -21,11 +21,7 @@ import pytest
 import unittest
 
 import brainstate as bst
-
-if jax.__version_info__ < (0, 4, 38):
-    from jax.core import jaxpr_as_fun
-else:
-    from jax.extend.core import jaxpr_as_fun
+from brainstate._compatible_import import jaxpr_as_fun
 
 
 class TestMakeJaxpr(unittest.TestCase):

--- a/brainstate/compile/_unvmap.py
+++ b/brainstate/compile/_unvmap.py
@@ -21,11 +21,8 @@ import jax.interpreters.mlir as mlir
 import jax.numpy as jnp
 
 from brainstate._utils import set_module_as
+from brainstate._compatible_import import Primitive
 
-if jax.__version_info__ < (0, 4, 38):
-    from jax.core import Primitive
-else:
-    from jax.extend.core import Primitive
 
 __all__ = [
     "unvmap",

--- a/brainstate/surrogate.py
+++ b/brainstate/surrogate.py
@@ -22,11 +22,8 @@ import jax.scipy as sci
 from jax.interpreters import batching, ad, mlir
 
 from brainstate.util._pretty_pytree import PrettyObject
+from brainstate._compatible_import import Primitive
 
-if jax.__version_info__ < (0, 4, 38):
-    from jax.core import Primitive
-else:
-    from jax.extend.core import Primitive
 
 __all__ = [
     'Surrogate',


### PR DESCRIPTION
This pull request simplifies type annotations and object instantiations in the `brainstate/compile/_make_jaxpr.py` file by replacing fully qualified references to `jax.core.ClosedJaxpr` with the shorter `ClosedJaxpr`. This improves code readability and consistency throughout the module.

### Type Annotation Simplifications:

* Replaced `jax.core.ClosedJaxpr` with `ClosedJaxpr` in the type annotation for the `_cached_jaxpr` attribute in the `__init__` method.
* Updated the return type of the `get_jaxpr` method to use `ClosedJaxpr` instead of `jax.core.ClosedJaxpr`.
* Simplified the return type annotation of the `make_jaxpr` function to use `ClosedJaxpr`.

### Object Instantiation Simplification:

* Replaced the instantiation of `jax.core.ClosedJaxpr` with `ClosedJaxpr` in the `make_jaxpr_f` function.

## Summary by Sourcery

Update type annotations and object instantiations to use simplified JAX core references

New Features:
- Improve code readability by using more concise type references in the compilation module

Enhancements:
- Simplify type annotations by replacing fully qualified `jax.core.ClosedJaxpr` with `ClosedJaxpr` throughout the module