### PR TITLE
Compatibility with jax>=0.6.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,6 +82,40 @@ jobs:
         run: |
           pytest brainstate/
 
+  test_jax_version:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.12" ]
+        jax-version: ["0.4.38", "0.5.2", "0.6.0"]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+      - name: Print concurrency group
+        run: echo '${{ github.workflow }}-${{ github.ref }}'
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip cache purge
+          python -m pip install --upgrade pip setuptools --no-cache-dir
+          python -m pip install -r requirements-dev.txt  --no-cache-dir
+          if [ "${{ matrix.jax-version }}" == "" ]; then
+            python -m pip install jax || exit 1
+          else
+            python -m pip install jax==${{ matrix.jax-version }} || exit 1
+          fi
+          python -m pip install . || exit 1
+      - name: Test with pytest
+        run: |
+          pytest brainstate/
 
   test_windows:
     runs-on: windows-latest

--- a/brainstate/__init__.py
+++ b/brainstate/__init__.py
@@ -17,7 +17,7 @@
 A ``State``-based Transformation System for Program Compilation and Augmentation
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from . import augment
 from . import compile

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -37,6 +37,7 @@ __all__ = [
     'unzip2',
     'wraps',
     'Device',
+    'wrap_init',
 ]
 
 T = TypeVar("T")
@@ -44,6 +45,8 @@ T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
 
+
+from saiunit._compatible_import import wrap_init
 brainevent_installed = importlib.util.find_spec('brainevent') is not None
 
 from jax.core import get_aval, Tracer

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -1049,7 +1049,7 @@ class StateTraceStack(Generic[A]):
         """
         if self._jax_trace_new_arg is not None:
             # internal use
-            state._value = jax.tree.map(lambda x: self._jax_trace_new_arg(shaped_abstractify(x)), state._value)
+            state._value = jax.tree.map(self._jax_trace_new_arg, state._value)
 
     def __enter__(self) -> 'StateTraceStack':
         TRACE_CONTEXT.state_stack.append(self)

--- a/brainstate/augment/_eval_shape_test.py
+++ b/brainstate/augment/_eval_shape_test.py
@@ -14,27 +14,25 @@
 # ==============================================================================
 
 
-from __future__ import annotations
-
 import unittest
 
-import brainstate as bst
+import brainstate
 
 
 class TestEvalShape(unittest.TestCase):
     def test1(self):
-        class MLP(bst.nn.Module):
+        class MLP(brainstate.nn.Module):
             def __init__(self, n_in, n_mid, n_out):
                 super().__init__()
-                self.dense1 = bst.nn.Linear(n_in, n_mid)
-                self.dense2 = bst.nn.Linear(n_mid, n_out)
+                self.dense1 = brainstate.nn.Linear(n_in, n_mid)
+                self.dense2 = brainstate.nn.Linear(n_mid, n_out)
 
             def __call__(self, x):
                 x = self.dense1(x)
-                x = bst.functional.relu(x)
+                x = brainstate.functional.relu(x)
                 x = self.dense2(x)
                 return x
 
-        r = bst.augment.abstract_init(lambda: MLP(1, 2, 3))
+        r = brainstate.augment.abstract_init(lambda: MLP(1, 2, 3))
         print(r)
-        print(bst.random.DEFAULT)
+        print(brainstate.random.DEFAULT)

--- a/brainstate/augment/_mapping_test.py
+++ b/brainstate/augment/_mapping_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
@@ -21,7 +20,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-import brainstate as bst
+import brainstate
 import brainstate.augment
 from brainstate.augment._mapping import BatchAxisError
 from brainstate.augment._mapping import _remove_axis
@@ -29,29 +28,29 @@ from brainstate.augment._mapping import _remove_axis
 
 class TestVmap(unittest.TestCase):
     def test_vmap_1(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
 
-                self.a = bst.State(bst.random.randn(5))
-                self.b = bst.State(bst.random.randn(5))
+                self.a = brainstate.State(brainstate.random.randn(5))
+                self.b = brainstate.State(brainstate.random.randn(5))
 
             def __call__(self, *args, **kwargs):
                 return self.a.value * self.b.value
 
         model = Model()
         r1 = model.a.value * model.b.value
-        r2 = bst.augment.vmap(model, in_states=model.states())()
+        r2 = brainstate.augment.vmap(model, in_states=model.states())()
         self.assertTrue(jnp.allclose(r1, r2))
 
     def test_vmap_2(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
 
-                self.a = bst.ShortTermState(bst.random.randn(5))
-                self.b = bst.ShortTermState(bst.random.randn(5))
-                self.c = bst.State(bst.random.randn(1))
+                self.a = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.b = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.c = brainstate.State(brainstate.random.randn(1))
 
             def __call__(self, *args, **kwargs):
                 self.c.value = self.a.value * self.b.value
@@ -59,104 +58,104 @@ class TestVmap(unittest.TestCase):
 
         model = Model()
         with self.assertRaises(BatchAxisError):
-            r2 = bst.augment.vmap(model, in_states=model.states(bst.ShortTermState))()
+            r2 = brainstate.augment.vmap(model, in_states=model.states(brainstate.ShortTermState))()
 
         model = Model()
-        r2 = bst.augment.vmap(model, in_states=model.states(bst.ShortTermState), out_states=model.c)()
+        r2 = brainstate.augment.vmap(model, in_states=model.states(brainstate.ShortTermState), out_states=model.c)()
 
     def test_vmap_3(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
 
-                self.a = bst.State(bst.random.randn(5))
-                self.b = bst.State(bst.random.randn(5))
+                self.a = brainstate.State(brainstate.random.randn(5))
+                self.b = brainstate.State(brainstate.random.randn(5))
 
             def __call__(self, *args, **kwargs):
                 return self.a.value * self.b.value
 
         model = Model()
         with self.assertRaises(BatchAxisError):
-            r2 = bst.augment.vmap(model, in_states=model.states(), out_states={1: model.states()})()
+            r2 = brainstate.augment.vmap(model, in_states=model.states(), out_states={1: model.states()})()
 
     def test_vmap_with_random(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
 
-                self.a = bst.ShortTermState(bst.random.randn(5))
-                self.b = bst.ShortTermState(bst.random.randn(5))
-                self.c = bst.State(bst.random.randn(1))
+                self.a = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.b = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.c = brainstate.State(brainstate.random.randn(1))
 
             def __call__(self, key):
-                bst.random.set_key(key)
+                brainstate.random.set_key(key)
                 self.c.value = self.a.value * self.b.value
-                return self.c.value + bst.random.randn(1)
+                return self.c.value + brainstate.random.randn(1)
 
         model = Model()
-        r2 = bst.augment.vmap(
+        r2 = brainstate.augment.vmap(
             model,
-            in_states=model.states(bst.ShortTermState),
+            in_states=model.states(brainstate.ShortTermState),
             out_states=model.c
         )(
-            bst.random.split_key(5)
+            brainstate.random.split_key(5)
         )
-        print(bst.random.DEFAULT)
+        print(brainstate.random.DEFAULT)
 
     def test_vmap_with_random_v3(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
 
-                self.a = bst.ShortTermState(bst.random.randn(5))
-                self.b = bst.ShortTermState(bst.random.randn(5))
-                self.c = bst.State(bst.random.randn(1))
+                self.a = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.b = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.c = brainstate.State(brainstate.random.randn(1))
 
             def __call__(self):
                 self.c.value = self.a.value * self.b.value
-                return self.c.value + bst.random.randn(1)
+                return self.c.value + brainstate.random.randn(1)
 
         model = Model()
-        r2 = bst.augment.vmap(
+        r2 = brainstate.augment.vmap(
             model,
-            in_states=model.states(bst.ShortTermState),
+            in_states=model.states(brainstate.ShortTermState),
             out_states=model.c
         )()
-        print(bst.random.DEFAULT)
+        print(brainstate.random.DEFAULT)
 
     def test_vmap_with_random_2(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
 
-                self.a = bst.ShortTermState(bst.random.randn(5))
-                self.b = bst.ShortTermState(bst.random.randn(5))
-                self.c = bst.State(bst.random.randn(1))
-                self.rng = bst.random.RandomState(1)
+                self.a = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.b = brainstate.ShortTermState(brainstate.random.randn(5))
+                self.c = brainstate.State(brainstate.random.randn(1))
+                self.rng = brainstate.random.RandomState(1)
 
             def __call__(self, key):
                 self.rng.set_key(key)
                 self.c.value = self.a.value * self.b.value
-                return self.c.value + bst.random.randn(1)
+                return self.c.value + brainstate.random.randn(1)
 
         model = Model()
-        r2 = bst.augment.vmap(
+        r2 = brainstate.augment.vmap(
             model,
-            in_states=model.states(bst.ShortTermState),
+            in_states=model.states(brainstate.ShortTermState),
             out_states=model.c
         )(
-            bst.random.split_key(5)
+            brainstate.random.split_key(5)
         )
 
     def test_vmap_input(self):
-        model = bst.nn.Linear(2, 3)
+        model = brainstate.nn.Linear(2, 3)
         print(id(model), id(model.weight))
         model_id = id(model)
         weight_id = id(model.weight)
 
         x = jnp.ones((5, 2))
 
-        @bst.augment.vmap
+        @brainstate.augment.vmap
         def forward(x):
             self.assertTrue(id(model) == model_id)
             self.assertTrue(id(model.weight) == weight_id)
@@ -169,39 +168,39 @@ class TestVmap(unittest.TestCase):
         print(model.weight.value)
 
     def test_vmap_states_and_input_1(self):
-        gru = bst.nn.GRUCell(2, 3)
+        gru = brainstate.nn.GRUCell(2, 3)
         gru.init_state(5)
 
-        @bst.augment.vmap(in_states=gru.states(bst.HiddenState))
+        @brainstate.augment.vmap(in_states=gru.states(brainstate.HiddenState))
         def forward(x):
             return gru(x)
 
-        xs = bst.random.randn(5, 2)
+        xs = brainstate.random.randn(5, 2)
         y = forward(xs)
         self.assertTrue(y.shape == (5, 3))
 
     def test_vmap_jit(self):
-        class Foo(bst.nn.Module):
+        class Foo(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = bst.ParamState(jnp.arange(4))
-                self.b = bst.ShortTermState(jnp.arange(4))
+                self.a = brainstate.ParamState(jnp.arange(4))
+                self.b = brainstate.ShortTermState(jnp.arange(4))
 
             def __call__(self):
                 self.b.value = self.a.value * self.b.value
 
         foo = Foo()
 
-        @bst.augment.vmap(in_states=foo.states())
+        @brainstate.augment.vmap(in_states=foo.states())
         def mul():
             foo()
 
-        @bst.compile.jit
+        @brainstate.compile.jit
         def mul_jit(inp):
             mul()
             foo.a.value += inp
 
-        with bst.StateTraceStack() as trace:
+        with brainstate.StateTraceStack() as trace:
             mul_jit(1.)
 
         print(foo.a.value)
@@ -219,27 +218,27 @@ class TestVmap(unittest.TestCase):
         print(trace.get_read_states())
 
     def test_vmap_jit_2(self):
-        class Foo(bst.nn.Module):
+        class Foo(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = bst.ParamState(jnp.arange(4))
-                self.b = bst.ShortTermState(jnp.arange(4))
+                self.a = brainstate.ParamState(jnp.arange(4))
+                self.b = brainstate.ShortTermState(jnp.arange(4))
 
             def __call__(self):
                 self.b.value = self.a.value * self.b.value
 
         foo = Foo()
 
-        @bst.augment.vmap(in_states=foo.states())
+        @brainstate.augment.vmap(in_states=foo.states())
         def mul():
             foo()
 
-        @bst.compile.jit
+        @brainstate.compile.jit
         def mul_jit(inp):
             mul()
             foo.b.value += inp
 
-        with bst.StateTraceStack() as trace:
+        with brainstate.StateTraceStack() as trace:
             mul_jit(1.)
 
         print(foo.a.value)
@@ -258,9 +257,9 @@ class TestVmap(unittest.TestCase):
 
     def test_auto_rand_key_split(self):
         def f():
-            return bst.random.rand(1)
+            return brainstate.random.rand(1)
 
-        res = bst.augment.vmap(f, axis_size=10)()
+        res = brainstate.augment.vmap(f, axis_size=10)()
         self.assertTrue(jnp.all(~(res[0] == res[1:])))
 
         res2 = jax.vmap(f, axis_size=10)()
@@ -278,17 +277,17 @@ class TestVmap(unittest.TestCase):
         self.assertTrue(jnp.allclose(r, r2))
 
     def test_vmap_init(self):
-        class Foo(bst.nn.Module):
+        class Foo(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = bst.ParamState(jnp.arange(4))
-                self.b = bst.ShortTermState(jnp.arange(4))
+                self.a = brainstate.ParamState(jnp.arange(4))
+                self.b = brainstate.ShortTermState(jnp.arange(4))
 
             def init_state_v1(self, *args, **kwargs):
-                self.c = bst.State(jnp.arange(4))
+                self.c = brainstate.State(jnp.arange(4))
 
             def init_state_v2(self):
-                self.d = bst.State(self.c.value * 2.)
+                self.d = brainstate.State(self.c.value * 2.)
 
         foo = Foo()
 
@@ -318,11 +317,11 @@ class TestVmap(unittest.TestCase):
 class TestMap(unittest.TestCase):
     def test_map(self):
         for dim in [(10,), (10, 10), (10, 10, 10)]:
-            x = bst.random.rand(*dim)
-            r1 = bst.augment.map(lambda a: a + 1, x, batch_size=None)
-            r2 = bst.augment.map(lambda a: a + 1, x, batch_size=2)
-            r3 = bst.augment.map(lambda a: a + 1, x, batch_size=4)
-            r4 = bst.augment.map(lambda a: a + 1, x, batch_size=5)
+            x = brainstate.random.rand(*dim)
+            r1 = brainstate.augment.map(lambda a: a + 1, x, batch_size=None)
+            r2 = brainstate.augment.map(lambda a: a + 1, x, batch_size=2)
+            r3 = brainstate.augment.map(lambda a: a + 1, x, batch_size=4)
+            r4 = brainstate.augment.map(lambda a: a + 1, x, batch_size=5)
             true_r = x + 1
 
             self.assertTrue(jnp.allclose(r1, true_r))
@@ -406,7 +405,7 @@ class TestVMAPNewStatesEdgeCases(unittest.TestCase):
         foo = brainstate.nn.LIF(3)
         # Testing that axis_size of 0 raises an error.
         with self.assertRaises(ValueError):
-            @bst.augment.vmap_new_states(state_tag='new1', axis_size=0)
+            @brainstate.augment.vmap_new_states(state_tag='new1', axis_size=0)
             def faulty_init():
                 foo.init_state()
 
@@ -417,7 +416,7 @@ class TestVMAPNewStatesEdgeCases(unittest.TestCase):
         foo = brainstate.nn.LIF(3)
         # Testing that a negative axis_size raises an error.
         with self.assertRaises(ValueError):
-            @bst.augment.vmap_new_states(state_tag='new1', axis_size=-3)
+            @brainstate.augment.vmap_new_states(state_tag='new1', axis_size=-3)
             def faulty_init():
                 foo.init_state()
 
@@ -428,9 +427,9 @@ class TestVMAPNewStatesEdgeCases(unittest.TestCase):
 
         # Simulate an incompatible shapes scenario:
         # We intentionally assign a state with a different shape than expected.
-        @bst.augment.vmap_new_states(state_tag='new1', axis_size=5)
+        @brainstate.augment.vmap_new_states(state_tag='new1', axis_size=5)
         def faulty_init():
             # Modify state to produce an incompatible shape
-            foo.c = bst.State(jnp.arange(3))  # Original expected shape is (4,)
+            foo.c = brainstate.State(jnp.arange(3))  # Original expected shape is (4,)
 
         faulty_init()

--- a/brainstate/compile/_ad_checkpoint_test.py
+++ b/brainstate/compile/_ad_checkpoint_test.py
@@ -13,34 +13,32 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 import jax
 import jax.numpy as jnp
 from absl.testing import absltest
 
-import brainstate as bst
+import brainstate
 
 
 class TestRemat(absltest.TestCase):
     def test_basic_remat(self):
-        module = bst.compile.remat(bst.nn.Linear(2, 3))
+        module = brainstate.compile.remat(brainstate.nn.Linear(2, 3))
         y = module(jnp.ones((1, 2)))
         assert y.shape == (1, 3)
 
     def test_remat_with_scan(self):
-        class ScanLinear(bst.nn.Module):
+        class ScanLinear(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.linear = bst.nn.Linear(3, 3)
+                self.linear = brainstate.nn.Linear(3, 3)
 
             def __call__(self, x: jax.Array):
-                @bst.compile.remat
+                @brainstate.compile.remat
                 def fun(x: jax.Array, _):
                     x = self.linear(x)
                     return x, None
 
-                return bst.compile.scan(fun, x, None, length=10)[0]
+                return brainstate.compile.scan(fun, x, None, length=10)[0]
 
         m = ScanLinear()
 

--- a/brainstate/compile/_error_if_test.py
+++ b/brainstate/compile/_error_if_test.py
@@ -13,43 +13,40 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 import unittest
 
 import jax
 import jax.numpy as jnp
-import jaxlib.xla_extension
 
-import brainstate as bst
+import brainstate
 
 
 class TestJitError(unittest.TestCase):
     def test1(self):
-        with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
-            bst.compile.jit_error_if(True, 'error')
+        with self.assertRaises(Exception):
+            brainstate.compile.jit_error_if(True, 'error')
 
         def err_f(x):
             raise ValueError(f'error: {x}')
 
-        bst.compile.jit_error_if(False, err_f, 1.)
-        with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
-            bst.compile.jit_error_if(True, err_f, 1.)
+        brainstate.compile.jit_error_if(False, err_f, 1.)
+        with self.assertRaises(Exception):
+            brainstate.compile.jit_error_if(True, err_f, 1.)
 
     def test_vmap(self):
         def f(x):
-            bst.compile.jit_error_if(x, 'error: {x}', x=x)
+            brainstate.compile.jit_error_if(x, 'error: {x}', x=x)
 
         jax.vmap(f)(jnp.array([False, False, False]))
-        with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
+        with self.assertRaises(Exception):
             jax.vmap(f)(jnp.array([True, False, False]))
 
     def test_vmap_vmap(self):
         def f(x):
-            bst.compile.jit_error_if(x, 'error: {x}', x=x)
+            brainstate.compile.jit_error_if(x, 'error: {x}', x=x)
 
         jax.vmap(jax.vmap(f))(jnp.array([[False, False, False],
                                          [False, False, False]]))
-        with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
+        with self.assertRaises(Exception):
             jax.vmap(jax.vmap(f))(jnp.array([[False, False, False],
                                              [True, False, False]]))

--- a/brainstate/compile/_loop_collect_return_test.py
+++ b/brainstate/compile/_loop_collect_return_test.py
@@ -13,20 +13,18 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 import unittest
 
 import jax.numpy as jnp
 import numpy as np
 
-import brainstate as bst
+import brainstate
 
 
 class TestForLoop(unittest.TestCase):
     def test_for_loop(self):
-        a = bst.ShortTermState(0.)
-        b = bst.ShortTermState(0.)
+        a = brainstate.ShortTermState(0.)
+        b = brainstate.ShortTermState(0.)
 
         def f(i):
             a.value += (1 + b.value)
@@ -34,7 +32,7 @@ class TestForLoop(unittest.TestCase):
 
         n_iter = 10
         ops = np.arange(n_iter)
-        r = bst.compile.for_loop(f, ops)
+        r = brainstate.compile.for_loop(f, ops)
 
         print(a)
         print(b)
@@ -42,8 +40,8 @@ class TestForLoop(unittest.TestCase):
         self.assertTrue(jnp.allclose(r, ops + 1))
 
     def test_checkpointed_for_loop(self):
-        a = bst.ShortTermState(0.)
-        b = bst.ShortTermState(0.)
+        a = brainstate.ShortTermState(0.)
+        b = brainstate.ShortTermState(0.)
 
         def f(i):
             a.value += (1 + b.value)
@@ -51,7 +49,7 @@ class TestForLoop(unittest.TestCase):
 
         n_iter = 18
         ops = jnp.arange(n_iter)
-        r = bst.compile.checkpointed_for_loop(f, ops, base=2, pbar=bst.compile.ProgressBar())
+        r = brainstate.compile.checkpointed_for_loop(f, ops, base=2, pbar=brainstate.compile.ProgressBar())
 
         print(a)
         print(b)

--- a/brainstate/compile/_loop_no_collection_test.py
+++ b/brainstate/compile/_loop_no_collection_test.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 from unittest import TestCase
 
-import brainstate as bst
+import brainstate 
 
 
 class TestWhileLoop(TestCase):
     def test1(self):
-        a = bst.State(1.)
-        b = bst.State(20.)
+        a = brainstate.State(1.)
+        b = brainstate.State(20.)
 
         def cond(_):
             return a.value < b.value
@@ -31,13 +30,13 @@ class TestWhileLoop(TestCase):
         def body(_):
             a.value += 1.
 
-        bst.compile.while_loop(cond, body, None)
+        brainstate.compile.while_loop(cond, body, None)
 
         print(a.value, b.value)
 
     def test2(self):
-        a = bst.State(1.)
-        b = bst.State(20.)
+        a = brainstate.State(1.)
+        b = brainstate.State(20.)
 
         def cond(x):
             return a.value < b.value
@@ -46,6 +45,6 @@ class TestWhileLoop(TestCase):
             a.value += x
             return x
 
-        r = bst.compile.while_loop(cond, body, 1.)
+        r = brainstate.compile.while_loop(cond, body, 1.)
 
         print(a.value, b.value, r)

--- a/brainstate/compile/_make_jaxpr.py
+++ b/brainstate/compile/_make_jaxpr.py
@@ -62,8 +62,8 @@ import jax
 from jax._src import source_info_util
 from jax._src.linear_util import annotate
 from jax._src.traceback_util import api_boundary
-from jax.api_util import shaped_abstractify, debug_info
-from jax.extend.linear_util import transformation_with_aux, wrap_init
+from jax.api_util import shaped_abstractify
+from jax.extend.linear_util import transformation_with_aux
 from jax.interpreters import partial_eval as pe
 
 from brainstate._compatible_import import (
@@ -73,6 +73,7 @@ from brainstate._compatible_import import (
     safe_zip,
     unzip2,
     wraps,
+    wrap_init,
 )
 from brainstate._state import State, StateTraceStack
 from brainstate._utils import set_module_as
@@ -743,7 +744,7 @@ def _make_jaxpr(
     @wraps(fun)
     @api_boundary
     def make_jaxpr_f(*args, **kwargs):
-        f = wrap_init(fun, debug_info=debug_info('make_jaxpr', fun, args, kwargs))
+        f = wrap_init(fun, (), {}, 'brainstate.compile.make_jaxpr')
         if static_argnums:
             dyn_argnums = [i for i in range(len(args)) if i not in static_argnums]
             f, args = jax.api_util.argnums_partial(f, dyn_argnums, args)

--- a/brainstate/compile/_make_jaxpr_test.py
+++ b/brainstate/compile/_make_jaxpr_test.py
@@ -21,7 +21,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-import brainstate as bst
+import brainstate
 from brainstate._compatible_import import jaxpr_as_fun
 
 
@@ -29,10 +29,10 @@ class TestMakeJaxpr(unittest.TestCase):
     def test_compar_jax_make_jaxpr(self):
         def func4(arg):  # Arg is a pair
             temp = arg[0] + jnp.sin(arg[1]) * 3.
-            c = bst.random.rand_like(arg[0])
+            c = brainstate.random.rand_like(arg[0])
             return jnp.sum(temp + c)
 
-        key = bst.random.DEFAULT.value
+        key = brainstate.random.DEFAULT.value
         jaxpr = jax.make_jaxpr(func4)((jnp.zeros(8), jnp.ones(8)))
         print(jaxpr)
         self.assertTrue(len(jaxpr.in_avals) == 2)
@@ -40,66 +40,66 @@ class TestMakeJaxpr(unittest.TestCase):
         self.assertTrue(len(jaxpr.out_avals) == 1)
         self.assertTrue(jnp.allclose(jaxpr.consts[0], key))
 
-        bst.random.seed(1)
-        print(bst.random.DEFAULT.value)
+        brainstate.random.seed(1)
+        print(brainstate.random.DEFAULT.value)
 
-        jaxpr2, states = bst.compile.make_jaxpr(func4)((jnp.zeros(8), jnp.ones(8)))
+        jaxpr2, states = brainstate.compile.make_jaxpr(func4)((jnp.zeros(8), jnp.ones(8)))
         print(jaxpr2)
         self.assertTrue(len(jaxpr2.in_avals) == 3)
         self.assertTrue(len(jaxpr2.out_avals) == 2)
         self.assertTrue(len(jaxpr2.consts) == 0)
-        print(bst.random.DEFAULT.value)
+        print(brainstate.random.DEFAULT.value)
 
     def test_StatefulFunction_1(self):
         def func4(arg):  # Arg is a pair
             temp = arg[0] + jnp.sin(arg[1]) * 3.
-            c = bst.random.rand_like(arg[0])
+            c = brainstate.random.rand_like(arg[0])
             return jnp.sum(temp + c)
 
-        fun = bst.compile.StatefulFunction(func4).make_jaxpr((jnp.zeros(8), jnp.ones(8)))
+        fun = brainstate.compile.StatefulFunction(func4).make_jaxpr((jnp.zeros(8), jnp.ones(8)))
         print(fun.get_states())
         print(fun.get_jaxpr())
 
     def test_StatefulFunction_2(self):
-        st1 = bst.State(jnp.ones(10))
+        st1 = brainstate.State(jnp.ones(10))
 
         def f1(x):
             st1.value = x + st1.value
 
         def f2(x):
-            jaxpr = bst.compile.make_jaxpr(f1)(x)
+            jaxpr = brainstate.compile.make_jaxpr(f1)(x)
             c = 1. + x
             return c
 
         def f3(x):
-            jaxpr = bst.compile.make_jaxpr(f1)(x)
+            jaxpr = brainstate.compile.make_jaxpr(f1)(x)
             c = 1.
             return c
 
         print()
-        jaxpr = bst.compile.make_jaxpr(f1)(jnp.zeros(1))
+        jaxpr = brainstate.compile.make_jaxpr(f1)(jnp.zeros(1))
         print(jaxpr)
         jaxpr = jax.make_jaxpr(f2)(jnp.zeros(1))
         print(jaxpr)
         jaxpr = jax.make_jaxpr(f3)(jnp.zeros(1))
         print(jaxpr)
-        jaxpr, _ = bst.compile.make_jaxpr(f3)(jnp.zeros(1))
+        jaxpr, _ = brainstate.compile.make_jaxpr(f3)(jnp.zeros(1))
         print(jaxpr)
         self.assertTrue(jnp.allclose(jaxpr_as_fun(jaxpr)(jnp.zeros(1), st1.value)[0],
                                      f3(jnp.zeros(1))))
 
     def test_compar_jax_make_jaxpr2(self):
-        st1 = bst.State(jnp.ones(10))
+        st1 = brainstate.State(jnp.ones(10))
 
         def fa(x):
             st1.value = x + st1.value
 
         def ffa(x):
-            jaxpr, states = bst.compile.make_jaxpr(fa)(x)
+            jaxpr, states = brainstate.compile.make_jaxpr(fa)(x)
             c = 1. + x
             return c
 
-        jaxpr, states = bst.compile.make_jaxpr(ffa)(jnp.zeros(1))
+        jaxpr, states = brainstate.compile.make_jaxpr(ffa)(jnp.zeros(1))
         print()
         print(jaxpr)
         print(states)
@@ -112,7 +112,7 @@ class TestMakeJaxpr(unittest.TestCase):
         def fa(x):
             return 1.
 
-        jaxpr, states = bst.compile.make_jaxpr(fa)(jnp.zeros(1))
+        jaxpr, states = brainstate.compile.make_jaxpr(fa)(jnp.zeros(1))
         print()
         print(jaxpr)
         print(states)
@@ -125,9 +125,9 @@ class TestMakeJaxpr(unittest.TestCase):
 def test_return_states():
     import jax.numpy
 
-    a = bst.State(jax.numpy.ones(3))
+    a = brainstate.State(jax.numpy.ones(3))
 
-    @bst.compile.jit
+    @brainstate.compile.jit
     def f():
         return a
 

--- a/brainstate/functional/_activations_test.py
+++ b/brainstate/functional/_activations_test.py
@@ -25,48 +25,48 @@ from absl.testing import parameterized
 from jax._src import test_util as jtu
 from jax.test_util import check_grads
 
-import brainstate as bst
+import brainstate
 
 
 class NNFunctionsTest(jtu.JaxTestCase):
     @jtu.skip_on_flag("jax_skip_slow_tests", True)
     def testSoftplusGrad(self):
-        check_grads(bst.functional.softplus, (1e-8,), order=4, )
+        check_grads(brainstate.functional.softplus, (1e-8,), order=4, )
 
     def testSoftplusGradZero(self):
-        check_grads(bst.functional.softplus, (0.,), order=1)
+        check_grads(brainstate.functional.softplus, (0.,), order=1)
 
     def testSoftplusGradInf(self):
-        self.assertAllClose(1., jax.grad(bst.functional.softplus)(float('inf')))
+        self.assertAllClose(1., jax.grad(brainstate.functional.softplus)(float('inf')))
 
     def testSoftplusGradNegInf(self):
-        check_grads(bst.functional.softplus, (-float('inf'),), order=1)
+        check_grads(brainstate.functional.softplus, (-float('inf'),), order=1)
 
     def testSoftplusGradNan(self):
-        check_grads(bst.functional.softplus, (float('nan'),), order=1)
+        check_grads(brainstate.functional.softplus, (float('nan'),), order=1)
 
     @parameterized.parameters([int, float] + jtu.dtypes.floating + jtu.dtypes.integer)
     def testSoftplusZero(self, dtype):
-        self.assertEqual(jnp.log(dtype(2)), bst.functional.softplus(dtype(0)))
+        self.assertEqual(jnp.log(dtype(2)), brainstate.functional.softplus(dtype(0)))
 
     def testSparseplusGradZero(self):
-        check_grads(bst.functional.sparse_plus, (-2.,), order=1)
+        check_grads(brainstate.functional.sparse_plus, (-2.,), order=1)
 
     def testSparseplusGrad(self):
-        check_grads(bst.functional.sparse_plus, (0.,), order=1)
+        check_grads(brainstate.functional.sparse_plus, (0.,), order=1)
 
     def testSparseplusAndSparseSigmoid(self):
         self.assertAllClose(
-            jax.grad(bst.functional.sparse_plus)(0.),
-            bst.functional.sparse_sigmoid(0.),
+            jax.grad(brainstate.functional.sparse_plus)(0.),
+            brainstate.functional.sparse_sigmoid(0.),
             check_dtypes=False)
         self.assertAllClose(
-            jax.grad(bst.functional.sparse_plus)(2.),
-            bst.functional.sparse_sigmoid(2.),
+            jax.grad(brainstate.functional.sparse_plus)(2.),
+            brainstate.functional.sparse_sigmoid(2.),
             check_dtypes=False)
         self.assertAllClose(
-            jax.grad(bst.functional.sparse_plus)(-2.),
-            bst.functional.sparse_sigmoid(-2.),
+            jax.grad(brainstate.functional.sparse_plus)(-2.),
+            brainstate.functional.sparse_sigmoid(-2.),
             check_dtypes=False)
 
     #   def testSquareplusGrad(self):
@@ -107,55 +107,55 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
     @parameterized.parameters([float] + jtu.dtypes.floating)
     def testMishZero(self, dtype):
-        self.assertEqual(dtype(0), bst.functional.mish(dtype(0)))
+        self.assertEqual(dtype(0), brainstate.functional.mish(dtype(0)))
 
     def testReluGrad(self):
         rtol = None
-        check_grads(bst.functional.relu, (1.,), order=3, rtol=rtol)
-        check_grads(bst.functional.relu, (-1.,), order=3, rtol=rtol)
-        jaxpr = jax.make_jaxpr(jax.grad(bst.functional.relu))(0.)
+        check_grads(brainstate.functional.relu, (1.,), order=3, rtol=rtol)
+        check_grads(brainstate.functional.relu, (-1.,), order=3, rtol=rtol)
+        jaxpr = jax.make_jaxpr(jax.grad(brainstate.functional.relu))(0.)
         self.assertGreaterEqual(len(jaxpr.jaxpr.eqns), 2)
 
     def testRelu6Grad(self):
         rtol = None
-        check_grads(bst.functional.relu6, (1.,), order=3, rtol=rtol)
-        check_grads(bst.functional.relu6, (-1.,), order=3, rtol=rtol)
-        self.assertAllClose(jax.grad(bst.functional.relu6)(0.), 0., check_dtypes=False)
-        self.assertAllClose(jax.grad(bst.functional.relu6)(6.), 0., check_dtypes=False)
+        check_grads(brainstate.functional.relu6, (1.,), order=3, rtol=rtol)
+        check_grads(brainstate.functional.relu6, (-1.,), order=3, rtol=rtol)
+        self.assertAllClose(jax.grad(brainstate.functional.relu6)(0.), 0., check_dtypes=False)
+        self.assertAllClose(jax.grad(brainstate.functional.relu6)(6.), 0., check_dtypes=False)
 
     def testSoftplusValue(self):
-        val = bst.functional.softplus(89.)
+        val = brainstate.functional.softplus(89.)
         self.assertAllClose(val, 89., check_dtypes=False)
 
     def testSparseplusValue(self):
-        val = bst.functional.sparse_plus(89.)
+        val = brainstate.functional.sparse_plus(89.)
         self.assertAllClose(val, 89., check_dtypes=False)
 
     def testSparsesigmoidValue(self):
-        self.assertAllClose(bst.functional.sparse_sigmoid(-2.), 0., check_dtypes=False)
-        self.assertAllClose(bst.functional.sparse_sigmoid(2.), 1., check_dtypes=False)
-        self.assertAllClose(bst.functional.sparse_sigmoid(0.), .5, check_dtypes=False)
+        self.assertAllClose(brainstate.functional.sparse_sigmoid(-2.), 0., check_dtypes=False)
+        self.assertAllClose(brainstate.functional.sparse_sigmoid(2.), 1., check_dtypes=False)
+        self.assertAllClose(brainstate.functional.sparse_sigmoid(0.), .5, check_dtypes=False)
 
     #   def testSquareplusValue(self):
     #     val = bst.functional.squareplus(1e3)
     #     self.assertAllClose(val, 1e3, check_dtypes=False, atol=1e-3)
 
     def testMishValue(self):
-        val = bst.functional.mish(1e3)
+        val = brainstate.functional.mish(1e3)
         self.assertAllClose(val, 1e3, check_dtypes=False, atol=1e-3)
 
     def testEluValue(self):
-        val = bst.functional.elu(1e4)
+        val = brainstate.functional.elu(1e4)
         self.assertAllClose(val, 1e4, check_dtypes=False)
 
     def testGluValue(self):
-        val = bst.functional.glu(jnp.array([1.0, 0.0]), axis=0)
+        val = brainstate.functional.glu(jnp.array([1.0, 0.0]), axis=0)
         self.assertAllClose(val, jnp.array([0.5]))
 
     @parameterized.parameters(False, True)
     def testGeluIntType(self, approximate):
-        val_float = bst.functional.gelu(jnp.array(-1.0), approximate=approximate)
-        val_int = bst.functional.gelu(jnp.array(-1), approximate=approximate)
+        val_float = brainstate.functional.gelu(jnp.array(-1.0), approximate=approximate)
+        val_int = brainstate.functional.gelu(jnp.array(-1), approximate=approximate)
         self.assertAllClose(val_float, val_int)
 
     @parameterized.parameters(False, True)
@@ -166,19 +166,19 @@ class NNFunctionsTest(jtu.JaxTestCase):
         rng = jtu.rand_default(self.rng())
         args_maker = lambda: [rng((4, 5, 6), jnp.float32)]
         self._CheckAgainstNumpy(
-            gelu_reference, partial(bst.functional.gelu, approximate=approximate), args_maker,
+            gelu_reference, partial(brainstate.functional.gelu, approximate=approximate), args_maker,
             check_dtypes=False, tol=1e-3 if approximate else None)
 
     @parameterized.parameters(*itertools.product(
         (jnp.float32, jnp.bfloat16, jnp.float16),
-        (partial(bst.functional.gelu, approximate=False),
-         partial(bst.functional.gelu, approximate=True),
-         bst.functional.relu,
-         bst.functional.softplus,
-         bst.functional.sparse_plus,
-         bst.functional.sigmoid,
+        (partial(brainstate.functional.gelu, approximate=False),
+         partial(brainstate.functional.gelu, approximate=True),
+         brainstate.functional.relu,
+         brainstate.functional.softplus,
+         brainstate.functional.sparse_plus,
+         brainstate.functional.sigmoid,
          #  bst.functional.squareplus,
-         bst.functional.mish)))
+         brainstate.functional.mish)))
     def testDtypeMatchesInput(self, dtype, fn):
         x = jnp.zeros((), dtype=dtype)
         out = fn(x)
@@ -187,26 +187,26 @@ class NNFunctionsTest(jtu.JaxTestCase):
     def testEluMemory(self):
         # see https://github.com/google/jax/pull/1640
         with jax.enable_checks(False):  # With checks we materialize the array
-            jax.make_jaxpr(lambda: bst.functional.elu(jnp.ones((10 ** 12,))))  # don't oom
+            jax.make_jaxpr(lambda: brainstate.functional.elu(jnp.ones((10 ** 12,))))  # don't oom
 
     def testHardTanhMemory(self):
         # see https://github.com/google/jax/pull/1640
         with jax.enable_checks(False):  # With checks we materialize the array
-            jax.make_jaxpr(lambda: bst.functional.hard_tanh(jnp.ones((10 ** 12,))))  # don't oom
+            jax.make_jaxpr(lambda: brainstate.functional.hard_tanh(jnp.ones((10 ** 12,))))  # don't oom
 
-    @parameterized.parameters([bst.functional.softmax, bst.functional.log_softmax])
+    @parameterized.parameters([brainstate.functional.softmax, brainstate.functional.log_softmax])
     def testSoftmaxEmptyArray(self, fn):
         x = jnp.array([], dtype=float)
         self.assertArraysEqual(fn(x), x)
 
-    @parameterized.parameters([bst.functional.softmax, bst.functional.log_softmax])
+    @parameterized.parameters([brainstate.functional.softmax, brainstate.functional.log_softmax])
     def testSoftmaxEmptyMask(self, fn):
         x = jnp.array([5.5, 1.3, -4.2, 0.9])
         m = jnp.zeros_like(x, dtype=bool)
-        expected = jnp.full_like(x, 0.0 if fn is bst.functional.softmax else -jnp.inf)
+        expected = jnp.full_like(x, 0.0 if fn is brainstate.functional.softmax else -jnp.inf)
         self.assertArraysEqual(fn(x, where=m), expected)
 
-    @parameterized.parameters([bst.functional.softmax, bst.functional.log_softmax])
+    @parameterized.parameters([brainstate.functional.softmax, brainstate.functional.log_softmax])
     def testSoftmaxWhereMask(self, fn):
         x = jnp.array([5.5, 1.3, -4.2, 0.9])
         m = jnp.array([True, False, True, True])
@@ -214,10 +214,10 @@ class NNFunctionsTest(jtu.JaxTestCase):
         out = fn(x, where=m)
         self.assertAllClose(out[m], fn(x[m]))
 
-        probs = out if fn is bst.functional.softmax else jnp.exp(out)
+        probs = out if fn is brainstate.functional.softmax else jnp.exp(out)
         self.assertAllClose(probs.sum(), 1.0)
 
-    @parameterized.parameters([bst.functional.softmax, bst.functional.log_softmax])
+    @parameterized.parameters([brainstate.functional.softmax, brainstate.functional.log_softmax])
     def testSoftmaxWhereGrad(self, fn):
         # regression test for https://github.com/google/jax/issues/19490
         x = jnp.array([36., 10000.])
@@ -229,46 +229,46 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
     def testSoftmaxGrad(self):
         x = jnp.array([5.5, 1.3, -4.2, 0.9])
-        jtu.check_grads(bst.functional.softmax, (x,), order=2, atol=5e-3)
+        jtu.check_grads(brainstate.functional.softmax, (x,), order=2, atol=5e-3)
 
     def testStandardizeWhereMask(self):
         x = jnp.array([5.5, 1.3, -4.2, 0.9])
         m = jnp.array([True, False, True, True])
         x_filtered = jnp.take(x, jnp.array([0, 2, 3]))
 
-        out_masked = jnp.take(bst.functional.standardize(x, where=m), jnp.array([0, 2, 3]))
-        out_filtered = bst.functional.standardize(x_filtered)
+        out_masked = jnp.take(brainstate.functional.standardize(x, where=m), jnp.array([0, 2, 3]))
+        out_filtered = brainstate.functional.standardize(x_filtered)
 
         self.assertAllClose(out_masked, out_filtered)
 
     def testOneHot(self):
-        actual = bst.functional.one_hot(jnp.array([0, 1, 2]), 3)
+        actual = brainstate.functional.one_hot(jnp.array([0, 1, 2]), 3)
         expected = jnp.array([[1., 0., 0.],
                               [0., 1., 0.],
                               [0., 0., 1.]])
         self.assertAllClose(actual, expected, check_dtypes=False)
 
-        actual = bst.functional.one_hot(jnp.array([1, 2, 0]), 3)
+        actual = brainstate.functional.one_hot(jnp.array([1, 2, 0]), 3)
         expected = jnp.array([[0., 1., 0.],
                               [0., 0., 1.],
                               [1., 0., 0.]])
         self.assertAllClose(actual, expected, check_dtypes=False)
 
     def testOneHotOutOfBound(self):
-        actual = bst.functional.one_hot(jnp.array([-1, 3]), 3)
+        actual = brainstate.functional.one_hot(jnp.array([-1, 3]), 3)
         expected = jnp.array([[0., 0., 0.],
                               [0., 0., 0.]])
         self.assertAllClose(actual, expected, check_dtypes=False)
 
     def testOneHotNonArrayInput(self):
-        actual = bst.functional.one_hot([0, 1, 2], 3)
+        actual = brainstate.functional.one_hot([0, 1, 2], 3)
         expected = jnp.array([[1., 0., 0.],
                               [0., 1., 0.],
                               [0., 0., 1.]])
         self.assertAllClose(actual, expected, check_dtypes=False)
 
     def testOneHotCustomDtype(self):
-        actual = bst.functional.one_hot(jnp.array([0, 1, 2]), 3, dtype=jnp.bool_)
+        actual = brainstate.functional.one_hot(jnp.array([0, 1, 2]), 3, dtype=jnp.bool_)
         expected = jnp.array([[True, False, False],
                               [False, True, False],
                               [False, False, True]])
@@ -279,14 +279,14 @@ class NNFunctionsTest(jtu.JaxTestCase):
                               [0., 0., 1.],
                               [1., 0., 0.]]).T
 
-        actual = bst.functional.one_hot(jnp.array([1, 2, 0]), 3, axis=0)
+        actual = brainstate.functional.one_hot(jnp.array([1, 2, 0]), 3, axis=0)
         self.assertAllClose(actual, expected, check_dtypes=False)
 
-        actual = bst.functional.one_hot(jnp.array([1, 2, 0]), 3, axis=-2)
+        actual = brainstate.functional.one_hot(jnp.array([1, 2, 0]), 3, axis=-2)
         self.assertAllClose(actual, expected, check_dtypes=False)
 
     def testTanhExists(self):
-        print(bst.functional.tanh)  # doesn't crash
+        print(brainstate.functional.tanh)  # doesn't crash
 
     def testCustomJVPLeak(self):
         # https://github.com/google/jax/issues/8171
@@ -295,7 +295,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
             a = jnp.array(1.)
 
             def f(hx, _):
-                hx = bst.functional.sigmoid(hx + a)
+                hx = brainstate.functional.sigmoid(hx + a)
                 return hx, None
 
             hx = jnp.array(0.)

--- a/brainstate/graph/_graph_node_test.py
+++ b/brainstate/graph/_graph_node_test.py
@@ -13,63 +13,61 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 import unittest
 
-import brainstate as bst
+import brainstate
 
 
 class TestSequential(unittest.TestCase):
     def test1(self):
-        s = bst.graph.Sequential(bst.nn.Linear(1, 2),
-                                 bst.nn.Linear(2, 3))
-        graphdef, states = bst.graph.treefy_split(s)
+        s = brainstate.graph.Sequential(brainstate.nn.Linear(1, 2),
+                                        brainstate.nn.Linear(2, 3))
+        graphdef, states = brainstate.graph.treefy_split(s)
         print(states)
         self.assertTrue(len(states.to_flat()) == 2)
 
 
 class TestStateRetrieve(unittest.TestCase):
     def test_list_of_states_1(self):
-        class Model(bst.graph.Node):
+        class Model(brainstate.graph.Node):
             def __init__(self):
                 self.a = [1, 2, 3]
-                self.b = [bst.State(1), bst.State(2), bst.State(3)]
+                self.b = [brainstate.State(1), brainstate.State(2), brainstate.State(3)]
 
         m = Model()
-        graphdef, states = bst.graph.treefy_split(m)
+        graphdef, states = brainstate.graph.treefy_split(m)
         print(states.to_flat())
         self.assertTrue(len(states.to_flat()) == 3)
 
     def test_list_of_states_2(self):
-        class Model(bst.graph.Node):
+        class Model(brainstate.graph.Node):
             def __init__(self):
                 self.a = [1, 2, 3]
-                self.b = [bst.State(1), [bst.State(2), bst.State(3)]]
+                self.b = [brainstate.State(1), [brainstate.State(2), brainstate.State(3)]]
 
         m = Model()
-        graphdef, states = bst.graph.treefy_split(m)
+        graphdef, states = brainstate.graph.treefy_split(m)
         print(states.to_flat())
         self.assertTrue(len(states.to_flat()) == 3)
 
     def test_list_of_node_1(self):
-        class Model(bst.graph.Node):
+        class Model(brainstate.graph.Node):
             def __init__(self):
                 self.a = [1, 2, 3]
-                self.b = [bst.nn.Linear(1, 2), bst.nn.Linear(2, 3)]
+                self.b = [brainstate.nn.Linear(1, 2), brainstate.nn.Linear(2, 3)]
 
         m = Model()
-        graphdef, states = bst.graph.treefy_split(m)
+        graphdef, states = brainstate.graph.treefy_split(m)
         print(states.to_flat())
         self.assertTrue(len(states.to_flat()) == 2)
 
     def test_list_of_node_2(self):
-        class Model(bst.graph.Node):
+        class Model(brainstate.graph.Node):
             def __init__(self):
                 self.a = [1, 2, 3]
-                self.b = [bst.nn.Linear(1, 2), [bst.nn.Linear(2, 3)], (bst.nn.Linear(3, 4), bst.nn.Linear(4, 5))]
+                self.b = [brainstate.nn.Linear(1, 2), [brainstate.nn.Linear(2, 3)], (brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5))]
 
         m = Model()
-        graphdef, states = bst.graph.treefy_split(m)
+        graphdef, states = brainstate.graph.treefy_split(m)
         print(states.to_flat())
         self.assertTrue(len(states.to_flat()) == 4)

--- a/brainstate/graph/_graph_operation_test.py
+++ b/brainstate/graph/_graph_operation_test.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 import unittest
 from collections.abc import Callable
 from threading import Thread
@@ -23,67 +21,67 @@ import jax
 import jax.numpy as jnp
 from absl.testing import absltest, parameterized
 
-import brainstate as bst
+import brainstate
 
 
 class TestIter(unittest.TestCase):
     def test1(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = bst.nn.Linear(1, 2)
-                self.b = bst.nn.Linear(2, 3)
-                self.c = [bst.nn.Linear(3, 4), bst.nn.Linear(4, 5)]
-                self.d = {'x': bst.nn.Linear(5, 6), 'y': bst.nn.Linear(6, 7)}
-                self.b.a = bst.nn.LIF(2)
+                self.a = brainstate.nn.Linear(1, 2)
+                self.b = brainstate.nn.Linear(2, 3)
+                self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
+                self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
+                self.b.a = brainstate.nn.LIF(2)
 
-        for path, node in bst.graph.iter_leaf(Model()):
+        for path, node in brainstate.graph.iter_leaf(Model()):
             print(path, node)
-        for path, node in bst.graph.iter_node(Model()):
+        for path, node in brainstate.graph.iter_node(Model()):
             print(path, node)
-        for path, node in bst.graph.iter_node(Model(), allowed_hierarchy=(1, 1)):
+        for path, node in brainstate.graph.iter_node(Model(), allowed_hierarchy=(1, 1)):
             print(path, node)
-        for path, node in bst.graph.iter_node(Model(), allowed_hierarchy=(2, 2)):
+        for path, node in brainstate.graph.iter_node(Model(), allowed_hierarchy=(2, 2)):
             print(path, node)
 
     def test_iter_leaf_v1(self):
-        class Linear(bst.nn.Module):
+        class Linear(brainstate.nn.Module):
             def __init__(self, din, dout):
                 super().__init__()
-                self.weight = bst.ParamState(bst.random.randn(din, dout))
-                self.bias = bst.ParamState(bst.random.randn(dout))
+                self.weight = brainstate.ParamState(brainstate.random.randn(din, dout))
+                self.bias = brainstate.ParamState(brainstate.random.randn(dout))
                 self.a = 1
 
         module = Linear(3, 4)
         graph = [module, module]
 
         num = 0
-        for path, value in bst.graph.iter_leaf(graph):
+        for path, value in brainstate.graph.iter_leaf(graph):
             print(path, type(value).__name__)
             num += 1
 
         assert num == 3
 
     def test_iter_node_v1(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = bst.nn.Linear(1, 2)
-                self.b = bst.nn.Linear(2, 3)
-                self.c = [bst.nn.Linear(3, 4), bst.nn.Linear(4, 5)]
-                self.d = {'x': bst.nn.Linear(5, 6), 'y': bst.nn.Linear(6, 7)}
-                self.b.a = bst.nn.LIF(2)
+                self.a = brainstate.nn.Linear(1, 2)
+                self.b = brainstate.nn.Linear(2, 3)
+                self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
+                self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
+                self.b.a = brainstate.nn.LIF(2)
 
         model = Model()
 
         num = 0
-        for path, node in bst.graph.iter_node([model, model]):
+        for path, node in brainstate.graph.iter_node([model, model]):
             print(path, node.__class__.__name__)
             num += 1
         assert num == 8
 
 
-class List(bst.nn.Module):
+class List(brainstate.nn.Module):
     def __init__(self, items):
         super().__init__()
         self.items = list(items)
@@ -95,7 +93,7 @@ class List(bst.nn.Module):
         self.items[idx] = value
 
 
-class Dict(bst.nn.Module):
+class Dict(brainstate.nn.Module):
     def __init__(self, *args, **kwargs):
         super().__init__()
         self.items = dict(*args, **kwargs)
@@ -107,12 +105,12 @@ class Dict(bst.nn.Module):
         self.items[key] = value
 
 
-class StatefulLinear(bst.nn.Module):
+class StatefulLinear(brainstate.nn.Module):
     def __init__(self, din, dout):
         super().__init__()
-        self.w = bst.ParamState(bst.random.rand(din, dout))
-        self.b = bst.ParamState(jnp.zeros((dout,)))
-        self.count = bst.State(jnp.array(0, dtype=jnp.uint32))
+        self.w = brainstate.ParamState(brainstate.random.rand(din, dout))
+        self.b = brainstate.ParamState(jnp.zeros((dout,)))
+        self.count = brainstate.State(jnp.array(0, dtype=jnp.uint32))
 
     def increment(self):
         self.count.value += 1
@@ -124,44 +122,44 @@ class StatefulLinear(bst.nn.Module):
 
 class TestGraphUtils(absltest.TestCase):
     def test_flatten_treey_state(self):
-        a = {'a': 1, 'b': bst.ParamState(2)}
-        g = [a, 3, a, bst.ParamState(4)]
+        a = {'a': 1, 'b': brainstate.ParamState(2)}
+        g = [a, 3, a, brainstate.ParamState(4)]
 
-        refmap = bst.graph.RefMap()
-        graphdef, states = bst.graph.flatten(g, ref_index=refmap, treefy_state=True)
+        refmap = brainstate.graph.RefMap()
+        graphdef, states = brainstate.graph.flatten(g, ref_index=refmap, treefy_state=True)
 
         states[0]['b'].value = 2
         states[3].value = 4
 
-        assert isinstance(states[0]['b'], bst.TreefyState)
-        assert isinstance(states[3], bst.TreefyState)
-        assert isinstance(states, bst.util.NestedDict)
+        assert isinstance(states[0]['b'], brainstate.TreefyState)
+        assert isinstance(states[3], brainstate.TreefyState)
+        assert isinstance(states, brainstate.util.NestedDict)
         assert len(refmap) == 2
         assert a['b'] in refmap
         assert g[3] in refmap
 
     def test_flatten(self):
-        a = {'a': 1, 'b': bst.ParamState(2)}
-        g = [a, 3, a, bst.ParamState(4)]
+        a = {'a': 1, 'b': brainstate.ParamState(2)}
+        g = [a, 3, a, brainstate.ParamState(4)]
 
-        refmap = bst.graph.RefMap()
-        graphdef, states = bst.graph.flatten(g, ref_index=refmap, treefy_state=False)
+        refmap = brainstate.graph.RefMap()
+        graphdef, states = brainstate.graph.flatten(g, ref_index=refmap, treefy_state=False)
 
         states[0]['b'].value = 2
         states[3].value = 4
 
-        assert isinstance(states[0]['b'], bst.State)
-        assert isinstance(states[3], bst.State)
+        assert isinstance(states[0]['b'], brainstate.State)
+        assert isinstance(states[3], brainstate.State)
         assert len(refmap) == 2
         assert a['b'] in refmap
         assert g[3] in refmap
 
     def test_unflatten_treey_state(self):
-        a = bst.graph.Dict(a=1, b=bst.ParamState(2))
-        g1 = bst.graph.List([a, 3, a, bst.ParamState(4)])
+        a = brainstate.graph.Dict(a=1, b=brainstate.ParamState(2))
+        g1 = brainstate.graph.List([a, 3, a, brainstate.ParamState(4)])
 
-        graphdef, references = bst.graph.flatten(g1, treefy_state=True)
-        g = bst.graph.unflatten(graphdef, references)
+        graphdef, references = brainstate.graph.flatten(g1, treefy_state=True)
+        g = brainstate.graph.unflatten(graphdef, references)
 
         print(graphdef)
         print(references)
@@ -170,11 +168,11 @@ class TestGraphUtils(absltest.TestCase):
         assert g1[0]['b'] is not g[0]['b']
 
     def test_unflatten(self):
-        a = bst.graph.Dict(a=1, b=bst.ParamState(2))
-        g1 = bst.graph.List([a, 3, a, bst.ParamState(4)])
+        a = brainstate.graph.Dict(a=1, b=brainstate.ParamState(2))
+        g1 = brainstate.graph.List([a, 3, a, brainstate.ParamState(4)])
 
-        graphdef, references = bst.graph.flatten(g1, treefy_state=False)
-        g = bst.graph.unflatten(graphdef, references)
+        graphdef, references = brainstate.graph.flatten(g1, treefy_state=False)
+        g = brainstate.graph.unflatten(graphdef, references)
 
         print(graphdef)
         print(references)
@@ -183,29 +181,29 @@ class TestGraphUtils(absltest.TestCase):
         assert g1[0]['b'] is g[0]['b']
 
     def test_unflatten_pytree(self):
-        a = {'a': 1, 'b': bst.ParamState(2)}
-        g = [a, 3, a, bst.ParamState(4)]
+        a = {'a': 1, 'b': brainstate.ParamState(2)}
+        g = [a, 3, a, brainstate.ParamState(4)]
 
-        graphdef, references = bst.graph.treefy_split(g)
-        g = bst.graph.treefy_merge(graphdef, references)
+        graphdef, references = brainstate.graph.treefy_split(g)
+        g = brainstate.graph.treefy_merge(graphdef, references)
 
         assert g[0] is not g[2]
 
     def test_unflatten_empty(self):
-        a = Dict({'a': 1, 'b': bst.ParamState(2)})
-        g = List([a, 3, a, bst.ParamState(4)])
+        a = Dict({'a': 1, 'b': brainstate.ParamState(2)})
+        g = List([a, 3, a, brainstate.ParamState(4)])
 
-        graphdef, references = bst.graph.treefy_split(g)
+        graphdef, references = brainstate.graph.treefy_split(g)
 
         with self.assertRaisesRegex(ValueError, 'Expected key'):
-            bst.graph.unflatten(graphdef, bst.util.NestedDict({}))
+            brainstate.graph.unflatten(graphdef, brainstate.util.NestedDict({}))
 
     def test_module_list(self):
         ls = [
-            bst.nn.Linear(2, 2),
-            bst.nn.BatchNorm1d([10, 2]),
+            brainstate.nn.Linear(2, 2),
+            brainstate.nn.BatchNorm1d([10, 2]),
         ]
-        graphdef, statetree = bst.graph.treefy_split(ls)
+        graphdef, statetree = brainstate.graph.treefy_split(ls)
 
         assert statetree[0]['weight'].value['weight'].shape == (2, 2)
         assert statetree[0]['weight'].value['bias'].shape == (2,)
@@ -215,47 +213,47 @@ class TestGraphUtils(absltest.TestCase):
         assert statetree[1]['running_var'].value.shape == (1, 2)
 
     def test_shared_variables(self):
-        v = bst.ParamState(1)
+        v = brainstate.ParamState(1)
         g = [v, v]
 
-        graphdef, statetree = bst.graph.treefy_split(g)
+        graphdef, statetree = brainstate.graph.treefy_split(g)
         assert len(statetree.to_flat()) == 1
 
-        g2 = bst.graph.treefy_merge(graphdef, statetree)
+        g2 = brainstate.graph.treefy_merge(graphdef, statetree)
         assert g2[0] is g2[1]
 
     def test_tied_weights(self):
-        class Foo(bst.nn.Module):
+        class Foo(brainstate.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.bar = bst.nn.Linear(2, 2)
-                self.baz = bst.nn.Linear(2, 2)
+                self.bar = brainstate.nn.Linear(2, 2)
+                self.baz = brainstate.nn.Linear(2, 2)
 
                 # tie the weights
                 self.baz.weight = self.bar.weight
 
         node = Foo()
-        graphdef, state = bst.graph.treefy_split(node)
+        graphdef, state = brainstate.graph.treefy_split(node)
 
         assert len(state.to_flat()) == 1
 
-        node2 = bst.graph.treefy_merge(graphdef, state)
+        node2 = brainstate.graph.treefy_merge(graphdef, state)
 
         assert node2.bar.weight is node2.baz.weight
 
     def test_tied_weights_example(self):
-        class LinearTranspose(bst.nn.Module):
+        class LinearTranspose(brainstate.nn.Module):
             def __init__(self, dout: int, din: int, ) -> None:
                 super().__init__()
-                self.kernel = bst.ParamState(bst.init.LecunNormal()((dout, din)))
+                self.kernel = brainstate.ParamState(brainstate.init.LecunNormal()((dout, din)))
 
             def __call__(self, x):
                 return x @ self.kernel.value.T
 
-        class Encoder(bst.nn.Module):
+        class Encoder(brainstate.nn.Module):
             def __init__(self, ) -> None:
                 super().__init__()
-                self.embed = bst.nn.Embedding(10, 2)
+                self.embed = brainstate.nn.Embedding(10, 2)
                 self.linear_out = LinearTranspose(10, 2)
 
                 # tie the weights
@@ -266,7 +264,7 @@ class TestGraphUtils(absltest.TestCase):
                 return self.linear_out(x)
 
         model = Encoder()
-        graphdef, state = bst.graph.treefy_split(model)
+        graphdef, state = brainstate.graph.treefy_split(model)
 
         assert len(state.to_flat()) == 1
 
@@ -276,49 +274,49 @@ class TestGraphUtils(absltest.TestCase):
         assert y.shape == (2, 10)
 
     def test_state_variables_not_shared_with_graph(self):
-        class Foo(bst.graph.Node):
+        class Foo(brainstate.graph.Node):
             def __init__(self):
-                self.a = bst.ParamState(1)
+                self.a = brainstate.ParamState(1)
 
         m = Foo()
-        graphdef, statetree = bst.graph.treefy_split(m)
+        graphdef, statetree = brainstate.graph.treefy_split(m)
 
-        assert isinstance(m.a, bst.ParamState)
-        assert issubclass(statetree.a.type, bst.ParamState)
+        assert isinstance(m.a, brainstate.ParamState)
+        assert issubclass(statetree.a.type, brainstate.ParamState)
         assert m.a is not statetree.a
         assert m.a.value == statetree.a.value
 
-        m2 = bst.graph.treefy_merge(graphdef, statetree)
+        m2 = brainstate.graph.treefy_merge(graphdef, statetree)
 
-        assert isinstance(m2.a, bst.ParamState)
-        assert issubclass(statetree.a.type, bst.ParamState)
+        assert isinstance(m2.a, brainstate.ParamState)
+        assert issubclass(statetree.a.type, brainstate.ParamState)
         assert m2.a is not statetree.a
         assert m2.a.value == statetree.a.value
 
     def test_shared_state_variables_not_shared_with_graph(self):
-        class Foo(bst.graph.Node):
+        class Foo(brainstate.graph.Node):
             def __init__(self):
-                p = bst.ParamState(1)
+                p = brainstate.ParamState(1)
                 self.a = p
                 self.b = p
 
         m = Foo()
-        graphdef, state = bst.graph.treefy_split(m)
+        graphdef, state = brainstate.graph.treefy_split(m)
 
-        assert isinstance(m.a, bst.ParamState)
-        assert isinstance(m.b, bst.ParamState)
-        assert issubclass(state.a.type, bst.ParamState)
+        assert isinstance(m.a, brainstate.ParamState)
+        assert isinstance(m.b, brainstate.ParamState)
+        assert issubclass(state.a.type, brainstate.ParamState)
         assert 'b' not in state
         assert m.a is not state.a
         assert m.b is not state.a
         assert m.a.value == state.a.value
         assert m.b.value == state.a.value
 
-        m2 = bst.graph.treefy_merge(graphdef, state)
+        m2 = brainstate.graph.treefy_merge(graphdef, state)
 
-        assert isinstance(m2.a, bst.ParamState)
-        assert isinstance(m2.b, bst.ParamState)
-        assert issubclass(state.a.type, bst.ParamState)
+        assert isinstance(m2.a, brainstate.ParamState)
+        assert isinstance(m2.b, brainstate.ParamState)
+        assert issubclass(state.a.type, brainstate.ParamState)
         assert m2.a is not state.a
         assert m2.b is not state.a
         assert m2.a.value == state.a.value
@@ -326,24 +324,24 @@ class TestGraphUtils(absltest.TestCase):
         assert m2.a is m2.b
 
     def test_pytree_node(self):
-        @bst.util.dataclass
+        @brainstate.util.dataclass
         class Tree:
-            a: bst.ParamState
-            b: str = bst.util.field(pytree_node=False)
+            a: brainstate.ParamState
+            b: str = brainstate.util.field(pytree_node=False)
 
-        class Foo(bst.graph.Node):
+        class Foo(brainstate.graph.Node):
             def __init__(self):
-                self.tree = Tree(bst.ParamState(1), 'a')
+                self.tree = Tree(brainstate.ParamState(1), 'a')
 
         m = Foo()
 
-        graphdef, state = bst.graph.treefy_split(m)
+        graphdef, state = brainstate.graph.treefy_split(m)
 
         assert 'tree' in state
         assert 'a' in state.tree
         assert graphdef.subgraphs['tree'].type.__name__ == 'PytreeType'
 
-        m2 = bst.graph.treefy_merge(graphdef, state)
+        m2 = brainstate.graph.treefy_merge(graphdef, state)
 
         assert isinstance(m2.tree, Tree)
         assert m2.tree.a.value == 1
@@ -352,36 +350,36 @@ class TestGraphUtils(absltest.TestCase):
         assert m2.tree is not m.tree
 
     def test_call_jit_update(self):
-        class Counter(bst.graph.Node):
+        class Counter(brainstate.graph.Node):
             def __init__(self):
-                self.count = bst.ParamState(jnp.zeros(()))
+                self.count = brainstate.ParamState(jnp.zeros(()))
 
             def inc(self):
                 self.count.value += 1
                 return 1
 
-        graph_state = bst.graph.treefy_split(Counter())
+        graph_state = brainstate.graph.treefy_split(Counter())
 
         @jax.jit
         def update(graph_state):
-            out, graph_state = bst.graph.call(graph_state).inc()
+            out, graph_state = brainstate.graph.call(graph_state).inc()
             self.assertEqual(out, 1)
             return graph_state
 
         graph_state = update(graph_state)
         graph_state = update(graph_state)
 
-        counter = bst.graph.treefy_merge(*graph_state)
+        counter = brainstate.graph.treefy_merge(*graph_state)
 
         self.assertEqual(counter.count.value, 2)
 
     def test_stateful_linear(self):
         linear = StatefulLinear(3, 2)
-        linear_state = bst.graph.treefy_split(linear)
+        linear_state = brainstate.graph.treefy_split(linear)
 
         @jax.jit
         def forward(x, pure_linear):
-            y, pure_linear = bst.graph.call(pure_linear)(x)
+            y, pure_linear = brainstate.graph.call(pure_linear)(x)
             return y, pure_linear
 
         x = jnp.ones((1, 3))
@@ -389,7 +387,7 @@ class TestGraphUtils(absltest.TestCase):
         y, linear_state = forward(x, linear_state)
 
         self.assertEqual(linear.count.value, 0)
-        new_linear = bst.graph.treefy_merge(*linear_state)
+        new_linear = brainstate.graph.treefy_merge(*linear_state)
         self.assertEqual(new_linear.count.value, 2)
 
     def test_getitem(self):
@@ -397,20 +395,20 @@ class TestGraphUtils(absltest.TestCase):
             a=StatefulLinear(3, 2),
             b=StatefulLinear(2, 1),
         )
-        node_state = bst.graph.treefy_split(nodes)
-        _, node_state = bst.graph.call(node_state)['b'].increment()
+        node_state = brainstate.graph.treefy_split(nodes)
+        _, node_state = brainstate.graph.call(node_state)['b'].increment()
 
-        nodes = bst.graph.treefy_merge(*node_state)
+        nodes = brainstate.graph.treefy_merge(*node_state)
 
         self.assertEqual(nodes['a'].count.value, 0)
         self.assertEqual(nodes['b'].count.value, 1)
 
 
-class SimpleModule(bst.nn.Module):
+class SimpleModule(brainstate.nn.Module):
     pass
 
 
-class SimplePyTreeModule(bst.nn.Module):
+class SimplePyTreeModule(brainstate.nn.Module):
     pass
 
 
@@ -420,13 +418,13 @@ class TestThreading(parameterized.TestCase):
         (SimpleModule,),
         (SimplePyTreeModule,),
     )
-    def test_threading(self, module_fn: Callable[[], bst.nn.Module]):
+    def test_threading(self, module_fn: Callable[[], brainstate.nn.Module]):
         x = module_fn()
 
         class MyThread(Thread):
 
             def run(self) -> None:
-                bst.graph.treefy_split(x)
+                brainstate.graph.treefy_split(x)
 
         thread = MyThread()
         thread.start()
@@ -435,26 +433,26 @@ class TestThreading(parameterized.TestCase):
 
 class TestGraphOperation(unittest.TestCase):
     def test1(self):
-        class MyNode(bst.graph.Node):
+        class MyNode(brainstate.graph.Node):
             def __init__(self):
-                self.a = bst.nn.Linear(2, 3)
-                self.b = bst.nn.Linear(3, 2)
-                self.c = [bst.nn.Linear(1, 2), bst.nn.Linear(1, 3)]
-                self.d = {'x': bst.nn.Linear(1, 3), 'y': bst.nn.Linear(1, 4)}
+                self.a = brainstate.nn.Linear(2, 3)
+                self.b = brainstate.nn.Linear(3, 2)
+                self.c = [brainstate.nn.Linear(1, 2), brainstate.nn.Linear(1, 3)]
+                self.d = {'x': brainstate.nn.Linear(1, 3), 'y': brainstate.nn.Linear(1, 4)}
 
-        graphdef, statetree = bst.graph.flatten(MyNode())
+        graphdef, statetree = brainstate.graph.flatten(MyNode())
         # print(graphdef)
         print(statetree)
         # print(bst.graph.unflatten(graphdef, statetree))
 
     def test_split(self):
-        class Foo(bst.graph.Node):
+        class Foo(brainstate.graph.Node):
             def __init__(self):
-                self.a = bst.nn.Linear(2, 2)
-                self.b = bst.nn.BatchNorm1d([10, 2])
+                self.a = brainstate.nn.Linear(2, 2)
+                self.b = brainstate.nn.BatchNorm1d([10, 2])
 
         node = Foo()
-        graphdef, params, others = bst.graph.treefy_split(node, bst.ParamState, ...)
+        graphdef, params, others = brainstate.graph.treefy_split(node, brainstate.ParamState, ...)
 
         print(params)
         print(jax.tree.map(jnp.shape, params))
@@ -462,24 +460,24 @@ class TestGraphOperation(unittest.TestCase):
         print(jax.tree.map(jnp.shape, others))
 
     def test_merge(self):
-        class Foo(bst.graph.Node):
+        class Foo(brainstate.graph.Node):
             def __init__(self):
-                self.a = bst.nn.Linear(2, 2)
-                self.b = bst.nn.BatchNorm1d([10, 2])
+                self.a = brainstate.nn.Linear(2, 2)
+                self.b = brainstate.nn.BatchNorm1d([10, 2])
 
         node = Foo()
-        graphdef, params, others = bst.graph.treefy_split(node, bst.ParamState, ...)
+        graphdef, params, others = brainstate.graph.treefy_split(node, brainstate.ParamState, ...)
 
-        new_node = bst.graph.treefy_merge(graphdef, params, others)
+        new_node = brainstate.graph.treefy_merge(graphdef, params, others)
 
         assert isinstance(new_node, Foo)
-        assert isinstance(new_node.b, bst.nn.BatchNorm1d)
-        assert isinstance(new_node.a, bst.nn.Linear)
+        assert isinstance(new_node.b, brainstate.nn.BatchNorm1d)
+        assert isinstance(new_node.a, brainstate.nn.Linear)
 
     def test_update_states(self):
         x = jnp.ones((1, 2))
         y = jnp.ones((1, 3))
-        model = bst.nn.Linear(2, 3)
+        model = brainstate.nn.Linear(2, 3)
 
         def loss_fn(x, y):
             return jnp.mean((y - model(x)) ** 2)
@@ -490,44 +488,44 @@ class TestGraphOperation(unittest.TestCase):
 
         prev_loss = loss_fn(x, y)
         weights = model.states()
-        grads = bst.augment.grad(loss_fn, weights)(x, y)
+        grads = brainstate.augment.grad(loss_fn, weights)(x, y)
         for key, val in grads.items():
             sgd(weights[key], val)
         assert loss_fn(x, y) < prev_loss
 
     def test_pop_states(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = bst.nn.Linear(2, 3)
-                self.b = bst.nn.LIF([10, 2])
+                self.a = brainstate.nn.Linear(2, 3)
+                self.b = brainstate.nn.LIF([10, 2])
 
         model = Model()
-        with bst.catch_new_states('new'):
-            bst.nn.init_all_states(model)
+        with brainstate.catch_new_states('new'):
+            brainstate.nn.init_all_states(model)
         # print(model.states())
         self.assertTrue(len(model.states()) == 2)
-        model_states = bst.graph.pop_states(model, 'new')
+        model_states = brainstate.graph.pop_states(model, 'new')
         print(model_states)
         self.assertTrue(len(model.states()) == 1)
         assert not hasattr(model.b, 'V')
         # print(model.states())
 
     def test_treefy_split(self):
-        class MLP(bst.graph.Node):
+        class MLP(brainstate.graph.Node):
             def __init__(self, din: int, dmid: int, dout: int, n_layer: int = 3):
-                self.input = bst.nn.Linear(din, dmid)
-                self.layers = [bst.nn.Linear(dmid, dmid) for _ in range(n_layer)]
-                self.output = bst.nn.Linear(dmid, dout)
+                self.input = brainstate.nn.Linear(din, dmid)
+                self.layers = [brainstate.nn.Linear(dmid, dmid) for _ in range(n_layer)]
+                self.output = brainstate.nn.Linear(dmid, dout)
 
             def __call__(self, x):
-                x = bst.functional.relu(self.input(x))
+                x = brainstate.functional.relu(self.input(x))
                 for layer in self.layers:
-                    x = bst.functional.relu(layer(x))
+                    x = brainstate.functional.relu(layer(x))
                 return self.output(x)
 
         model = MLP(2, 1, 3)
-        graph_def, treefy_states = bst.graph.treefy_split(model)
+        graph_def, treefy_states = brainstate.graph.treefy_split(model)
 
         print(graph_def)
         print(treefy_states)
@@ -538,25 +536,25 @@ class TestGraphOperation(unittest.TestCase):
         # print(nest_states)
 
     def test_states(self):
-        class MLP(bst.graph.Node):
+        class MLP(brainstate.graph.Node):
             def __init__(self, din: int, dmid: int, dout: int, n_layer: int = 3):
-                self.input = bst.nn.Linear(din, dmid)
-                self.layers = [bst.nn.Linear(dmid, dmid) for _ in range(n_layer)]
-                self.output = bst.nn.LIF(dout)
+                self.input = brainstate.nn.Linear(din, dmid)
+                self.layers = [brainstate.nn.Linear(dmid, dmid) for _ in range(n_layer)]
+                self.output = brainstate.nn.LIF(dout)
 
             def __call__(self, x):
-                x = bst.functional.relu(self.input(x))
+                x = brainstate.functional.relu(self.input(x))
                 for layer in self.layers:
-                    x = bst.functional.relu(layer(x))
+                    x = brainstate.functional.relu(layer(x))
                 return self.output(x)
 
-        model = bst.nn.init_all_states(MLP(2, 1, 3))
-        states = bst.graph.states(model)
+        model = brainstate.nn.init_all_states(MLP(2, 1, 3))
+        states = brainstate.graph.states(model)
         print(states)
         nest_states = states.to_nest()
         print(nest_states)
 
-        params, others = bst.graph.states(model, bst.ParamState, bst.ShortTermState)
+        params, others = brainstate.graph.states(model, brainstate.ParamState, brainstate.ShortTermState)
         print(params)
         print(others)
 

--- a/brainstate/init/_random_inits_test.py
+++ b/brainstate/init/_random_inits_test.py
@@ -14,30 +14,29 @@
 # ==============================================================================
 
 # -*- coding: utf-8 -*-
-from __future__ import annotations
 
 import unittest
 
-import brainstate as bst
+import brainstate
 
 
 class TestNormalInit(unittest.TestCase):
 
     def test_normal_init1(self):
-        init = bst.init.Normal()
+        init = brainstate.init.Normal()
         for size in [(100,), (10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
 
     def test_normal_init2(self):
-        init = bst.init.Normal(scale=0.5)
+        init = brainstate.init.Normal(scale=0.5)
         for size in [(100,), (10, 20)]:
             weights = init(size)
             assert weights.shape == size
 
     def test_normal_init3(self):
-        init1 = bst.init.Normal(scale=0.5, seed=10)
-        init2 = bst.init.Normal(scale=0.5, seed=10)
+        init1 = brainstate.init.Normal(scale=0.5, seed=10)
+        init2 = brainstate.init.Normal(scale=0.5, seed=10)
         size = (10,)
         weights1 = init1(size)
         weights2 = init2(size)
@@ -47,13 +46,13 @@ class TestNormalInit(unittest.TestCase):
 
 class TestUniformInit(unittest.TestCase):
     def test_uniform_init1(self):
-        init = bst.init.Normal()
+        init = brainstate.init.Normal()
         for size in [(100,), (10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
 
     def test_uniform_init2(self):
-        init = bst.init.Uniform(min_val=10, max_val=20)
+        init = brainstate.init.Uniform(min_val=10, max_val=20)
         for size in [(100,), (10, 20)]:
             weights = init(size)
             assert weights.shape == size
@@ -61,20 +60,20 @@ class TestUniformInit(unittest.TestCase):
 
 class TestVarianceScaling(unittest.TestCase):
     def test_var_scaling1(self):
-        init = bst.init.VarianceScaling(scale=1., mode='fan_in', distribution='truncated_normal')
+        init = brainstate.init.VarianceScaling(scale=1., mode='fan_in', distribution='truncated_normal')
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
 
     def test_var_scaling2(self):
-        init = bst.init.VarianceScaling(scale=2, mode='fan_out', distribution='normal')
+        init = brainstate.init.VarianceScaling(scale=2, mode='fan_out', distribution='normal')
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
 
     def test_var_scaling3(self):
-        init = bst.init.VarianceScaling(scale=2 / 4, mode='fan_avg', in_axis=0, out_axis=1,
-                                        distribution='uniform')
+        init = brainstate.init.VarianceScaling(scale=2 / 4, mode='fan_avg', in_axis=0, out_axis=1,
+                                               distribution='uniform')
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -82,7 +81,7 @@ class TestVarianceScaling(unittest.TestCase):
 
 class TestKaimingUniformUnit(unittest.TestCase):
     def test_kaiming_uniform_init(self):
-        init = bst.init.KaimingUniform()
+        init = brainstate.init.KaimingUniform()
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -90,7 +89,7 @@ class TestKaimingUniformUnit(unittest.TestCase):
 
 class TestKaimingNormalUnit(unittest.TestCase):
     def test_kaiming_normal_init(self):
-        init = bst.init.KaimingNormal()
+        init = brainstate.init.KaimingNormal()
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -98,7 +97,7 @@ class TestKaimingNormalUnit(unittest.TestCase):
 
 class TestXavierUniformUnit(unittest.TestCase):
     def test_xavier_uniform_init(self):
-        init = bst.init.XavierUniform()
+        init = brainstate.init.XavierUniform()
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -106,7 +105,7 @@ class TestXavierUniformUnit(unittest.TestCase):
 
 class TestXavierNormalUnit(unittest.TestCase):
     def test_xavier_normal_init(self):
-        init = bst.init.XavierNormal()
+        init = brainstate.init.XavierNormal()
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -114,7 +113,7 @@ class TestXavierNormalUnit(unittest.TestCase):
 
 class TestLecunUniformUnit(unittest.TestCase):
     def test_lecun_uniform_init(self):
-        init = bst.init.LecunUniform()
+        init = brainstate.init.LecunUniform()
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -122,7 +121,7 @@ class TestLecunUniformUnit(unittest.TestCase):
 
 class TestLecunNormalUnit(unittest.TestCase):
     def test_lecun_normal_init(self):
-        init = bst.init.LecunNormal()
+        init = brainstate.init.LecunNormal()
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -130,13 +129,13 @@ class TestLecunNormalUnit(unittest.TestCase):
 
 class TestOrthogonalUnit(unittest.TestCase):
     def test_orthogonal_init1(self):
-        init = bst.init.Orthogonal()
+        init = brainstate.init.Orthogonal()
         for size in [(20, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
 
     def test_orthogonal_init2(self):
-        init = bst.init.Orthogonal(scale=2., axis=0)
+        init = brainstate.init.Orthogonal(scale=2., axis=0)
         for size in [(10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -144,7 +143,7 @@ class TestOrthogonalUnit(unittest.TestCase):
 
 class TestDeltaOrthogonalUnit(unittest.TestCase):
     def test_delta_orthogonal_init1(self):
-        init = bst.init.DeltaOrthogonal()
+        init = brainstate.init.DeltaOrthogonal()
         for size in [(20, 20, 20), (10, 20, 30, 40), (50, 40, 30, 20, 20)]:
             weights = init(size)
             assert weights.shape == size

--- a/brainstate/init/_regular_inits_test.py
+++ b/brainstate/init/_regular_inits_test.py
@@ -14,16 +14,15 @@
 # ==============================================================================
 
 # -*- coding: utf-8 -*-
-from __future__ import annotations
 
 import unittest
 
-import brainstate as bst
+import brainstate
 
 
 class TestZeroInit(unittest.TestCase):
     def test_zero_init(self):
-        init = bst.init.ZeroInit()
+        init = brainstate.init.ZeroInit()
         for size in [(100,), (10, 20), (10, 20, 30)]:
             weights = init(size)
             assert weights.shape == size
@@ -33,7 +32,7 @@ class TestOneInit(unittest.TestCase):
     def test_one_init(self):
         for size in [(100,), (10, 20), (10, 20, 30)]:
             for value in [0., 1., -1.]:
-                init = bst.init.Constant(value=value)
+                init = brainstate.init.Constant(value=value)
                 weights = init(size)
                 assert weights.shape == size
                 assert (weights == value).all()
@@ -43,7 +42,7 @@ class TestIdentityInit(unittest.TestCase):
     def test_identity_init(self):
         for size in [(100,), (10, 20)]:
             for value in [0., 1., -1.]:
-                init = bst.init.Identity(value=value)
+                init = brainstate.init.Identity(value=value)
                 weights = init(size)
                 if len(size) == 1:
                     assert weights.shape == (size[0], size[0])

--- a/brainstate/nn/_collective_ops_test.py
+++ b/brainstate/nn/_collective_ops_test.py
@@ -16,21 +16,21 @@
 # -*- coding: utf-8 -*-
 
 
-import brainstate as bst
+import brainstate
 
 
 class Test_vmap_init_all_states:
 
     def test_vmap_init_all_states(self):
-        gru = bst.nn.GRUCell(1, 2)
-        bst.nn.vmap_init_all_states(gru, axis_size=10)
+        gru = brainstate.nn.GRUCell(1, 2)
+        brainstate.nn.vmap_init_all_states(gru, axis_size=10)
         print(gru)
 
     def test_vmap_init_all_states_v2(self):
-        @bst.compile.jit
+        @brainstate.compile.jit
         def init():
-            gru = bst.nn.GRUCell(1, 2)
-            bst.nn.vmap_init_all_states(gru, axis_size=10)
+            gru = brainstate.nn.GRUCell(1, 2)
+            brainstate.nn.vmap_init_all_states(gru, axis_size=10)
             print(gru)
 
         init()
@@ -38,6 +38,6 @@ class Test_vmap_init_all_states:
 
 class Test_init_all_states:
     def test_init_all_states(self):
-        gru = bst.nn.GRUCell(1, 2)
-        bst.nn.init_all_states(gru, batch_size=10)
+        gru = brainstate.nn.GRUCell(1, 2)
+        brainstate.nn.init_all_states(gru, batch_size=10)
         print(gru)

--- a/brainstate/nn/_dyn_impl/_dynamics_neuron_test.py
+++ b/brainstate/nn/_dyn_impl/_dynamics_neuron_test.py
@@ -15,7 +15,6 @@
 
 # -*- coding: utf-8 -*-
 
-from __future__ import annotations
 
 import unittest
 
@@ -23,7 +22,7 @@ import brainunit as u
 import jax
 import jax.numpy as jnp
 
-import brainstate as bst
+import brainstate
 from brainstate.nn import IF, LIF, ALIF
 
 
@@ -35,13 +34,13 @@ class TestNeuron(unittest.TestCase):
 
     def test_neuron_base_class(self):
         with self.assertRaises(NotImplementedError):
-            bst.nn.Neuron(self.in_size).get_spike()  # Neuron is an abstract base class
+            brainstate.nn.Neuron(self.in_size).get_spike()  # Neuron is an abstract base class
 
     def generate_input(self):
-        return bst.random.randn(self.time_steps, self.batch_size, self.in_size) * u.mA
+        return brainstate.random.randn(self.time_steps, self.batch_size, self.in_size) * u.mA
 
     def test_if_neuron(self):
-        with bst.environ.context(dt=0.1 * u.ms):
+        with brainstate.environ.context(dt=0.1 * u.ms):
             neuron = IF(self.in_size)
             inputs = self.generate_input()
 
@@ -62,7 +61,7 @@ class TestNeuron(unittest.TestCase):
             self.assertTrue(jnp.all((spikes >= 0) & (spikes <= 1)))
 
     def test_lif_neuron(self):
-        with bst.environ.context(dt=0.1 * u.ms):
+        with brainstate.environ.context(dt=0.1 * u.ms):
             tau = 20.0 * u.ms
             neuron = LIF(self.in_size, tau=tau)
             inputs = self.generate_input()
@@ -74,7 +73,7 @@ class TestNeuron(unittest.TestCase):
 
             # Test forward pass
             state = neuron.init_state(self.batch_size)
-            call = bst.compile.jit(neuron)
+            call = brainstate.compile.jit(neuron)
 
             for t in range(self.time_steps):
                 out = call(inputs[t])
@@ -94,8 +93,8 @@ class TestNeuron(unittest.TestCase):
 
         # Test forward pass
         neuron.init_state(self.batch_size)
-        call = bst.compile.jit(neuron)
-        with bst.environ.context(dt=0.1 * u.ms):
+        call = brainstate.compile.jit(neuron)
+        with brainstate.environ.context(dt=0.1 * u.ms):
             for t in range(self.time_steps):
                 out = call(inputs[t])
                 self.assertEqual(out.shape, (self.batch_size, self.in_size))
@@ -113,8 +112,8 @@ class TestNeuron(unittest.TestCase):
             neuron = NeuronClass(self.in_size, spk_reset='soft')
             inputs = self.generate_input()
             state = neuron.init_state(self.batch_size)
-            call = bst.compile.jit(neuron)
-            with bst.environ.context(dt=0.1 * u.ms):
+            call = brainstate.compile.jit(neuron)
+            with brainstate.environ.context(dt=0.1 * u.ms):
                 for t in range(self.time_steps):
                     out = call(inputs[t])
                     self.assertTrue(jnp.all(neuron.V.value <= neuron.V_th))
@@ -124,8 +123,8 @@ class TestNeuron(unittest.TestCase):
             neuron = NeuronClass(self.in_size, spk_reset='hard')
             inputs = self.generate_input()
             state = neuron.init_state(self.batch_size)
-            call = bst.compile.jit(neuron)
-            with bst.environ.context(dt=0.1 * u.ms):
+            call = brainstate.compile.jit(neuron)
+            with brainstate.environ.context(dt=0.1 * u.ms):
                 for t in range(self.time_steps):
                     out = call(inputs[t])
                     self.assertTrue(jnp.all((neuron.V.value < neuron.V_th) | (neuron.V.value == 0. * u.mV)))
@@ -135,8 +134,8 @@ class TestNeuron(unittest.TestCase):
             neuron = NeuronClass(self.in_size)
             inputs = self.generate_input()
             state = neuron.init_state(self.batch_size)
-            call = bst.compile.jit(neuron)
-            with bst.environ.context(dt=0.1 * u.ms):
+            call = brainstate.compile.jit(neuron)
+            with brainstate.environ.context(dt=0.1 * u.ms):
                 for t in range(self.time_steps):
                     out = call(inputs[t])
                     self.assertFalse(jax.tree_util.tree_leaves(out)[0].aval.weak_type)
@@ -148,15 +147,15 @@ class TestNeuron(unittest.TestCase):
             self.assertEqual(neuron.in_size, in_size)
             self.assertEqual(neuron.out_size, in_size)
 
-            inputs = bst.random.randn(self.time_steps, self.batch_size, *in_size) * u.mA
+            inputs = brainstate.random.randn(self.time_steps, self.batch_size, *in_size) * u.mA
             state = neuron.init_state(self.batch_size)
-            call = bst.compile.jit(neuron)
-            with bst.environ.context(dt=0.1 * u.ms):
+            call = brainstate.compile.jit(neuron)
+            with brainstate.environ.context(dt=0.1 * u.ms):
                 for t in range(self.time_steps):
                     out = call(inputs[t])
                     self.assertEqual(out.shape, (self.batch_size, *in_size))
 
 
 if __name__ == '__main__':
-    with bst.environ.context(dt=0.1):
+    with brainstate.environ.context(dt=0.1):
         unittest.main()

--- a/brainstate/nn/_dyn_impl/_dynamics_synapse_test.py
+++ b/brainstate/nn/_dyn_impl/_dynamics_synapse_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
@@ -21,7 +20,7 @@ import brainunit as u
 import jax.numpy as jnp
 import pytest
 
-import brainstate as bst
+import brainstate
 from brainstate.nn import Expon, STP, STD
 
 
@@ -32,7 +31,7 @@ class TestSynapse(unittest.TestCase):
         self.time_steps = 100
 
     def generate_input(self):
-        return bst.random.randn(self.time_steps, self.batch_size, self.in_size) * u.mS
+        return brainstate.random.randn(self.time_steps, self.batch_size, self.in_size) * u.mS
 
     def test_expon_synapse(self):
         tau = 20.0 * u.ms
@@ -46,8 +45,8 @@ class TestSynapse(unittest.TestCase):
 
         # Test forward pass
         state = synapse.init_state(self.batch_size)
-        call = bst.compile.jit(synapse)
-        with bst.environ.context(dt=0.1 * u.ms):
+        call = brainstate.compile.jit(synapse)
+        with brainstate.environ.context(dt=0.1 * u.ms):
             for t in range(self.time_steps):
                 out = call(inputs[t])
                 self.assertEqual(out.shape, (self.batch_size, self.in_size))
@@ -75,7 +74,7 @@ class TestSynapse(unittest.TestCase):
 
         # Test forward pass
         state = synapse.init_state(self.batch_size)
-        call = bst.compile.jit(synapse)
+        call = brainstate.compile.jit(synapse)
         for t in range(self.time_steps):
             out = call(inputs[t])
             self.assertEqual(out.shape, (self.batch_size, self.in_size))
@@ -118,15 +117,15 @@ class TestSynapse(unittest.TestCase):
             self.assertEqual(synapse.in_size, in_size)
             self.assertEqual(synapse.out_size, in_size)
 
-            inputs = bst.random.randn(self.time_steps, self.batch_size, *in_size) * u.mS
+            inputs = brainstate.random.randn(self.time_steps, self.batch_size, *in_size) * u.mS
             state = synapse.init_state(self.batch_size)
-            call = bst.compile.jit(synapse)
-            with bst.environ.context(dt=0.1 * u.ms):
+            call = brainstate.compile.jit(synapse)
+            with brainstate.environ.context(dt=0.1 * u.ms):
                 for t in range(self.time_steps):
                     out = call(inputs[t])
                     self.assertEqual(out.shape, (self.batch_size, *in_size))
 
 
 if __name__ == '__main__':
-    with bst.environ.context(dt=0.1):
+    with brainstate.environ.context(dt=0.1):
         unittest.main()

--- a/brainstate/nn/_dyn_impl/_rate_rnns_test.py
+++ b/brainstate/nn/_dyn_impl/_rate_rnns_test.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
 import jax.numpy as jnp
 
-import brainstate as bst
+import brainstate
 
 
 class TestRateRNNModels(unittest.TestCase):
@@ -30,31 +29,31 @@ class TestRateRNNModels(unittest.TestCase):
         self.x = jnp.ones((self.batch_size, self.num_in))
 
     def test_ValinaRNNCell(self):
-        model = bst.nn.ValinaRNNCell(num_in=self.num_in, num_out=self.num_out)
+        model = brainstate.nn.ValinaRNNCell(num_in=self.num_in, num_out=self.num_out)
         model.init_state(batch_size=self.batch_size)
         output = model.update(self.x)
         self.assertEqual(output.shape, (self.batch_size, self.num_out))
 
     def test_GRUCell(self):
-        model = bst.nn.GRUCell(num_in=self.num_in, num_out=self.num_out)
+        model = brainstate.nn.GRUCell(num_in=self.num_in, num_out=self.num_out)
         model.init_state(batch_size=self.batch_size)
         output = model.update(self.x)
         self.assertEqual(output.shape, (self.batch_size, self.num_out))
 
     def test_MGUCell(self):
-        model = bst.nn.MGUCell(num_in=self.num_in, num_out=self.num_out)
+        model = brainstate.nn.MGUCell(num_in=self.num_in, num_out=self.num_out)
         model.init_state(batch_size=self.batch_size)
         output = model.update(self.x)
         self.assertEqual(output.shape, (self.batch_size, self.num_out))
 
     def test_LSTMCell(self):
-        model = bst.nn.LSTMCell(num_in=self.num_in, num_out=self.num_out)
+        model = brainstate.nn.LSTMCell(num_in=self.num_in, num_out=self.num_out)
         model.init_state(batch_size=self.batch_size)
         output = model.update(self.x)
         self.assertEqual(output.shape, (self.batch_size, self.num_out))
 
     def test_URLSTMCell(self):
-        model = bst.nn.URLSTMCell(num_in=self.num_in, num_out=self.num_out)
+        model = brainstate.nn.URLSTMCell(num_in=self.num_in, num_out=self.num_out)
         model.init_state(batch_size=self.batch_size)
         output = model.update(self.x)
         self.assertEqual(output.shape, (self.batch_size, self.num_out))

--- a/brainstate/nn/_dyn_impl/_readout_test.py
+++ b/brainstate/nn/_dyn_impl/_readout_test.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
 import jax.numpy as jnp
 
-import brainstate as bst
+import brainstate
 
 
 class TestReadoutModels(unittest.TestCase):
@@ -32,23 +31,23 @@ class TestReadoutModels(unittest.TestCase):
         self.x = jnp.ones((self.batch_size, self.in_size))
 
     def test_LeakyRateReadout(self):
-        with bst.environ.context(dt=0.1):
-            model = bst.nn.LeakyRateReadout(in_size=self.in_size, out_size=self.out_size, tau=self.tau)
+        with brainstate.environ.context(dt=0.1):
+            model = brainstate.nn.LeakyRateReadout(in_size=self.in_size, out_size=self.out_size, tau=self.tau)
             model.init_state(batch_size=self.batch_size)
             output = model.update(self.x)
             self.assertEqual(output.shape, (self.batch_size, self.out_size))
 
     def test_LeakySpikeReadout(self):
-        with bst.environ.context(dt=0.1):
-            model = bst.nn.LeakySpikeReadout(in_size=self.in_size, tau=self.tau, V_th=self.V_th,
-                                             V_initializer=bst.init.ZeroInit(),
-                                             w_init=bst.init.KaimingNormal())
+        with brainstate.environ.context(dt=0.1):
+            model = brainstate.nn.LeakySpikeReadout(in_size=self.in_size, tau=self.tau, V_th=self.V_th,
+                                                    V_initializer=brainstate.init.ZeroInit(),
+                                                    w_init=brainstate.init.KaimingNormal())
             model.init_state(batch_size=self.batch_size)
-            with bst.environ.context(t=0.):
+            with brainstate.environ.context(t=0.):
                 output = model.update(self.x)
             self.assertEqual(output.shape, (self.batch_size, self.out_size))
 
 
 if __name__ == '__main__':
-    with bst.environ.context(dt=0.1):
+    with brainstate.environ.context(dt=0.1):
         unittest.main()

--- a/brainstate/nn/_dynamics/_dynamics_base_test.py
+++ b/brainstate/nn/_dynamics/_dynamics_base_test.py
@@ -15,47 +15,46 @@
 
 # -*- coding: utf-8 -*-
 
-from __future__ import annotations
 
 import unittest
 
 import numpy as np
 
-import brainstate as bst
+import brainstate
 
 
 class TestModuleGroup(unittest.TestCase):
     def test_initialization(self):
-        group = bst.nn.DynamicsGroup()
-        self.assertIsInstance(group, bst.nn.DynamicsGroup)
+        group = brainstate.nn.DynamicsGroup()
+        self.assertIsInstance(group, brainstate.nn.DynamicsGroup)
 
 
 class TestProjection(unittest.TestCase):
     def test_initialization(self):
-        proj = bst.nn.Projection()
-        self.assertIsInstance(proj, bst.nn.Projection)
+        proj = brainstate.nn.Projection()
+        self.assertIsInstance(proj, brainstate.nn.Projection)
 
     def test_update_not_implemented(self):
-        proj = bst.nn.Projection()
+        proj = brainstate.nn.Projection()
         with self.assertRaises(ValueError):
             proj.update()
 
 
 class TestDynamics(unittest.TestCase):
     def test_initialization(self):
-        dyn = bst.nn.Dynamics(in_size=10)
-        self.assertIsInstance(dyn, bst.nn.Dynamics)
+        dyn = brainstate.nn.Dynamics(in_size=10)
+        self.assertIsInstance(dyn, brainstate.nn.Dynamics)
         self.assertEqual(dyn.in_size, (10,))
         self.assertEqual(dyn.out_size, (10,))
 
     def test_size_validation(self):
         with self.assertRaises(ValueError):
-            bst.nn.Dynamics(in_size=[])
+            brainstate.nn.Dynamics(in_size=[])
         with self.assertRaises(ValueError):
-            bst.nn.Dynamics(in_size="invalid")
+            brainstate.nn.Dynamics(in_size="invalid")
 
     def test_input_handling(self):
-        dyn = bst.nn.Dynamics(in_size=10)
+        dyn = brainstate.nn.Dynamics(in_size=10)
         dyn.add_current_input("test_current", lambda: np.random.rand(10))
         dyn.add_delta_input("test_delta", lambda: np.random.rand(10))
 
@@ -63,15 +62,15 @@ class TestDynamics(unittest.TestCase):
         self.assertIn("test_delta", dyn.delta_inputs)
 
     def test_duplicate_input_key(self):
-        dyn = bst.nn.Dynamics(in_size=10)
+        dyn = brainstate.nn.Dynamics(in_size=10)
         dyn.add_current_input("test", lambda: np.random.rand(10))
         with self.assertRaises(ValueError):
             dyn.add_current_input("test", lambda: np.random.rand(10))
 
     def test_varshape(self):
-        dyn = bst.nn.Dynamics(in_size=(2, 3))
+        dyn = brainstate.nn.Dynamics(in_size=(2, 3))
         self.assertEqual(dyn.varshape, (2, 3))
-        dyn = bst.nn.Dynamics(in_size=(2, 3))
+        dyn = brainstate.nn.Dynamics(in_size=(2, 3))
         self.assertEqual(dyn.varshape, (2, 3))
 
 

--- a/brainstate/nn/_dynamics/_synouts_test.py
+++ b/brainstate/nn/_dynamics/_synouts_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
@@ -21,7 +20,7 @@ import brainunit as u
 import jax.numpy as jnp
 import numpy as np
 
-import brainstate as bst
+import brainstate
 
 
 class TestSynOutModels(unittest.TestCase):
@@ -35,19 +34,19 @@ class TestSynOutModels(unittest.TestCase):
         self.V_offset = jnp.array([0.0])
 
     def test_COBA(self):
-        model = bst.nn.COBA(E=self.E)
+        model = brainstate.nn.COBA(E=self.E)
         output = model.update(self.conductance, self.potential)
         expected_output = self.conductance * (self.E - self.potential)
         np.testing.assert_array_almost_equal(output, expected_output)
 
     def test_CUBA(self):
-        model = bst.nn.CUBA()
+        model = brainstate.nn.CUBA()
         output = model.update(self.conductance)
         expected_output = self.conductance * model.scale
         self.assertTrue(u.math.allclose(output, expected_output))
 
     def test_MgBlock(self):
-        model = bst.nn.MgBlock(E=self.E, cc_Mg=self.cc_Mg, alpha=self.alpha, beta=self.beta, V_offset=self.V_offset)
+        model = brainstate.nn.MgBlock(E=self.E, cc_Mg=self.cc_Mg, alpha=self.alpha, beta=self.beta, V_offset=self.V_offset)
         output = model.update(self.conductance, self.potential)
         norm = (1 + self.cc_Mg / self.beta * jnp.exp(self.alpha * (self.V_offset - self.potential)))
         expected_output = self.conductance * (self.E - self.potential) / norm

--- a/brainstate/nn/_elementwise/_dropout_test.py
+++ b/brainstate/nn/_elementwise/_dropout_test.py
@@ -18,19 +18,19 @@ import unittest
 
 import numpy as np
 
-import brainstate as bst
+import brainstate
 
 
 class TestDropout(unittest.TestCase):
 
     def test_dropout(self):
         # Create a Dropout layer with a dropout rate of 0.5
-        dropout_layer = bst.nn.Dropout(0.5)
+        dropout_layer = brainstate.nn.Dropout(0.5)
 
         # Input data
         input_data = np.arange(20)
 
-        with bst.environ.context(fit=True):
+        with brainstate.environ.context(fit=True):
             # Apply dropout
             output_data = dropout_layer(input_data)
 
@@ -47,10 +47,10 @@ class TestDropout(unittest.TestCase):
             np.testing.assert_almost_equal(non_zero_elements, expected_non_zero_elements)
 
     def test_DropoutFixed(self):
-        dropout_layer = bst.nn.DropoutFixed(in_size=(2, 3), prob=0.5)
+        dropout_layer = brainstate.nn.DropoutFixed(in_size=(2, 3), prob=0.5)
         dropout_layer.init_state(batch_size=2)
         input_data = np.random.randn(2, 2, 3)
-        with bst.environ.context(fit=True):
+        with brainstate.environ.context(fit=True):
             output_data = dropout_layer.update(input_data)
         self.assertEqual(input_data.shape, output_data.shape)
         self.assertTrue(np.any(output_data == 0))
@@ -72,9 +72,9 @@ class TestDropout(unittest.TestCase):
     #     np.testing.assert_almost_equal(non_zero_elements, expected_non_zero_elements, decimal=4)
 
     def test_Dropout2d(self):
-        dropout_layer = bst.nn.Dropout2d(prob=0.5)
+        dropout_layer = brainstate.nn.Dropout2d(prob=0.5)
         input_data = np.random.randn(2, 3, 4, 5)
-        with bst.environ.context(fit=True):
+        with brainstate.environ.context(fit=True):
             output_data = dropout_layer(input_data)
         self.assertEqual(input_data.shape, output_data.shape)
         self.assertTrue(np.any(output_data == 0))
@@ -84,9 +84,9 @@ class TestDropout(unittest.TestCase):
         np.testing.assert_almost_equal(non_zero_elements, expected_non_zero_elements, decimal=4)
 
     def test_Dropout3d(self):
-        dropout_layer = bst.nn.Dropout3d(prob=0.5)
+        dropout_layer = brainstate.nn.Dropout3d(prob=0.5)
         input_data = np.random.randn(2, 3, 4, 5, 6)
-        with bst.environ.context(fit=True):
+        with brainstate.environ.context(fit=True):
             output_data = dropout_layer(input_data)
         self.assertEqual(input_data.shape, output_data.shape)
         self.assertTrue(np.any(output_data == 0))

--- a/brainstate/nn/_elementwise/_elementwise_test.py
+++ b/brainstate/nn/_elementwise/_elementwise_test.py
@@ -13,157 +13,155 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 from absl.testing import absltest
 from absl.testing import parameterized
 
-import brainstate as bst
+import brainstate
 
 
 class Test_Activation(parameterized.TestCase):
 
     def test_Threshold(self):
-        threshold_layer = bst.nn.Threshold(5, 20)
-        input = bst.random.randn(2)
+        threshold_layer = brainstate.nn.Threshold(5, 20)
+        input = brainstate.random.randn(2)
         output = threshold_layer(input)
 
     def test_ReLU(self):
-        ReLU_layer = bst.nn.ReLU()
-        input = bst.random.randn(2)
+        ReLU_layer = brainstate.nn.ReLU()
+        input = brainstate.random.randn(2)
         output = ReLU_layer(input)
 
     def test_RReLU(self):
-        RReLU_layer = bst.nn.RReLU(lower=0, upper=1)
-        input = bst.random.randn(2)
+        RReLU_layer = brainstate.nn.RReLU(lower=0, upper=1)
+        input = brainstate.random.randn(2)
         output = RReLU_layer(input)
 
     def test_Hardtanh(self):
-        Hardtanh_layer = bst.nn.Hardtanh(min_val=0, max_val=1, )
-        input = bst.random.randn(2)
+        Hardtanh_layer = brainstate.nn.Hardtanh(min_val=0, max_val=1, )
+        input = brainstate.random.randn(2)
         output = Hardtanh_layer(input)
 
     def test_ReLU6(self):
-        ReLU6_layer = bst.nn.ReLU6()
-        input = bst.random.randn(2)
+        ReLU6_layer = brainstate.nn.ReLU6()
+        input = brainstate.random.randn(2)
         output = ReLU6_layer(input)
 
     def test_Sigmoid(self):
-        Sigmoid_layer = bst.nn.Sigmoid()
-        input = bst.random.randn(2)
+        Sigmoid_layer = brainstate.nn.Sigmoid()
+        input = brainstate.random.randn(2)
         output = Sigmoid_layer(input)
 
     def test_Hardsigmoid(self):
-        Hardsigmoid_layer = bst.nn.Hardsigmoid()
-        input = bst.random.randn(2)
+        Hardsigmoid_layer = brainstate.nn.Hardsigmoid()
+        input = brainstate.random.randn(2)
         output = Hardsigmoid_layer(input)
 
     def test_Tanh(self):
-        Tanh_layer = bst.nn.Tanh()
-        input = bst.random.randn(2)
+        Tanh_layer = brainstate.nn.Tanh()
+        input = brainstate.random.randn(2)
         output = Tanh_layer(input)
 
     def test_SiLU(self):
-        SiLU_layer = bst.nn.SiLU()
-        input = bst.random.randn(2)
+        SiLU_layer = brainstate.nn.SiLU()
+        input = brainstate.random.randn(2)
         output = SiLU_layer(input)
 
     def test_Mish(self):
-        Mish_layer = bst.nn.Mish()
-        input = bst.random.randn(2)
+        Mish_layer = brainstate.nn.Mish()
+        input = brainstate.random.randn(2)
         output = Mish_layer(input)
 
     def test_Hardswish(self):
-        Hardswish_layer = bst.nn.Hardswish()
-        input = bst.random.randn(2)
+        Hardswish_layer = brainstate.nn.Hardswish()
+        input = brainstate.random.randn(2)
         output = Hardswish_layer(input)
 
     def test_ELU(self):
-        ELU_layer = bst.nn.ELU(alpha=0.5, )
-        input = bst.random.randn(2)
+        ELU_layer = brainstate.nn.ELU(alpha=0.5, )
+        input = brainstate.random.randn(2)
         output = ELU_layer(input)
 
     def test_CELU(self):
-        CELU_layer = bst.nn.CELU(alpha=0.5, )
-        input = bst.random.randn(2)
+        CELU_layer = brainstate.nn.CELU(alpha=0.5, )
+        input = brainstate.random.randn(2)
         output = CELU_layer(input)
 
     def test_SELU(self):
-        SELU_layer = bst.nn.SELU()
-        input = bst.random.randn(2)
+        SELU_layer = brainstate.nn.SELU()
+        input = brainstate.random.randn(2)
         output = SELU_layer(input)
 
     def test_GLU(self):
-        GLU_layer = bst.nn.GLU()
-        input = bst.random.randn(4, 2)
+        GLU_layer = brainstate.nn.GLU()
+        input = brainstate.random.randn(4, 2)
         output = GLU_layer(input)
 
     @parameterized.product(
         approximate=['tanh', 'none']
     )
     def test_GELU(self, approximate):
-        GELU_layer = bst.nn.GELU()
-        input = bst.random.randn(2)
+        GELU_layer = brainstate.nn.GELU()
+        input = brainstate.random.randn(2)
         output = GELU_layer(input)
 
     def test_Hardshrink(self):
-        Hardshrink_layer = bst.nn.Hardshrink(lambd=1)
-        input = bst.random.randn(2)
+        Hardshrink_layer = brainstate.nn.Hardshrink(lambd=1)
+        input = brainstate.random.randn(2)
         output = Hardshrink_layer(input)
 
     def test_LeakyReLU(self):
-        LeakyReLU_layer = bst.nn.LeakyReLU()
-        input = bst.random.randn(2)
+        LeakyReLU_layer = brainstate.nn.LeakyReLU()
+        input = brainstate.random.randn(2)
         output = LeakyReLU_layer(input)
 
     def test_LogSigmoid(self):
-        LogSigmoid_layer = bst.nn.LogSigmoid()
-        input = bst.random.randn(2)
+        LogSigmoid_layer = brainstate.nn.LogSigmoid()
+        input = brainstate.random.randn(2)
         output = LogSigmoid_layer(input)
 
     def test_Softplus(self):
-        Softplus_layer = bst.nn.Softplus()
-        input = bst.random.randn(2)
+        Softplus_layer = brainstate.nn.Softplus()
+        input = brainstate.random.randn(2)
         output = Softplus_layer(input)
 
     def test_Softshrink(self):
-        Softshrink_layer = bst.nn.Softshrink(lambd=1)
-        input = bst.random.randn(2)
+        Softshrink_layer = brainstate.nn.Softshrink(lambd=1)
+        input = brainstate.random.randn(2)
         output = Softshrink_layer(input)
 
     def test_PReLU(self):
-        PReLU_layer = bst.nn.PReLU(num_parameters=2, init=0.5)
-        input = bst.random.randn(2)
+        PReLU_layer = brainstate.nn.PReLU(num_parameters=2, init=0.5)
+        input = brainstate.random.randn(2)
         output = PReLU_layer(input)
 
     def test_Softsign(self):
-        Softsign_layer = bst.nn.Softsign()
-        input = bst.random.randn(2)
+        Softsign_layer = brainstate.nn.Softsign()
+        input = brainstate.random.randn(2)
         output = Softsign_layer(input)
 
     def test_Tanhshrink(self):
-        Tanhshrink_layer = bst.nn.Tanhshrink()
-        input = bst.random.randn(2)
+        Tanhshrink_layer = brainstate.nn.Tanhshrink()
+        input = brainstate.random.randn(2)
         output = Tanhshrink_layer(input)
 
     def test_Softmin(self):
-        Softmin_layer = bst.nn.Softmin(dim=2)
-        input = bst.random.randn(2, 3, 4)
+        Softmin_layer = brainstate.nn.Softmin(dim=2)
+        input = brainstate.random.randn(2, 3, 4)
         output = Softmin_layer(input)
 
     def test_Softmax(self):
-        Softmax_layer = bst.nn.Softmax(dim=2)
-        input = bst.random.randn(2, 3, 4)
+        Softmax_layer = brainstate.nn.Softmax(dim=2)
+        input = brainstate.random.randn(2, 3, 4)
         output = Softmax_layer(input)
 
     def test_Softmax2d(self):
-        Softmax2d_layer = bst.nn.Softmax2d()
-        input = bst.random.randn(2, 3, 12, 13)
+        Softmax2d_layer = brainstate.nn.Softmax2d()
+        input = brainstate.random.randn(2, 3, 12, 13)
         output = Softmax2d_layer(input)
 
     def test_LogSoftmax(self):
-        LogSoftmax_layer = bst.nn.LogSoftmax(dim=2)
-        input = bst.random.randn(2, 3, 4)
+        LogSoftmax_layer = brainstate.nn.LogSoftmax(dim=2)
+        input = brainstate.random.randn(2, 3, 4)
         output = LogSoftmax_layer(input)
 
 

--- a/brainstate/nn/_event/_fixedprob_mv_test.py
+++ b/brainstate/nn/_event/_fixedprob_mv_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import jax.numpy
 import jax.numpy as jnp

--- a/brainstate/nn/_event/_linear_mv_test.py
+++ b/brainstate/nn/_event/_linear_mv_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import jax
 import jax.numpy as jnp

--- a/brainstate/nn/_exp_euler_test.py
+++ b/brainstate/nn/_exp_euler_test.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
 import brainunit as u
 
-import brainstate as bst
+import brainstate
 
 
 class TestExpEuler(unittest.TestCase):
@@ -27,10 +26,10 @@ class TestExpEuler(unittest.TestCase):
         def fun(x, tau):
             return -x / tau
 
-        with bst.environ.context(dt=0.1):
+        with brainstate.environ.context(dt=0.1):
             with self.assertRaises(AssertionError):
-                r = bst.nn.exp_euler_step(fun, 1.0 * u.mV, 1. * u.ms)
+                r = brainstate.nn.exp_euler_step(fun, 1.0 * u.mV, 1. * u.ms)
 
-        with bst.environ.context(dt=1. * u.ms):
-            r = bst.nn.exp_euler_step(fun, 1.0 * u.mV, 1. * u.ms)
+        with brainstate.environ.context(dt=1. * u.ms):
+            r = brainstate.nn.exp_euler_step(fun, 1.0 * u.mV, 1. * u.ms)
             print(r)

--- a/brainstate/nn/_interaction/_conv_test.py
+++ b/brainstate/nn/_interaction/_conv_test.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import annotations
-
 import jax.numpy as jnp
 import pytest
 from absl.testing import absltest
 from absl.testing import parameterized
 
-import brainstate as bst
+import brainstate
 
 
 class TestConv(parameterized.TestCase):
@@ -19,8 +17,8 @@ class TestConv(parameterized.TestCase):
             img = img.at[0, x:x + 10, y:y + 10, k].set(1.0)
             img = img.at[1, x:x + 20, y:y + 20, k].set(3.0)
 
-        net = bst.nn.Conv2d((200, 198, 4), out_channels=32, kernel_size=(3, 3),
-                            stride=(2, 1), padding='VALID', groups=4)
+        net = brainstate.nn.Conv2d((200, 198, 4), out_channels=32, kernel_size=(3, 3),
+                                   stride=(2, 1), padding='VALID', groups=4)
         out = net(img)
         print("out shape: ", out.shape)
         self.assertEqual(out.shape, (2, 99, 196, 32))
@@ -30,7 +28,7 @@ class TestConv(parameterized.TestCase):
         # plt.show()
 
     def test_conv1D(self):
-        model = bst.nn.Conv1d((5, 3), out_channels=32, kernel_size=(3,))
+        model = brainstate.nn.Conv1d((5, 3), out_channels=32, kernel_size=(3,))
         input = jnp.ones((2, 5, 3))
         out = model(input)
         print("out shape: ", out.shape)
@@ -41,7 +39,7 @@ class TestConv(parameterized.TestCase):
         # plt.show()
 
     def test_conv2D(self):
-        model = bst.nn.Conv2d((5, 5, 3), out_channels=32, kernel_size=(3, 3))
+        model = brainstate.nn.Conv2d((5, 5, 3), out_channels=32, kernel_size=(3, 3))
         input = jnp.ones((2, 5, 5, 3))
 
         out = model(input)
@@ -49,7 +47,7 @@ class TestConv(parameterized.TestCase):
         self.assertEqual(out.shape, (2, 5, 5, 32))
 
     def test_conv3D(self):
-        model = bst.nn.Conv3d((5, 5, 5, 3), out_channels=32, kernel_size=(3, 3, 3))
+        model = brainstate.nn.Conv3d((5, 5, 5, 3), out_channels=32, kernel_size=(3, 3, 3))
         input = jnp.ones((2, 5, 5, 5, 3))
         out = model(input)
         print("out shape: ", out.shape)
@@ -62,13 +60,13 @@ class TestConvTranspose1d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 3))
         for use_bias in [True, False]:
-            conv_transpose_module = bst.nn.ConvTranspose1d(
+            conv_transpose_module = brainstate.nn.ConvTranspose1d(
                 in_channels=3,
                 out_channels=4,
                 kernel_size=(3,),
                 padding='VALID',
-                w_initializer=bst.init.Constant(1.),
-                b_initializer=bst.init.Constant(1.) if use_bias else None,
+                w_initializer=brainstate.init.Constant(1.),
+                b_initializer=brainstate.init.Constant(1.) if use_bias else None,
             )
             self.assertEqual(conv_transpose_module.w.shape, (3, 3, 4))
             y = conv_transpose_module(x)
@@ -91,14 +89,14 @@ class TestConvTranspose1d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 3))
         m = jnp.tril(jnp.ones((3, 3, 4)))
-        conv_transpose_module = bst.nn.ConvTranspose1d(
+        conv_transpose_module = brainstate.nn.ConvTranspose1d(
             in_channels=3,
             out_channels=4,
             kernel_size=(3,),
             padding='VALID',
             mask=m,
-            w_initializer=bst.init.Constant(),
-            b_initializer=bst.init.Constant(),
+            w_initializer=brainstate.init.Constant(),
+            b_initializer=brainstate.init.Constant(),
         )
         self.assertEqual(conv_transpose_module.w.shape, (3, 3, 4))
         y = conv_transpose_module(x)
@@ -119,14 +117,14 @@ class TestConvTranspose1d(parameterized.TestCase):
 
         data = jnp.ones([1, 3, 1])
         for use_bias in [True, False]:
-            net = bst.nn.ConvTranspose1d(
+            net = brainstate.nn.ConvTranspose1d(
                 in_channels=1,
                 out_channels=1,
                 kernel_size=3,
                 stride=1,
                 padding="SAME",
-                w_initializer=bst.init.Constant(),
-                b_initializer=bst.init.Constant() if use_bias else None,
+                w_initializer=brainstate.init.Constant(),
+                b_initializer=brainstate.init.Constant() if use_bias else None,
             )
             out = net(data)
             self.assertEqual(out.shape, (1, 3, 1))
@@ -143,13 +141,13 @@ class TestConvTranspose2d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 8, 3))
         for use_bias in [True, False]:
-            conv_transpose_module = bst.nn.ConvTranspose2d(
+            conv_transpose_module = brainstate.nn.ConvTranspose2d(
                 in_channels=3,
                 out_channels=4,
                 kernel_size=(3, 3),
                 padding='VALID',
-                w_initializer=bst.init.Constant(),
-                b_initializer=bst.init.Constant() if use_bias else None,
+                w_initializer=brainstate.init.Constant(),
+                b_initializer=brainstate.init.Constant() if use_bias else None,
             )
         self.assertEqual(conv_transpose_module.w.shape, (3, 3, 3, 4))
         y = conv_transpose_module(x)
@@ -159,13 +157,13 @@ class TestConvTranspose2d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 8, 3))
         m = jnp.tril(jnp.ones((3, 3, 3, 4)))
-        conv_transpose_module = bst.nn.ConvTranspose2d(
+        conv_transpose_module = brainstate.nn.ConvTranspose2d(
             in_channels=3,
             out_channels=4,
             kernel_size=(3, 3),
             padding='VALID',
             mask=m,
-            w_initializer=bst.init.Constant(),
+            w_initializer=brainstate.init.Constant(),
         )
         y = conv_transpose_module(x)
         print(y.shape)
@@ -174,14 +172,14 @@ class TestConvTranspose2d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 8, 3))
         for use_bias in [True, False]:
-            conv_transpose_module = bst.nn.ConvTranspose2d(
+            conv_transpose_module = brainstate.nn.ConvTranspose2d(
                 in_channels=3,
                 out_channels=4,
                 kernel_size=(3, 3),
                 stride=1,
                 padding='SAME',
-                w_initializer=bst.init.Constant(),
-                b_initializer=bst.init.Constant() if use_bias else None,
+                w_initializer=brainstate.init.Constant(),
+                b_initializer=brainstate.init.Constant() if use_bias else None,
             )
         y = conv_transpose_module(x)
         print(y.shape)
@@ -193,13 +191,13 @@ class TestConvTranspose3d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 8, 8, 3))
         for use_bias in [True, False]:
-            conv_transpose_module = bst.nn.ConvTranspose3d(
+            conv_transpose_module = brainstate.nn.ConvTranspose3d(
                 in_channels=3,
                 out_channels=4,
                 kernel_size=(3, 3, 3),
                 padding='VALID',
-                w_initializer=bst.init.Constant(),
-                b_initializer=bst.init.Constant() if use_bias else None,
+                w_initializer=brainstate.init.Constant(),
+                b_initializer=brainstate.init.Constant() if use_bias else None,
             )
         y = conv_transpose_module(x)
         print(y.shape)
@@ -208,13 +206,13 @@ class TestConvTranspose3d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 8, 8, 3))
         m = jnp.tril(jnp.ones((3, 3, 3, 3, 4)))
-        conv_transpose_module = bst.nn.ConvTranspose3d(
+        conv_transpose_module = brainstate.nn.ConvTranspose3d(
             in_channels=3,
             out_channels=4,
             kernel_size=(3, 3, 3),
             padding='VALID',
             mask=m,
-            w_initializer=bst.init.Constant(),
+            w_initializer=brainstate.init.Constant(),
         )
         y = conv_transpose_module(x)
         print(y.shape)
@@ -223,14 +221,14 @@ class TestConvTranspose3d(parameterized.TestCase):
 
         x = jnp.ones((1, 8, 8, 8, 3))
         for use_bias in [True, False]:
-            conv_transpose_module = bst.nn.ConvTranspose3d(
+            conv_transpose_module = brainstate.nn.ConvTranspose3d(
                 in_channels=3,
                 out_channels=4,
                 kernel_size=(3, 3, 3),
                 stride=1,
                 padding='SAME',
-                w_initializer=bst.init.Constant(),
-                b_initializer=bst.init.Constant() if use_bias else None,
+                w_initializer=brainstate.init.Constant(),
+                b_initializer=brainstate.init.Constant() if use_bias else None,
             )
         y = conv_transpose_module(x)
         print(y.shape)

--- a/brainstate/nn/_interaction/_linear_test.py
+++ b/brainstate/nn/_interaction/_linear_test.py
@@ -14,14 +14,12 @@
 # ==============================================================================
 
 
-from __future__ import annotations
-
 import unittest
 
 import brainunit as u
 from absl.testing import parameterized
 
-import brainstate as bst
+import brainstate
 
 
 class TestDense(parameterized.TestCase):
@@ -32,19 +30,19 @@ class TestDense(parameterized.TestCase):
         num_out=[20, ]
     )
     def test_Dense1(self, size, num_out):
-        f = bst.nn.Linear(10, num_out)
-        x = bst.random.random(size)
+        f = brainstate.nn.Linear(10, num_out)
+        x = brainstate.random.random(size)
         y = f(x)
         self.assertTrue(y.shape == size[:-1] + (num_out,))
 
 
 class TestSparseMatrix(unittest.TestCase):
     def test_csr(self):
-        data = bst.random.rand(10, 20)
+        data = brainstate.random.rand(10, 20)
         data = data * (data > 0.9)
-        f = bst.nn.SparseLinear(u.sparse.CSR.fromdense(data))
+        f = brainstate.nn.SparseLinear(u.sparse.CSR.fromdense(data))
 
-        x = bst.random.rand(10)
+        x = brainstate.random.rand(10)
         y = f(x)
         self.assertTrue(
             u.math.allclose(
@@ -53,7 +51,7 @@ class TestSparseMatrix(unittest.TestCase):
             )
         )
 
-        x = bst.random.rand(5, 10)
+        x = brainstate.random.rand(5, 10)
         y = f(x)
         self.assertTrue(
             u.math.allclose(
@@ -63,11 +61,11 @@ class TestSparseMatrix(unittest.TestCase):
         )
 
     def test_csc(self):
-        data = bst.random.rand(10, 20)
+        data = brainstate.random.rand(10, 20)
         data = data * (data > 0.9)
-        f = bst.nn.SparseLinear(u.sparse.CSC.fromdense(data))
+        f = brainstate.nn.SparseLinear(u.sparse.CSC.fromdense(data))
 
-        x = bst.random.rand(10)
+        x = brainstate.random.rand(10)
         y = f(x)
         self.assertTrue(
             u.math.allclose(
@@ -76,7 +74,7 @@ class TestSparseMatrix(unittest.TestCase):
             )
         )
 
-        x = bst.random.rand(5, 10)
+        x = brainstate.random.rand(5, 10)
         y = f(x)
         self.assertTrue(
             u.math.allclose(
@@ -86,11 +84,11 @@ class TestSparseMatrix(unittest.TestCase):
         )
 
     def test_coo(self):
-        data = bst.random.rand(10, 20)
+        data = brainstate.random.rand(10, 20)
         data = data * (data > 0.9)
-        f = bst.nn.SparseLinear(u.sparse.COO.fromdense(data))
+        f = brainstate.nn.SparseLinear(u.sparse.COO.fromdense(data))
 
-        x = bst.random.rand(10)
+        x = brainstate.random.rand(10)
         y = f(x)
         self.assertTrue(
             u.math.allclose(
@@ -99,7 +97,7 @@ class TestSparseMatrix(unittest.TestCase):
             )
         )
 
-        x = bst.random.rand(5, 10)
+        x = brainstate.random.rand(5, 10)
         y = f(x)
         self.assertTrue(
             u.math.allclose(

--- a/brainstate/nn/_interaction/_normalizations_test.py
+++ b/brainstate/nn/_interaction/_normalizations_test.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 from absl.testing import absltest
 from absl.testing import parameterized
 
-import brainstate as bst
+import brainstate
 
 
 class Test_Normalization(parameterized.TestCase):
@@ -26,27 +24,27 @@ class Test_Normalization(parameterized.TestCase):
         fit=[True, False],
     )
     def test_BatchNorm1d(self, fit):
-        net = bst.nn.BatchNorm1d((3, 10))
-        bst.environ.set(fit=fit)
-        input = bst.random.randn(1, 3, 10)
+        net = brainstate.nn.BatchNorm1d((3, 10))
+        brainstate.environ.set(fit=fit)
+        input = brainstate.random.randn(1, 3, 10)
         output = net(input)
 
     @parameterized.product(
         fit=[True, False]
     )
     def test_BatchNorm2d(self, fit):
-        net = bst.nn.BatchNorm2d([3, 4, 10])
-        bst.environ.set(fit=fit)
-        input = bst.random.randn(1, 3, 4, 10)
+        net = brainstate.nn.BatchNorm2d([3, 4, 10])
+        brainstate.environ.set(fit=fit)
+        input = brainstate.random.randn(1, 3, 4, 10)
         output = net(input)
 
     @parameterized.product(
         fit=[True, False]
     )
     def test_BatchNorm3d(self, fit):
-        net = bst.nn.BatchNorm3d([3, 4, 5, 10])
-        bst.environ.set(fit=fit)
-        input = bst.random.randn(1, 3, 4, 5, 10)
+        net = brainstate.nn.BatchNorm3d([3, 4, 5, 10])
+        brainstate.environ.set(fit=fit)
+        input = brainstate.random.randn(1, 3, 4, 5, 10)
         output = net(input)
 
     # @parameterized.product(

--- a/brainstate/nn/_interaction/_poolings_test.py
+++ b/brainstate/nn/_interaction/_poolings_test.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import annotations
-
 import jax
 import numpy as np
 from absl.testing import absltest
 from absl.testing import parameterized
 
-import brainstate as bst
+import brainstate
 import brainstate.nn as nn
 
 
@@ -18,7 +16,7 @@ class TestFlatten(parameterized.TestCase):
             (32, 8),
             (10, 20, 30),
         ]:
-            arr = bst.random.rand(*size)
+            arr = brainstate.random.rand(*size)
             f = nn.Flatten(start_axis=0)
             out = f(arr)
             self.assertTrue(out.shape == (np.prod(size),))
@@ -29,21 +27,21 @@ class TestFlatten(parameterized.TestCase):
             (32, 8),
             (10, 20, 30),
         ]:
-            arr = bst.random.rand(*size)
+            arr = brainstate.random.rand(*size)
             f = nn.Flatten(start_axis=1)
             out = f(arr)
             self.assertTrue(out.shape == (size[0], np.prod(size[1:])))
 
     def test_flatten3(self):
         size = (16, 32, 32, 8)
-        arr = bst.random.rand(*size)
+        arr = brainstate.random.rand(*size)
         f = nn.Flatten(start_axis=0, in_size=(32, 8))
         out = f(arr)
         self.assertTrue(out.shape == (16, 32, 32 * 8))
 
     def test_flatten4(self):
         size = (16, 32, 32, 8)
-        arr = bst.random.rand(*size)
+        arr = brainstate.random.rand(*size)
         f = nn.Flatten(start_axis=1, in_size=(32, 32, 8))
         out = f(arr)
         self.assertTrue(out.shape == (16, 32, 32 * 8))
@@ -58,7 +56,7 @@ class TestPool(parameterized.TestCase):
         super().__init__(*args, **kwargs)
 
     def test_MaxPool2d_v1(self):
-        arr = bst.random.rand(16, 32, 32, 8)
+        arr = brainstate.random.rand(16, 32, 32, 8)
 
         out = nn.MaxPool2d(2, 2, channel_axis=-1)(arr)
         self.assertTrue(out.shape == (16, 16, 16, 8))
@@ -79,7 +77,7 @@ class TestPool(parameterized.TestCase):
         self.assertTrue(out.shape == (16, 17, 32, 5))
 
     def test_AvgPool2d_v1(self):
-        arr = bst.random.rand(16, 32, 32, 8)
+        arr = brainstate.random.rand(16, 32, 32, 8)
 
         out = nn.AvgPool2d(2, 2, channel_axis=-1)(arr)
         self.assertTrue(out.shape == (16, 16, 16, 8))
@@ -107,7 +105,7 @@ class TestPool(parameterized.TestCase):
     def test_adaptive_pool1d(self, target_size):
         from brainstate.nn._interaction._poolings import _adaptive_pool1d
 
-        arr = bst.random.rand(100)
+        arr = brainstate.random.rand(100)
         op = jax.numpy.mean
 
         out = _adaptive_pool1d(arr, target_size, op)
@@ -119,7 +117,7 @@ class TestPool(parameterized.TestCase):
         self.assertTrue(out.shape == (target_size,))
 
     def test_AdaptiveAvgPool2d_v1(self):
-        input = bst.random.randn(64, 8, 9)
+        input = brainstate.random.randn(64, 8, 9)
 
         output = nn.AdaptiveAvgPool2d((5, 7), channel_axis=0)(input)
         self.assertTrue(output.shape == (64, 5, 7))
@@ -137,8 +135,8 @@ class TestPool(parameterized.TestCase):
         self.assertTrue(output.shape == (64, 2, 3))
 
     def test_AdaptiveAvgPool2d_v2(self):
-        bst.random.seed()
-        input = bst.random.randn(128, 64, 32, 16)
+        brainstate.random.seed()
+        input = brainstate.random.randn(128, 64, 32, 16)
 
         output = nn.AdaptiveAvgPool2d((5, 7), channel_axis=0)(input)
         self.assertTrue(output.shape == (128, 64, 5, 7))
@@ -154,13 +152,13 @@ class TestPool(parameterized.TestCase):
         print()
 
     def test_AdaptiveAvgPool3d_v1(self):
-        input = bst.random.randn(10, 128, 64, 32)
+        input = brainstate.random.randn(10, 128, 64, 32)
         net = nn.AdaptiveAvgPool3d(target_size=[6, 5, 3], channel_axis=0)
         output = net(input)
         self.assertTrue(output.shape == (10, 6, 5, 3))
 
     def test_AdaptiveAvgPool3d_v2(self):
-        input = bst.random.randn(10, 20, 128, 64, 32)
+        input = brainstate.random.randn(10, 20, 128, 64, 32)
         net = nn.AdaptiveAvgPool3d(target_size=[6, 5, 3])
         output = net(input)
         self.assertTrue(output.shape == (10, 6, 5, 3, 32))
@@ -169,7 +167,7 @@ class TestPool(parameterized.TestCase):
         axis=(-1, 0, 1)
     )
     def test_AdaptiveMaxPool1d_v1(self, axis):
-        input = bst.random.randn(32, 16)
+        input = brainstate.random.randn(32, 16)
         net = nn.AdaptiveMaxPool1d(target_size=4, channel_axis=axis)
         output = net(input)
 
@@ -177,7 +175,7 @@ class TestPool(parameterized.TestCase):
         axis=(-1, 0, 1, 2)
     )
     def test_AdaptiveMaxPool1d_v2(self, axis):
-        input = bst.random.randn(2, 32, 16)
+        input = brainstate.random.randn(2, 32, 16)
         net = nn.AdaptiveMaxPool1d(target_size=4, channel_axis=axis)
         output = net(input)
 
@@ -185,7 +183,7 @@ class TestPool(parameterized.TestCase):
         axis=(-1, 0, 1, 2)
     )
     def test_AdaptiveMaxPool2d_v1(self, axis):
-        input = bst.random.randn(32, 16, 12)
+        input = brainstate.random.randn(32, 16, 12)
         net = nn.AdaptiveAvgPool2d(target_size=[5, 4], channel_axis=axis)
         output = net(input)
 
@@ -193,7 +191,7 @@ class TestPool(parameterized.TestCase):
         axis=(-1, 0, 1, 2, 3)
     )
     def test_AdaptiveMaxPool2d_v2(self, axis):
-        input = bst.random.randn(2, 32, 16, 12)
+        input = brainstate.random.randn(2, 32, 16, 12)
         net = nn.AdaptiveAvgPool2d(target_size=[5, 4], channel_axis=axis)
         output = net(input)
 
@@ -201,7 +199,7 @@ class TestPool(parameterized.TestCase):
         axis=(-1, 0, 1, 2, 3)
     )
     def test_AdaptiveMaxPool3d_v1(self, axis):
-        input = bst.random.randn(2, 128, 64, 32)
+        input = brainstate.random.randn(2, 128, 64, 32)
         net = nn.AdaptiveMaxPool3d(target_size=[6, 5, 4], channel_axis=axis)
         output = net(input)
         print()
@@ -210,7 +208,7 @@ class TestPool(parameterized.TestCase):
         axis=(-1, 0, 1, 2, 3, 4)
     )
     def test_AdaptiveMaxPool3d_v1(self, axis):
-        input = bst.random.randn(2, 128, 64, 32, 16)
+        input = brainstate.random.randn(2, 128, 64, 32, 16)
         net = nn.AdaptiveMaxPool3d(target_size=[6, 5, 4], channel_axis=axis)
         output = net(input)
 

--- a/brainstate/nn/_module_test.py
+++ b/brainstate/nn/_module_test.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 import unittest
 
 import jax.numpy as jnp
-import jaxlib.xla_extension
 
 import brainstate as bst
 
@@ -88,14 +85,14 @@ class TestDelay(unittest.TestCase):
 
         with bst.environ.context(i=0, t=0, jit_error_check=True):
             rotation_delay.retrieve_at_time(-2.0)
-            with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
+            with self.assertRaises(Exception):
                 rotation_delay.retrieve_at_time(-2.1)
             rotation_delay.retrieve_at_time(-2.01)
-            with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
+            with self.assertRaises(Exception):
                 rotation_delay.retrieve_at_time(-2.09)
-            with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
+            with self.assertRaises(Exception):
                 rotation_delay.retrieve_at_time(0.1)
-            with self.assertRaises(jaxlib.xla_extension.XlaRuntimeError):
+            with self.assertRaises(Exception):
                 rotation_delay.retrieve_at_time(0.01)
 
     def test_round_interp(self):

--- a/brainstate/nn/_module_test.py
+++ b/brainstate/nn/_module_test.py
@@ -17,13 +17,13 @@ import unittest
 
 import jax.numpy as jnp
 
-import brainstate as bst
+import brainstate
 
 
 class TestDelay(unittest.TestCase):
     def test_delay1(self):
-        a = bst.State(bst.random.random(10, 20))
-        delay = bst.nn.Delay(a.value)
+        a = brainstate.State(brainstate.random.random(10, 20))
+        delay = brainstate.nn.Delay(a.value)
         delay.register_entry('a', 1.)
         delay.register_entry('b', 2.)
         delay.register_entry('c', None)
@@ -33,7 +33,7 @@ class TestDelay(unittest.TestCase):
             delay.register_entry('c', 10.)
 
     def test_rotation_delay(self):
-        rotation_delay = bst.nn.Delay(jnp.ones((1,)))
+        rotation_delay = brainstate.nn.Delay(jnp.ones((1,)))
         t0 = 0.
         t1, n1 = 1., 10
         t2, n2 = 2., 20
@@ -50,7 +50,7 @@ class TestDelay(unittest.TestCase):
         # print(rotation_delay.max_length)
 
         for i in range(100):
-            bst.environ.set(i=i)
+            brainstate.environ.set(i=i)
             rotation_delay.update(jnp.ones((1,)) * i)
             # print(i, rotation_delay.at('a'), rotation_delay.at('b'), rotation_delay.at('c2'), rotation_delay.at('c'))
             self.assertTrue(jnp.allclose(rotation_delay.at('a'), jnp.ones((1,)) * i))
@@ -58,7 +58,7 @@ class TestDelay(unittest.TestCase):
             self.assertTrue(jnp.allclose(rotation_delay.at('c'), jnp.maximum(jnp.ones((1,)) * i - n2, 0.)))
 
     def test_concat_delay(self):
-        rotation_delay = bst.nn.Delay(jnp.ones([1]), delay_method='concat')
+        rotation_delay = brainstate.nn.Delay(jnp.ones([1]), delay_method='concat')
         t0 = 0.
         t1, n1 = 1., 10
         t2, n2 = 2., 20
@@ -71,7 +71,7 @@ class TestDelay(unittest.TestCase):
 
         print()
         for i in range(100):
-            bst.environ.set(i=i)
+            brainstate.environ.set(i=i)
             rotation_delay.update(jnp.ones((1,)) * i)
             print(i, rotation_delay.at('a'), rotation_delay.at('b'), rotation_delay.at('c'))
             self.assertTrue(jnp.allclose(rotation_delay.at('a'), jnp.ones((1,)) * i))
@@ -80,10 +80,10 @@ class TestDelay(unittest.TestCase):
         # bst.util.clear_buffer_memory()
 
     def test_jit_erro(self):
-        rotation_delay = bst.nn.Delay(jnp.ones([1]), time=2., delay_method='concat', interp_method='round')
+        rotation_delay = brainstate.nn.Delay(jnp.ones([1]), time=2., delay_method='concat', interp_method='round')
         rotation_delay.init_state()
 
-        with bst.environ.context(i=0, t=0, jit_error_check=True):
+        with brainstate.environ.context(i=0, t=0, jit_error_check=True):
             rotation_delay.retrieve_at_time(-2.0)
             with self.assertRaises(Exception):
                 rotation_delay.retrieve_at_time(-2.1)
@@ -98,22 +98,22 @@ class TestDelay(unittest.TestCase):
     def test_round_interp(self):
         for shape in [(1,), (1, 1), (1, 1, 1)]:
             for delay_method in ['rotation', 'concat']:
-                rotation_delay = bst.nn.Delay(jnp.ones(shape), time=2., delay_method=delay_method,
-                                              interp_method='round')
+                rotation_delay = brainstate.nn.Delay(jnp.ones(shape), time=2., delay_method=delay_method,
+                                                     interp_method='round')
                 t0, n1 = 0.01, 0
                 t1, n1 = 1.04, 10
                 t2, n2 = 1.06, 11
                 rotation_delay.init_state()
 
-                @bst.compile.jit
+                @brainstate.compile.jit
                 def retrieve(td, i):
-                    with bst.environ.context(i=i, t=i * bst.environ.get_dt()):
+                    with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
                         return rotation_delay.retrieve_at_time(td)
 
                 print()
                 for i in range(100):
-                    t = i * bst.environ.get_dt()
-                    with bst.environ.context(i=i, t=t):
+                    t = i * brainstate.environ.get_dt()
+                    with brainstate.environ.context(i=i, t=t):
                         rotation_delay.update(jnp.ones(shape) * i)
                         print(i,
                               retrieve(t - t0, i),
@@ -128,22 +128,22 @@ class TestDelay(unittest.TestCase):
             for delay_method in ['rotation', 'concat']:
                 print(shape, delay_method)
 
-                rotation_delay = bst.nn.Delay(jnp.ones(shape), time=2., delay_method=delay_method,
-                                              interp_method='linear_interp')
+                rotation_delay = brainstate.nn.Delay(jnp.ones(shape), time=2., delay_method=delay_method,
+                                                     interp_method='linear_interp')
                 t0, n0 = 0.01, 0.1
                 t1, n1 = 1.04, 10.4
                 t2, n2 = 1.06, 10.6
                 rotation_delay.init_state()
 
-                @bst.compile.jit
+                @brainstate.compile.jit
                 def retrieve(td, i):
-                    with bst.environ.context(i=i, t=i * bst.environ.get_dt()):
+                    with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
                         return rotation_delay.retrieve_at_time(td)
 
                 print()
                 for i in range(100):
-                    t = i * bst.environ.get_dt()
-                    with bst.environ.context(i=i, t=t):
+                    t = i * brainstate.environ.get_dt()
+                    with brainstate.environ.context(i=i, t=t):
                         rotation_delay.update(jnp.ones(shape) * i)
                         print(i,
                               retrieve(t - t0, i),
@@ -154,8 +154,8 @@ class TestDelay(unittest.TestCase):
                         self.assertTrue(jnp.allclose(retrieve(t - t2, i), jnp.maximum(jnp.ones(shape) * i - n2, 0.)))
 
     def test_rotation_and_concat_delay(self):
-        rotation_delay = bst.nn.Delay(jnp.ones((1,)))
-        concat_delay = bst.nn.Delay(jnp.ones([1]), delay_method='concat')
+        rotation_delay = brainstate.nn.Delay(jnp.ones((1,)))
+        concat_delay = brainstate.nn.Delay(jnp.ones([1]), delay_method='concat')
         t0 = 0.
         t1, n1 = 1., 10
         t2, n2 = 2., 20
@@ -172,7 +172,7 @@ class TestDelay(unittest.TestCase):
 
         print()
         for i in range(100):
-            bst.environ.set(i=i)
+            brainstate.environ.set(i=i)
             new = jnp.ones((1,)) * i
             rotation_delay.update(new)
             concat_delay.update(new)
@@ -183,17 +183,17 @@ class TestDelay(unittest.TestCase):
 
 class TestModule(unittest.TestCase):
     def test_states(self):
-        class A(bst.nn.Module):
+        class A(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = bst.State(bst.random.random(10, 20))
-                self.b = bst.State(bst.random.random(10, 20))
+                self.a = brainstate.State(brainstate.random.random(10, 20))
+                self.b = brainstate.State(brainstate.random.random(10, 20))
 
-        class B(bst.nn.Module):
+        class B(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.a = A()
-                self.b = bst.State(bst.random.random(10, 20))
+                self.b = brainstate.State(brainstate.random.random(10, 20))
 
         b = B()
         print()
@@ -204,5 +204,5 @@ class TestModule(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    with bst.environ.context(dt=0.1):
+    with brainstate.environ.context(dt=0.1):
         unittest.main()

--- a/brainstate/optim/_lr_scheduler_test.py
+++ b/brainstate/optim/_lr_scheduler_test.py
@@ -19,12 +19,12 @@ import unittest
 
 import jax.numpy as jnp
 
-import brainstate as bst
+import brainstate
 
 
 class TestMultiStepLR(unittest.TestCase):
     def test1(self):
-        lr = bst.optim.MultiStepLR(0.1, [10, 20, 30], gamma=0.1)
+        lr = brainstate.optim.MultiStepLR(0.1, [10, 20, 30], gamma=0.1)
         for i in range(40):
             r = lr(i)
             if i < 10:
@@ -37,7 +37,7 @@ class TestMultiStepLR(unittest.TestCase):
                 self.assertTrue(jnp.allclose(r, 0.0001))
 
     def test2(self):
-        lr = bst.compile.jit(bst.optim.MultiStepLR(0.1, [10, 20, 30], gamma=0.1))
+        lr = brainstate.compile.jit(brainstate.optim.MultiStepLR(0.1, [10, 20, 30], gamma=0.1))
         for i in range(40):
             r = lr(i)
             if i < 10:

--- a/brainstate/optim/_optax_optimizer_test.py
+++ b/brainstate/optim/_optax_optimizer_test.py
@@ -13,39 +13,38 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
 import jax
 import optax
 
-import brainstate as bst
+import brainstate
 
 
 class TestOptaxOptimizer(unittest.TestCase):
     def test1(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.linear1 = bst.nn.Linear(2, 3)
-                self.linear2 = bst.nn.Linear(3, 4)
+                self.linear1 = brainstate.nn.Linear(2, 3)
+                self.linear2 = brainstate.nn.Linear(3, 4)
 
             def __call__(self, x):
                 return self.linear2(self.linear1(x))
 
-        x = bst.random.randn(1, 2)
+        x = brainstate.random.randn(1, 2)
         y = jax.numpy.ones((1, 4))
 
         model = Model()
         tx = optax.adam(1e-3)
-        optimizer = bst.optim.OptaxOptimizer(tx)
-        optimizer.register_trainable_weights(model.states(bst.ParamState))
+        optimizer = brainstate.optim.OptaxOptimizer(tx)
+        optimizer.register_trainable_weights(model.states(brainstate.ParamState))
 
         loss_fn = lambda: ((model(x) - y) ** 2).mean()
         prev_loss = loss_fn()
 
-        grads = bst.augment.grad(loss_fn, model.states(bst.ParamState))()
+        grads = brainstate.augment.grad(loss_fn, model.states(brainstate.ParamState))()
         optimizer.update(grads)
 
         new_loss = loss_fn()

--- a/brainstate/random/_rand_funs_test.py
+++ b/brainstate/random/_rand_funs_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import platform
 import unittest
@@ -23,110 +22,110 @@ import jax.random as jr
 import numpy as np
 import pytest
 
-import brainstate as bst
+import brainstate
 
 
 class TestRandom(unittest.TestCase):
 
     def test_rand(self):
-        bst.random.seed()
-        a = bst.random.rand(3, 2)
+        brainstate.random.seed()
+        a = brainstate.random.rand(3, 2)
         self.assertTupleEqual(a.shape, (3, 2))
         self.assertTrue((a >= 0).all() and (a < 1).all())
 
         key = jr.PRNGKey(123)
         jres = jr.uniform(key, shape=(10, 100))
-        self.assertTrue(jnp.allclose(jres, bst.random.rand(10, 100, key=key)))
-        self.assertTrue(jnp.allclose(jres, bst.random.rand(10, 100, key=123)))
+        self.assertTrue(jnp.allclose(jres, brainstate.random.rand(10, 100, key=key)))
+        self.assertTrue(jnp.allclose(jres, brainstate.random.rand(10, 100, key=123)))
 
     def test_randint1(self):
-        bst.random.seed()
-        a = bst.random.randint(5)
+        brainstate.random.seed()
+        a = brainstate.random.randint(5)
         self.assertTupleEqual(a.shape, ())
         self.assertTrue(0 <= a < 5)
 
     def test_randint2(self):
-        bst.random.seed()
-        a = bst.random.randint(2, 6, size=(4, 3))
+        brainstate.random.seed()
+        a = brainstate.random.randint(2, 6, size=(4, 3))
         self.assertTupleEqual(a.shape, (4, 3))
         self.assertTrue((a >= 2).all() and (a < 6).all())
 
     def test_randint3(self):
-        bst.random.seed()
-        a = bst.random.randint([1, 2, 3], [10, 7, 8])
+        brainstate.random.seed()
+        a = brainstate.random.randint([1, 2, 3], [10, 7, 8])
         self.assertTupleEqual(a.shape, (3,))
         self.assertTrue((a - jnp.array([1, 2, 3]) >= 0).all()
                         and (-a + jnp.array([10, 7, 8]) > 0).all())
 
     def test_randint4(self):
-        bst.random.seed()
-        a = bst.random.randint([1, 2, 3], [10, 7, 8], size=(2, 3))
+        brainstate.random.seed()
+        a = brainstate.random.randint([1, 2, 3], [10, 7, 8], size=(2, 3))
         self.assertTupleEqual(a.shape, (2, 3))
 
     def test_randn(self):
-        bst.random.seed()
-        a = bst.random.randn(3, 2)
+        brainstate.random.seed()
+        a = brainstate.random.randn(3, 2)
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_random1(self):
-        bst.random.seed()
-        a = bst.random.random()
+        brainstate.random.seed()
+        a = brainstate.random.random()
         self.assertTrue(0. <= a < 1)
 
     def test_random2(self):
-        bst.random.seed()
-        a = bst.random.random(size=(3, 2))
+        brainstate.random.seed()
+        a = brainstate.random.random(size=(3, 2))
         self.assertTupleEqual(a.shape, (3, 2))
         self.assertTrue((a >= 0).all() and (a < 1).all())
 
     def test_random_sample(self):
-        bst.random.seed()
-        a = bst.random.random_sample(size=(3, 2))
+        brainstate.random.seed()
+        a = brainstate.random.random_sample(size=(3, 2))
         self.assertTupleEqual(a.shape, (3, 2))
         self.assertTrue((a >= 0).all() and (a < 1).all())
 
     def test_choice1(self):
-        bst.random.seed()
-        a = bst.random.choice(5)
+        brainstate.random.seed()
+        a = brainstate.random.choice(5)
         self.assertTupleEqual(jnp.shape(a), ())
         self.assertTrue(0 <= a < 5)
 
     def test_choice2(self):
-        bst.random.seed()
-        a = bst.random.choice(5, 3, p=[0.1, 0.4, 0.2, 0., 0.3])
+        brainstate.random.seed()
+        a = brainstate.random.choice(5, 3, p=[0.1, 0.4, 0.2, 0., 0.3])
         self.assertTupleEqual(a.shape, (3,))
         self.assertTrue((a >= 0).all() and (a < 5).all())
 
     def test_choice3(self):
-        bst.random.seed()
-        a = bst.random.choice(jnp.arange(2, 20), size=(4, 3), replace=False)
+        brainstate.random.seed()
+        a = brainstate.random.choice(jnp.arange(2, 20), size=(4, 3), replace=False)
         self.assertTupleEqual(a.shape, (4, 3))
         self.assertTrue((a >= 2).all() and (a < 20).all())
         self.assertEqual(len(jnp.unique(a)), 12)
 
     def test_permutation1(self):
-        bst.random.seed()
-        a = bst.random.permutation(10)
+        brainstate.random.seed()
+        a = brainstate.random.permutation(10)
         self.assertTupleEqual(a.shape, (10,))
         self.assertEqual(len(jnp.unique(a)), 10)
 
     def test_permutation2(self):
-        bst.random.seed()
-        a = bst.random.permutation(jnp.arange(10))
+        brainstate.random.seed()
+        a = brainstate.random.permutation(jnp.arange(10))
         self.assertTupleEqual(a.shape, (10,))
         self.assertEqual(len(jnp.unique(a)), 10)
 
     def test_shuffle1(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = jnp.arange(10)
-        bst.random.shuffle(a)
+        brainstate.random.shuffle(a)
         self.assertTupleEqual(a.shape, (10,))
         self.assertEqual(len(jnp.unique(a)), 10)
 
     def test_shuffle2(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = jnp.arange(12).reshape(4, 3)
-        bst.random.shuffle(a, axis=1)
+        brainstate.random.shuffle(a, axis=1)
         self.assertTupleEqual(a.shape, (4, 3))
         self.assertEqual(len(jnp.unique(a)), 12)
 
@@ -135,173 +134,173 @@ class TestRandom(unittest.TestCase):
         self.assertEqual(uni, jnp.asarray([3]))
 
     def test_beta1(self):
-        bst.random.seed()
-        a = bst.random.beta(2, 2)
+        brainstate.random.seed()
+        a = brainstate.random.beta(2, 2)
         self.assertTupleEqual(a.shape, ())
 
     def test_beta2(self):
-        bst.random.seed()
-        a = bst.random.beta([2, 2, 3], 2, size=(3,))
+        brainstate.random.seed()
+        a = brainstate.random.beta([2, 2, 3], 2, size=(3,))
         self.assertTupleEqual(a.shape, (3,))
 
     def test_exponential1(self):
-        bst.random.seed()
-        a = bst.random.exponential(10., size=[3, 2])
+        brainstate.random.seed()
+        a = brainstate.random.exponential(10., size=[3, 2])
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_exponential2(self):
-        bst.random.seed()
-        a = bst.random.exponential([1., 2., 5.])
+        brainstate.random.seed()
+        a = brainstate.random.exponential([1., 2., 5.])
         self.assertTupleEqual(a.shape, (3,))
 
     def test_gamma(self):
-        bst.random.seed()
-        a = bst.random.gamma(2, 10., size=[3, 2])
+        brainstate.random.seed()
+        a = brainstate.random.gamma(2, 10., size=[3, 2])
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_gumbel(self):
-        bst.random.seed()
-        a = bst.random.gumbel(0., 2., size=[3, 2])
+        brainstate.random.seed()
+        a = brainstate.random.gumbel(0., 2., size=[3, 2])
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_laplace(self):
-        bst.random.seed()
-        a = bst.random.laplace(0., 2., size=[3, 2])
+        brainstate.random.seed()
+        a = brainstate.random.laplace(0., 2., size=[3, 2])
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_logistic(self):
-        bst.random.seed()
-        a = bst.random.logistic(0., 2., size=[3, 2])
+        brainstate.random.seed()
+        a = brainstate.random.logistic(0., 2., size=[3, 2])
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_normal1(self):
-        bst.random.seed()
-        a = bst.random.normal()
+        brainstate.random.seed()
+        a = brainstate.random.normal()
         self.assertTupleEqual(a.shape, ())
 
     def test_normal2(self):
-        bst.random.seed()
-        a = bst.random.normal(loc=[0., 2., 4.], scale=[1., 2., 3.])
+        brainstate.random.seed()
+        a = brainstate.random.normal(loc=[0., 2., 4.], scale=[1., 2., 3.])
         self.assertTupleEqual(a.shape, (3,))
 
     def test_normal3(self):
-        bst.random.seed()
-        a = bst.random.normal(loc=[0., 2., 4.], scale=[[1., 2., 3.], [1., 1., 1.]])
+        brainstate.random.seed()
+        a = brainstate.random.normal(loc=[0., 2., 4.], scale=[[1., 2., 3.], [1., 1., 1.]])
         print(a)
         self.assertTupleEqual(a.shape, (2, 3))
 
     def test_pareto(self):
-        bst.random.seed()
-        a = bst.random.pareto([1, 2, 2])
+        brainstate.random.seed()
+        a = brainstate.random.pareto([1, 2, 2])
         self.assertTupleEqual(a.shape, (3,))
 
     def test_poisson(self):
-        bst.random.seed()
-        a = bst.random.poisson([1., 2., 2.], size=3)
+        brainstate.random.seed()
+        a = brainstate.random.poisson([1., 2., 2.], size=3)
         self.assertTupleEqual(a.shape, (3,))
 
     def test_standard_cauchy(self):
-        bst.random.seed()
-        a = bst.random.standard_cauchy(size=(3, 2))
+        brainstate.random.seed()
+        a = brainstate.random.standard_cauchy(size=(3, 2))
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_standard_exponential(self):
-        bst.random.seed()
-        a = bst.random.standard_exponential(size=(3, 2))
+        brainstate.random.seed()
+        a = brainstate.random.standard_exponential(size=(3, 2))
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_standard_gamma(self):
-        bst.random.seed()
-        a = bst.random.standard_gamma(shape=[1, 2, 4], size=3)
+        brainstate.random.seed()
+        a = brainstate.random.standard_gamma(shape=[1, 2, 4], size=3)
         self.assertTupleEqual(a.shape, (3,))
 
     def test_standard_normal(self):
-        bst.random.seed()
-        a = bst.random.standard_normal(size=(3, 2))
+        brainstate.random.seed()
+        a = brainstate.random.standard_normal(size=(3, 2))
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_standard_t(self):
-        bst.random.seed()
-        a = bst.random.standard_t(df=[1, 2, 4], size=3)
+        brainstate.random.seed()
+        a = brainstate.random.standard_t(df=[1, 2, 4], size=3)
         self.assertTupleEqual(a.shape, (3,))
 
     def test_standard_uniform1(self):
-        bst.random.seed()
-        a = bst.random.uniform()
+        brainstate.random.seed()
+        a = brainstate.random.uniform()
         self.assertTupleEqual(a.shape, ())
         self.assertTrue(0 <= a < 1)
 
     def test_uniform2(self):
-        bst.random.seed()
-        a = bst.random.uniform(low=[-1., 5., 2.], high=[2., 6., 10.], size=3)
+        brainstate.random.seed()
+        a = brainstate.random.uniform(low=[-1., 5., 2.], high=[2., 6., 10.], size=3)
         self.assertTupleEqual(a.shape, (3,))
         self.assertTrue((a - jnp.array([-1., 5., 2.]) >= 0).all()
                         and (-a + jnp.array([2., 6., 10.]) > 0).all())
 
     def test_uniform3(self):
-        bst.random.seed()
-        a = bst.random.uniform(low=-1., high=[2., 6., 10.], size=(2, 3))
+        brainstate.random.seed()
+        a = brainstate.random.uniform(low=-1., high=[2., 6., 10.], size=(2, 3))
         self.assertTupleEqual(a.shape, (2, 3))
 
     def test_uniform4(self):
-        bst.random.seed()
-        a = bst.random.uniform(low=[-1., 5., 2.], high=[[2., 6., 10.], [10., 10., 10.]])
+        brainstate.random.seed()
+        a = brainstate.random.uniform(low=[-1., 5., 2.], high=[[2., 6., 10.], [10., 10., 10.]])
         self.assertTupleEqual(a.shape, (2, 3))
 
     def test_truncated_normal1(self):
-        bst.random.seed()
-        a = bst.random.truncated_normal(-1., 1.)
+        brainstate.random.seed()
+        a = brainstate.random.truncated_normal(-1., 1.)
         self.assertTupleEqual(a.shape, ())
         self.assertTrue(-1. <= a <= 1.)
 
     def test_truncated_normal2(self):
-        bst.random.seed()
-        a = bst.random.truncated_normal(-1., [1., 2., 1.], size=(4, 3))
+        brainstate.random.seed()
+        a = brainstate.random.truncated_normal(-1., [1., 2., 1.], size=(4, 3))
         self.assertTupleEqual(a.shape, (4, 3))
 
     def test_truncated_normal3(self):
-        bst.random.seed()
-        a = bst.random.truncated_normal([-1., 0., 1.], [[2., 2., 4.], [2., 2., 4.]])
+        brainstate.random.seed()
+        a = brainstate.random.truncated_normal([-1., 0., 1.], [[2., 2., 4.], [2., 2., 4.]])
         self.assertTupleEqual(a.shape, (2, 3))
         self.assertTrue((a - jnp.array([-1., 0., 1.]) >= 0.).all()
                         and (- a + jnp.array([2., 2., 4.]) >= 0.).all())
 
     def test_bernoulli1(self):
-        bst.random.seed()
-        a = bst.random.bernoulli()
+        brainstate.random.seed()
+        a = brainstate.random.bernoulli()
         self.assertTupleEqual(a.shape, ())
         self.assertTrue(a == 0 or a == 1)
 
     def test_bernoulli2(self):
-        bst.random.seed()
-        a = bst.random.bernoulli([0.5, 0.6, 0.8])
+        brainstate.random.seed()
+        a = brainstate.random.bernoulli([0.5, 0.6, 0.8])
         self.assertTupleEqual(a.shape, (3,))
         self.assertTrue(jnp.logical_xor(a == 1, a == 0).all())
 
     def test_bernoulli3(self):
-        bst.random.seed()
-        a = bst.random.bernoulli([0.5, 0.6], size=(3, 2))
+        brainstate.random.seed()
+        a = brainstate.random.bernoulli([0.5, 0.6], size=(3, 2))
         self.assertTupleEqual(a.shape, (3, 2))
         self.assertTrue(jnp.logical_xor(a == 1, a == 0).all())
 
     def test_lognormal1(self):
-        bst.random.seed()
-        a = bst.random.lognormal()
+        brainstate.random.seed()
+        a = brainstate.random.lognormal()
         self.assertTupleEqual(a.shape, ())
 
     def test_lognormal2(self):
-        bst.random.seed()
-        a = bst.random.lognormal(sigma=[2., 1.], size=[3, 2])
+        brainstate.random.seed()
+        a = brainstate.random.lognormal(sigma=[2., 1.], size=[3, 2])
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_lognormal3(self):
-        bst.random.seed()
-        a = bst.random.lognormal([2., 0.], [[2., 1.], [3., 1.2]])
+        brainstate.random.seed()
+        a = brainstate.random.lognormal([2., 0.], [[2., 1.], [3., 1.2]])
         self.assertTupleEqual(a.shape, (2, 2))
 
     def test_binomial1(self):
-        bst.random.seed()
-        a = bst.random.binomial(5, 0.5)
+        brainstate.random.seed()
+        a = brainstate.random.binomial(5, 0.5)
         b = np.random.binomial(5, 0.5)
         print(a)
         print(b)
@@ -309,99 +308,99 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(a.dtype, int)
 
     def test_binomial2(self):
-        bst.random.seed()
-        a = bst.random.binomial(5, 0.5, size=(3, 2))
+        brainstate.random.seed()
+        a = brainstate.random.binomial(5, 0.5, size=(3, 2))
         self.assertTupleEqual(a.shape, (3, 2))
         self.assertTrue((a >= 0).all() and (a <= 5).all())
 
     def test_binomial3(self):
-        bst.random.seed()
-        a = bst.random.binomial(n=jnp.asarray([2, 3, 4]), p=jnp.asarray([[0.5, 0.5, 0.5], [0.6, 0.6, 0.6]]))
+        brainstate.random.seed()
+        a = brainstate.random.binomial(n=jnp.asarray([2, 3, 4]), p=jnp.asarray([[0.5, 0.5, 0.5], [0.6, 0.6, 0.6]]))
         self.assertTupleEqual(a.shape, (2, 3))
 
     def test_chisquare1(self):
-        bst.random.seed()
-        a = bst.random.chisquare(3)
+        brainstate.random.seed()
+        a = brainstate.random.chisquare(3)
         self.assertTupleEqual(a.shape, ())
         self.assertTrue(a.dtype, float)
 
     def test_chisquare2(self):
-        bst.random.seed()
+        brainstate.random.seed()
         with self.assertRaises(NotImplementedError):
-            a = bst.random.chisquare(df=[2, 3, 4])
+            a = brainstate.random.chisquare(df=[2, 3, 4])
 
     def test_chisquare3(self):
-        bst.random.seed()
-        a = bst.random.chisquare(df=2, size=100)
+        brainstate.random.seed()
+        a = brainstate.random.chisquare(df=2, size=100)
         self.assertTupleEqual(a.shape, (100,))
 
     def test_chisquare4(self):
-        bst.random.seed()
-        a = bst.random.chisquare(df=2, size=(100, 10))
+        brainstate.random.seed()
+        a = brainstate.random.chisquare(df=2, size=(100, 10))
         self.assertTupleEqual(a.shape, (100, 10))
 
     def test_dirichlet1(self):
-        bst.random.seed()
-        a = bst.random.dirichlet((10, 5, 3))
+        brainstate.random.seed()
+        a = brainstate.random.dirichlet((10, 5, 3))
         self.assertTupleEqual(a.shape, (3,))
 
     def test_dirichlet2(self):
-        bst.random.seed()
-        a = bst.random.dirichlet((10, 5, 3), 20)
+        brainstate.random.seed()
+        a = brainstate.random.dirichlet((10, 5, 3), 20)
         self.assertTupleEqual(a.shape, (20, 3))
 
     def test_f(self):
-        bst.random.seed()
-        a = bst.random.f(1., 48., 100)
+        brainstate.random.seed()
+        a = brainstate.random.f(1., 48., 100)
         self.assertTupleEqual(a.shape, (100,))
 
     def test_geometric(self):
-        bst.random.seed()
-        a = bst.random.geometric([0.7, 0.5, 0.2])
+        brainstate.random.seed()
+        a = brainstate.random.geometric([0.7, 0.5, 0.2])
         self.assertTupleEqual(a.shape, (3,))
 
     def test_hypergeometric1(self):
-        bst.random.seed()
-        a = bst.random.hypergeometric(10, 10, 10, 20)
+        brainstate.random.seed()
+        a = brainstate.random.hypergeometric(10, 10, 10, 20)
         self.assertTupleEqual(a.shape, (20,))
 
     @pytest.mark.skipif(platform.system() == 'Windows', reason='Windows jaxlib error')
     def test_hypergeometric2(self):
-        bst.random.seed()
-        a = bst.random.hypergeometric(8, [10, 4], [[5, 2], [5, 5]])
+        brainstate.random.seed()
+        a = brainstate.random.hypergeometric(8, [10, 4], [[5, 2], [5, 5]])
         self.assertTupleEqual(a.shape, (2, 2))
 
     @pytest.mark.skipif(platform.system() == 'Windows', reason='Windows jaxlib error')
     def test_hypergeometric3(self):
-        bst.random.seed()
-        a = bst.random.hypergeometric(8, [10, 4], [[5, 2], [5, 5]], size=(3, 2, 2))
+        brainstate.random.seed()
+        a = brainstate.random.hypergeometric(8, [10, 4], [[5, 2], [5, 5]], size=(3, 2, 2))
         self.assertTupleEqual(a.shape, (3, 2, 2))
 
     def test_logseries(self):
-        bst.random.seed()
-        a = bst.random.logseries([0.7, 0.5, 0.2], size=[4, 3])
+        brainstate.random.seed()
+        a = brainstate.random.logseries([0.7, 0.5, 0.2], size=[4, 3])
         self.assertTupleEqual(a.shape, (4, 3))
 
     def test_multinominal1(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.multinomial(100, (0.5, 0.2, 0.3), size=[4, 2])
         print(a, a.shape)
-        b = bst.random.multinomial(100, (0.5, 0.2, 0.3), size=[4, 2])
+        b = brainstate.random.multinomial(100, (0.5, 0.2, 0.3), size=[4, 2])
         print(b, b.shape)
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (4, 2, 3))
 
     def test_multinominal2(self):
-        bst.random.seed()
-        a = bst.random.multinomial(100, (0.5, 0.2, 0.3))
+        brainstate.random.seed()
+        a = brainstate.random.multinomial(100, (0.5, 0.2, 0.3))
         self.assertTupleEqual(a.shape, (3,))
         self.assertTrue(a.sum() == 100)
 
     def test_multivariate_normal1(self):
-        bst.random.seed()
+        brainstate.random.seed()
         # self.skipTest('Windows jaxlib error')
         a = np.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], size=3)
-        b = bst.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], size=3)
+        b = brainstate.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], size=3)
         print('test_multivariate_normal1')
         print(a)
         print(b)
@@ -409,156 +408,156 @@ class TestRandom(unittest.TestCase):
         self.assertTupleEqual(a.shape, (3, 2))
 
     def test_multivariate_normal2(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.multivariate_normal([1, 2], [[1, 3], [3, 1]])
-        b = bst.random.multivariate_normal([1, 2], [[1, 3], [3, 1]], method='svd')
+        b = brainstate.random.multivariate_normal([1, 2], [[1, 3], [3, 1]], method='svd')
         print(a)
         print(b)
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(a.shape, (2,))
 
     def test_negative_binomial(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.negative_binomial([3., 10.], 0.5)
-        b = bst.random.negative_binomial([3., 10.], 0.5)
+        b = brainstate.random.negative_binomial([3., 10.], 0.5)
         print(a)
         print(b)
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (2,))
 
     def test_negative_binomial2(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.negative_binomial(3., 0.5, 10)
-        b = bst.random.negative_binomial(3., 0.5, 10)
+        b = brainstate.random.negative_binomial(3., 0.5, 10)
         print(a)
         print(b)
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (10,))
 
     def test_noncentral_chisquare(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.noncentral_chisquare(3, [3., 2.], (4, 2))
-        b = bst.random.noncentral_chisquare(3, [3., 2.], (4, 2))
+        b = brainstate.random.noncentral_chisquare(3, [3., 2.], (4, 2))
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (4, 2))
 
     def test_noncentral_chisquare2(self):
-        bst.random.seed()
-        a = bst.random.noncentral_chisquare(3, [3., 2.])
+        brainstate.random.seed()
+        a = brainstate.random.noncentral_chisquare(3, [3., 2.])
         self.assertTupleEqual(a.shape, (2,))
 
     def test_noncentral_f(self):
-        bst.random.seed()
-        a = bst.random.noncentral_f(3, 20, 3., 100)
+        brainstate.random.seed()
+        a = brainstate.random.noncentral_f(3, 20, 3., 100)
         self.assertTupleEqual(a.shape, (100,))
 
     def test_power(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.power(2, (4, 2))
-        b = bst.random.power(2, (4, 2))
+        b = brainstate.random.power(2, (4, 2))
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (4, 2))
 
     def test_rayleigh(self):
-        bst.random.seed()
-        a = bst.random.power(2., (4, 2))
+        brainstate.random.seed()
+        a = brainstate.random.power(2., (4, 2))
         self.assertTupleEqual(a.shape, (4, 2))
 
     def test_triangular(self):
-        bst.random.seed()
-        a = bst.random.triangular((2, 2))
+        brainstate.random.seed()
+        a = brainstate.random.triangular((2, 2))
         self.assertTupleEqual(a.shape, (2, 2))
 
     def test_vonmises(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.vonmises(2., 2.)
-        b = bst.random.vonmises(2., 2.)
+        b = brainstate.random.vonmises(2., 2.)
         print(a, b)
         self.assertTupleEqual(np.shape(a), b.shape)
         self.assertTupleEqual(b.shape, ())
 
     def test_vonmises2(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.vonmises(2., 2., 10)
-        b = bst.random.vonmises(2., 2., 10)
+        b = brainstate.random.vonmises(2., 2., 10)
         print(a, b)
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (10,))
 
     def test_wald(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.wald([2., 0.5], 2.)
-        b = bst.random.wald([2., 0.5], 2.)
+        b = brainstate.random.wald([2., 0.5], 2.)
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (2,))
 
     def test_wald2(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.wald(2., 2., 100)
-        b = bst.random.wald(2., 2., 100)
+        b = brainstate.random.wald(2., 2., 100)
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (100,))
 
     def test_weibull(self):
-        bst.random.seed()
-        a = bst.random.weibull(2., (4, 2))
+        brainstate.random.seed()
+        a = brainstate.random.weibull(2., (4, 2))
         self.assertTupleEqual(a.shape, (4, 2))
 
     def test_weibull2(self):
-        bst.random.seed()
-        a = bst.random.weibull(2., )
+        brainstate.random.seed()
+        a = brainstate.random.weibull(2., )
         self.assertTupleEqual(a.shape, ())
 
     def test_weibull3(self):
-        bst.random.seed()
-        a = bst.random.weibull([2., 3.], )
+        brainstate.random.seed()
+        a = brainstate.random.weibull([2., 3.], )
         self.assertTupleEqual(a.shape, (2,))
 
     def test_weibull_min(self):
-        bst.random.seed()
-        a = bst.random.weibull_min(2., 2., (4, 2))
+        brainstate.random.seed()
+        a = brainstate.random.weibull_min(2., 2., (4, 2))
         self.assertTupleEqual(a.shape, (4, 2))
 
     def test_weibull_min2(self):
-        bst.random.seed()
-        a = bst.random.weibull_min(2., 2.)
+        brainstate.random.seed()
+        a = brainstate.random.weibull_min(2., 2.)
         self.assertTupleEqual(a.shape, ())
 
     def test_weibull_min3(self):
-        bst.random.seed()
-        a = bst.random.weibull_min([2., 3.], 2.)
+        brainstate.random.seed()
+        a = brainstate.random.weibull_min([2., 3.], 2.)
         self.assertTupleEqual(a.shape, (2,))
 
     def test_zipf(self):
-        bst.random.seed()
-        a = bst.random.zipf(2., (4, 2))
+        brainstate.random.seed()
+        a = brainstate.random.zipf(2., (4, 2))
         self.assertTupleEqual(a.shape, (4, 2))
 
     def test_zipf2(self):
-        bst.random.seed()
+        brainstate.random.seed()
         a = np.random.zipf([1.1, 2.])
-        b = bst.random.zipf([1.1, 2.])
+        b = brainstate.random.zipf([1.1, 2.])
         self.assertTupleEqual(a.shape, b.shape)
         self.assertTupleEqual(b.shape, (2,))
 
     def test_maxwell(self):
-        bst.random.seed()
-        a = bst.random.maxwell(10)
+        brainstate.random.seed()
+        a = brainstate.random.maxwell(10)
         self.assertTupleEqual(a.shape, (10,))
 
     def test_maxwell2(self):
-        bst.random.seed()
-        a = bst.random.maxwell()
+        brainstate.random.seed()
+        a = brainstate.random.maxwell()
         self.assertTupleEqual(a.shape, ())
 
     def test_t(self):
-        bst.random.seed()
-        a = bst.random.t(1., size=10)
+        brainstate.random.seed()
+        a = brainstate.random.t(1., size=10)
         self.assertTupleEqual(a.shape, (10,))
 
     def test_t2(self):
-        bst.random.seed()
-        a = bst.random.t([1., 2.], size=None)
+        brainstate.random.seed()
+        a = brainstate.random.t([1., 2.], size=None)
         self.assertTupleEqual(a.shape, (2,))
 
 # class TestRandomKey(unittest.TestCase):

--- a/brainstate/random/_rand_seed_test.py
+++ b/brainstate/random/_rand_seed_test.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
-
 import unittest
 
 import jax.numpy as jnp
 import jax.random
 
-import brainstate as bst
+import brainstate
 
 
 class TestRandom(unittest.TestCase):
@@ -28,23 +26,23 @@ class TestRandom(unittest.TestCase):
     def test_seed2(self):
         test_seed = 299
         key = jax.random.PRNGKey(test_seed)
-        bst.random.seed(key)
+        brainstate.random.seed(key)
 
         @jax.jit
         def jit_seed(key):
-            bst.random.seed(key)
-            with bst.random.seed_context(key):
-                print(bst.random.DEFAULT.value)
+            brainstate.random.seed(key)
+            with brainstate.random.seed_context(key):
+                print(brainstate.random.DEFAULT.value)
 
         jit_seed(key)
         jit_seed(1)
         jit_seed(None)
-        bst.random.seed(1)
+        brainstate.random.seed(1)
 
     def test_seed(self):
         test_seed = 299
-        bst.random.seed(test_seed)
-        a = bst.random.rand(3)
-        bst.random.seed(test_seed)
-        b = bst.random.rand(3)
+        brainstate.random.seed(test_seed)
+        a = brainstate.random.rand(3)
+        brainstate.random.seed(test_seed)
+        b = brainstate.random.rand(3)
         self.assertTrue(jnp.array_equal(a, b))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 jax
 jaxlib
-brainunit>=0.0.4
+brainunit>=0.0.13
 brainevent


### PR DESCRIPTION
## Summary by Sourcery

Add a new CI matrix job to validate JAX compatibility on macOS with Python 3.12, bump the brainunit dependency, and refine internal wrap_init handling.

Enhancements:
- Expose wrap_init in the compatible imports list
- Refactor wrap_init invocation in make_jaxpr to use explicit module path
- Bump brainunit requirement to >=0.0.13

CI:
- Add test_jax_version GitHub Actions job to run tests against JAX versions 0.4.38, 0.5.2, and 0.6.0 on macOS with Python 3.12