### PR TITLE
Standardize 'brainstate' import alias

### DIFF
--- a/benchmark/CUBA_2005.py
+++ b/benchmark/CUBA_2005.py
@@ -86,7 +86,7 @@ def run(scale: float):
     with brainstate.environ.context(dt=0.1 * u.ms):
         times = u.math.arange(0. * u.ms, duration, brainstate.environ.get_dt())
         brainstate.compile.for_loop(lambda t: net.update(t, 20. * u.mA), times,
-                                    # pbar=bst.compile.ProgressBar(100)
+                                    # pbar=brainstate.compile.ProgressBar(100)
                                     )
 
     return net.num, net.rate.value.sum() / net.num / duration.to_decimal(u.second)

--- a/brainstate/__init__.py
+++ b/brainstate/__init__.py
@@ -17,7 +17,7 @@
 A ``State``-based Transformation System for Program Compilation and Augmentation
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 from . import augment
 from . import compile

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -116,10 +116,10 @@ def check_state_value_tree(val: bool = True) -> Generator[None, None, None]:
 
     Example::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax.numpy as jnp
-      >>> state = bst.ShortTermState(jnp.zeros((2, 3)))
-      >>> with bst.check_state_value_tree():
+      >>> state = brainstate.ShortTermState(jnp.zeros((2, 3)))
+      >>> with brainstate.check_state_value_tree():
       >>>   # The line below will not raise an error.
       >>>   state.value = jnp.zeros((2, 3))
       ...
@@ -163,10 +163,10 @@ def check_state_jax_tracer(val: bool = True) -> Generator[None, None, None]:
     Example::
 
       >>> import jax
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax.numpy as jnp
       >>>
-      >>> a = bst.ShortTermState(jnp.zeros((2, 3)))
+      >>> a = brainstate.ShortTermState(jnp.zeros((2, 3)))
       >>>
       >>> @jax.jit
       >>> def run_state(b):

--- a/brainstate/augment/_autograd_test.py
+++ b/brainstate/augment/_autograd_test.py
@@ -619,7 +619,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.array([1., 2., 3.])
 #     _y = jnp.array([10., 5.])
 #
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.array([1., 2., 3.]))
@@ -635,12 +635,12 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     _jr = jax.jacfwd(f1)(_x, _y)
 #     t = Test()
-#     br = bst.augment.jacfwd(t, grad_states=t.x)()
+#     br = brainstate.augment.jacfwd(t, grad_states=t.x)()
 #     self.assertTrue((br == _jr).all())
 #
 #     _jr = jax.jacfwd(f1, argnums=(0, 1))(_x, _y)
 #     t = Test()
-#     br = bst.augment.jacfwd(t, grad_states=[t.x, t.y])()
+#     br = brainstate.augment.jacfwd(t, grad_states=[t.x, t.y])()
 #     self.assertTrue((br[0] == _jr[0]).all())
 #     self.assertTrue((br[1] == _jr[1]).all())
 #
@@ -652,7 +652,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.array([1., 2., 3.])
 #     _y = jnp.array([10., 5.])
 #
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.array([1., 2., 3.]))
@@ -667,12 +667,12 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     _jr = jax.jacrev(f1)(_x, _y)
 #     t = Test()
-#     br = bst.augment.jacrev(t, grad_states=t.x)(_y)
+#     br = brainstate.augment.jacrev(t, grad_states=t.x)(_y)
 #     self.assertTrue((br == _jr).all())
 #
 #     _jr = jax.jacrev(f1, argnums=(0, 1))(_x, _y)
 #     t = Test()
-#     var_grads, arg_grads = bst.augment.jacrev(t, grad_states=t.x, argnums=0)(_y)
+#     var_grads, arg_grads = brainstate.augment.jacrev(t, grad_states=t.x, argnums=0)(_y)
 #     print(var_grads, )
 #     print(arg_grads, )
 #     self.assertTrue((var_grads == _jr[0]).all())
@@ -686,7 +686,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.array([1., 2., 3.])
 #     _y = jnp.array([10., 5.])
 #
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.array([1., 2., 3.]))
@@ -701,12 +701,12 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     _jr = jax.jacfwd(f1)(_x, _y)
 #     t = Test()
-#     br = bst.augment.jacfwd(t, grad_states=t.x)(_y)
+#     br = brainstate.augment.jacfwd(t, grad_states=t.x)(_y)
 #     self.assertTrue((br == _jr).all())
 #
 #     _jr = jax.jacfwd(f1, argnums=(0, 1))(_x, _y)
 #     t = Test()
-#     var_grads, arg_grads = bst.augment.jacfwd(t, grad_states=t.x, argnums=0)(_y)
+#     var_grads, arg_grads = brainstate.augment.jacfwd(t, grad_states=t.x, argnums=0)(_y)
 #     print(var_grads, )
 #     print(arg_grads, )
 #     self.assertTrue((var_grads == _jr[0]).all())
@@ -722,7 +722,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.array([1., 2., 3.])
 #     _y = jnp.array([10., 5.])
 #
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.array([1., 2., 3.]))
@@ -737,13 +737,13 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     _jr = jax.jacrev(f1)(_x, _y)
 #     t = Test()
-#     br, _ = bst.augment.jacrev(t, grad_states=t.x, has_aux=True)(_y)
+#     br, _ = brainstate.augment.jacrev(t, grad_states=t.x, has_aux=True)(_y)
 #     self.assertTrue((br == _jr).all())
 #
 #     t = Test()
 #     _jr = jax.jacrev(f1, argnums=(0, 1))(_x, _y)
 #     _aux = t(_y)[1]
-#     (var_grads, arg_grads), aux = bst.augment.jacrev(t, grad_states=t.x, argnums=0, has_aux=True)(_y)
+#     (var_grads, arg_grads), aux = brainstate.augment.jacrev(t, grad_states=t.x, argnums=0, has_aux=True)(_y)
 #     print(var_grads, )
 #     print(arg_grads, )
 #     self.assertTrue((var_grads == _jr[0]).all())
@@ -762,7 +762,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.array([1., 2., 3.])
 #     _y = jnp.array([10., 5.])
 #
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.array([1., 2., 3.]))
@@ -777,7 +777,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     _jr = jax.jacfwd(f1)(_x, _y)
 #     t = Test()
-#     br, (c, d) = bst.augment.jacfwd(t, grad_states=t.x, has_aux=True)(_y)
+#     br, (c, d) = brainstate.augment.jacfwd(t, grad_states=t.x, has_aux=True)(_y)
 #     # print(_jr)
 #     # print(br)
 #     a = (br == _jr)
@@ -786,7 +786,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     t = Test()
 #     _jr = jax.jacfwd(f1, argnums=(0, 1))(_x, _y)
 #     _aux = t(_y)[1]
-#     (var_grads, arg_grads), aux = bst.augment.jacfwd(t, grad_states=t.x, argnums=0, has_aux=True)(_y)
+#     (var_grads, arg_grads), aux = brainstate.augment.jacfwd(t, grad_states=t.x, argnums=0, has_aux=True)(_y)
 #     print(var_grads, )
 #     print(arg_grads, )
 #     self.assertTrue((var_grads == _jr[0]).all())
@@ -805,7 +805,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.array([1., 2., 3.])
 #     _y = jnp.array([10., 5.])
 #
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.array([1., 2., 3.]))
@@ -820,13 +820,13 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     _jr = jax.jacrev(f1)(_x, _y)
 #     t = Test()
-#     br, _ = bst.augment.jacrev(t, grad_states=t.x, has_aux=True)(_y)
+#     br, _ = brainstate.augment.jacrev(t, grad_states=t.x, has_aux=True)(_y)
 #     self.assertTrue((br == _jr).all())
 #
 #     t = Test()
 #     _jr = jax.jacrev(f1, argnums=(0, 1))(_x, _y)
 #     _val, _aux = t(_y)
-#     (var_grads, arg_grads), value, aux = bst.augment.jacrev(t, grad_states=t.x, argnums=0, has_aux=True, return_value=True)(_y)
+#     (var_grads, arg_grads), value, aux = brainstate.augment.jacrev(t, grad_states=t.x, argnums=0, has_aux=True, return_value=True)(_y)
 #     print(var_grads, )
 #     print(arg_grads, )
 #     self.assertTrue((var_grads == _jr[0]).all())
@@ -846,7 +846,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.array([1., 2., 3.])
 #     _y = jnp.array([10., 5.])
 #
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.array([1., 2., 3.]))
@@ -861,13 +861,13 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     _jr = jax.jacfwd(f1)(_x, _y)
 #     t = Test()
-#     br, _ = bst.augment.jacfwd(t, grad_states=t.x, has_aux=True)(_y)
+#     br, _ = brainstate.augment.jacfwd(t, grad_states=t.x, has_aux=True)(_y)
 #     self.assertTrue((br == _jr).all())
 #
 #     t = Test()
 #     _jr = jax.jacfwd(f1, argnums=(0, 1))(_x, _y)
 #     _val, _aux = t(_y)
-#     (var_grads, arg_grads), value, aux = bst.augment.jacfwd(t, grad_states=t.x, argnums=0, has_aux=True, return_value=True)(_y)
+#     (var_grads, arg_grads), value, aux = brainstate.augment.jacfwd(t, grad_states=t.x, argnums=0, has_aux=True, return_value=True)(_y)
 #     print(_val, )
 #     print('_aux: ', _aux, 'aux: ', aux)
 #     print(var_grads, )
@@ -884,7 +884,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #   def test1(self):
 #     f = lambda x: 3 * x ** 2
 #     _x = jnp.ones(10)
-#     pprint(bst.augment.vector_grad(f, argnums=0)(_x))
+#     pprint(brainstate.augment.vector_grad(f, argnums=0)(_x))
 #
 #   def test2(self):
 #     def f(x, y):
@@ -894,14 +894,14 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.ones(5)
 #     _y = jnp.ones(5)
 #
-#     g = bst.augment.vector_grad(f, argnums=0)(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=0)(_x, _y)
 #     pprint(g)
 #     self.assertTrue(jnp.array_equal(g, 2 * _x))
 #
-#     g = bst.augment.vector_grad(f, argnums=(0,))(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=(0,))(_x, _y)
 #     self.assertTrue(jnp.array_equal(g[0], 2 * _x))
 #
-#     g = bst.augment.vector_grad(f, argnums=(0, 1))(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=(0, 1))(_x, _y)
 #     pprint(g)
 #     self.assertTrue(jnp.array_equal(g[0], 2 * _x))
 #     self.assertTrue(jnp.array_equal(g[1], 2 * _y))
@@ -915,14 +915,14 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.ones(5)
 #     _y = jnp.ones(5)
 #
-#     g = bst.augment.vector_grad(f, argnums=0)(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=0)(_x, _y)
 #     # pprint(g)
 #     self.assertTrue(jnp.array_equal(g, 2 * _x + 3 * _x ** 2))
 #
-#     g = bst.augment.vector_grad(f, argnums=(0,))(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=(0,))(_x, _y)
 #     self.assertTrue(jnp.array_equal(g[0], 2 * _x + 3 * _x ** 2))
 #
-#     g = bst.augment.vector_grad(f, argnums=(0, 1))(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=(0, 1))(_x, _y)
 #     # pprint(g)
 #     self.assertTrue(jnp.array_equal(g[0], 2 * _x + 3 * _x ** 2))
 #     self.assertTrue(jnp.array_equal(g[1], 2 * _y + 3 * _y ** 2))
@@ -935,14 +935,14 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.ones((5, 5))
 #     _y = jnp.ones((5, 5))
 #
-#     g = bst.augment.vector_grad(f, argnums=0)(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=0)(_x, _y)
 #     pprint(g)
 #     self.assertTrue(jnp.array_equal(g, 2 * _x))
 #
-#     g = bst.augment.vector_grad(f, argnums=(0,))(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=(0,))(_x, _y)
 #     self.assertTrue(jnp.array_equal(g[0], 2 * _x))
 #
-#     g = bst.augment.vector_grad(f, argnums=(0, 1))(_x, _y)
+#     g = brainstate.augment.vector_grad(f, argnums=(0, 1))(_x, _y)
 #     pprint(g)
 #     self.assertTrue(jnp.array_equal(g[0], 2 * _x))
 #     self.assertTrue(jnp.array_equal(g[1], 2 * _y))
@@ -956,7 +956,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.ones(5)
 #     _y = jnp.ones(5)
 #
-#     g, aux = bst.augment.vector_grad(f, has_aux=True)(_x, _y)
+#     g, aux = brainstate.augment.vector_grad(f, has_aux=True)(_x, _y)
 #     pprint(g, )
 #     pprint(aux)
 #     self.assertTrue(jnp.array_equal(g, 2 * _x))
@@ -970,7 +970,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.ones(5)
 #     _y = jnp.ones(5)
 #
-#     g, value = bst.augment.vector_grad(f, return_value=True)(_x, _y)
+#     g, value = brainstate.augment.vector_grad(f, return_value=True)(_x, _y)
 #     pprint(g, )
 #     pprint(value)
 #     self.assertTrue(jnp.array_equal(g, 2 * _x))
@@ -985,7 +985,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #     _x = jnp.ones(5)
 #     _y = jnp.ones(5)
 #
-#     g, value, aux = bst.augment.vector_grad(f, has_aux=True, return_value=True)(_x, _y)
+#     g, value, aux = brainstate.augment.vector_grad(f, has_aux=True, return_value=True)(_x, _y)
 #     print('grad', g)
 #     print('value', value)
 #     print('aux', aux)
@@ -996,7 +996,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 # class TestClassFuncVectorGrad(unittest.TestCase):
 #   def test1(self):
-#     class Test(bst.nn.Module):
+#     class Test(brainstate.nn.Module):
 #       def __init__(self):
 #         super(Test, self).__init__()
 #         self.x = jnp.Variable(jnp.ones(5))
@@ -1007,13 +1007,13 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #     t = Test()
 #
-#     g = bst.augment.vector_grad(t, grad_states=t.x)()
+#     g = brainstate.augment.vector_grad(t, grad_states=t.x)()
 #     self.assertTrue(jnp.array_equal(g, 2 * t.x))
 #
-#     g = bst.augment.vector_grad(t, grad_states=(t.x,))()
+#     g = brainstate.augment.vector_grad(t, grad_states=(t.x,))()
 #     self.assertTrue(jnp.array_equal(g[0], 2 * t.x))
 #
-#     g = bst.augment.vector_grad(t, grad_states=(t.x, t.y))()
+#     g = brainstate.augment.vector_grad(t, grad_states=(t.x, t.y))()
 #     self.assertTrue(jnp.array_equal(g[0], 2 * t.x))
 #     self.assertTrue(jnp.array_equal(g[1], 2 * t.y))
 #
@@ -1025,20 +1025,20 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 # class TestDebug(parameterized.TestCase):
 #   def test_debug1(self):
-#     a = bst.random.RandomState()
+#     a = brainstate.random.RandomState()
 #
 #     def f(b):
 #       print(a.value)
 #       return a + b + a.random()
 #
-#     f = bst.augment.vector_grad(f, argnums=0)
+#     f = brainstate.augment.vector_grad(f, argnums=0)
 #     f(1.)
 #
 #     with jax.disable_jit():
 #       f(1.)
 #
 #   @parameterized.product(
-#     grad_fun=[bst.augment.grad, bst.augment.vector_grad]
+#     grad_fun=[brainstate.augment.grad, brainstate.augment.vector_grad]
 #   )
 #   def test_print_info1(self, grad_fun):
 #     file = tempfile.TemporaryFile(mode='w+')
@@ -1075,7 +1075,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #       self.assertTrue(file.read().strip() == expect_res.strip())
 #
 #   @parameterized.product(
-#     grad_fun=[bst.augment.grad, bst.augment.vector_grad]
+#     grad_fun=[brainstate.augment.grad, brainstate.augment.vector_grad]
 #   )
 #   def test_print_info2(self, grad_fun):
 #     file = tempfile.TemporaryFile(mode='w+')
@@ -1117,7 +1117,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #       a = jnp.Variable(jnp.ones(2))
 #       b = jnp.Variable(jnp.zeros(2))
 #
-#       @bst.augment.vector_grad(argnums=0)
+#       @brainstate.augment.vector_grad(argnums=0)
 #       def f1(c):
 #         a.value += 1
 #         b.value += 10
@@ -1149,7 +1149,7 @@ class TestClassFuncJacobian(unittest.TestCase):
 #
 #
 #     def run_fun(d):
-#       @bst.augment.vector_grad(argnums=0)
+#       @brainstate.augment.vector_grad(argnums=0)
 #       def f1(c):
 #         a.value += d
 #         b.value += 10
@@ -1178,8 +1178,8 @@ class TestClassFuncJacobian(unittest.TestCase):
 #         print('compiling f ...', file=file)
 #         return a + b
 #
-#       grad1 = bst.augment.grad(f)(1., 2.)  # call "f" twice, one for Variable finding, one for compiling
-#       grad2 = bst.augment.vector_grad(f)(1., 2.)  # call "f" once for compiling
+#       grad1 = brainstate.augment.grad(f)(1., 2.)  # call "f" twice, one for Variable finding, one for compiling
+#       grad2 = brainstate.augment.vector_grad(f)(1., 2.)  # call "f" once for compiling
 #
 #       file.seek(0)
 #       print(file.read().strip())

--- a/brainstate/augment/_eval_shape.py
+++ b/brainstate/augment/_eval_shape.py
@@ -40,13 +40,13 @@ def abstract_init(
 
     Here's an example::
 
-        >>> import brainstate as bst
+        >>> import brainstate
         >>> class MLP:
         ...     def __init__(self, n_in, n_mid, n_out):
-        ...         self.dense1 = bst.nn.Linear(n_in, n_mid)
-        ...         self.dense2 = bst.nn.Linear(n_mid, n_out)
+        ...         self.dense1 = brainstate.nn.Linear(n_in, n_mid)
+        ...         self.dense2 = brainstate.nn.Linear(n_mid, n_out)
 
-        >>> r = bst.augment.abstract_init(lambda: MLP(1, 2, 3))
+        >>> r = brainstate.augment.abstract_init(lambda: MLP(1, 2, 3))
         >>> r
         MLP(
           dense1=Linear(

--- a/brainstate/augment/_mapping.py
+++ b/brainstate/augment/_mapping.py
@@ -615,16 +615,16 @@ def vmap(
 
     These are several example usage::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> import jax.numpy as jnp
 
-        >>> class Model(bst.nn.Module):
+        >>> class Model(brainstate.nn.Module):
         >>>     def __init__(self):
         >>>         super().__init__()
         >>>
-        >>>         self.a = bst.ShortTermState(bst.random.randn(5))
-        >>>         self.b = bst.ShortTermState(bst.random.randn(5))
-        >>>         self.c = bst.State(bst.random.randn(1))
+        >>>         self.a = brainstate.ShortTermState(brainstate.random.randn(5))
+        >>>         self.b = brainstate.ShortTermState(brainstate.random.randn(5))
+        >>>         self.c = brainstate.State(brainstate.random.randn(1))
 
         >>>     def __call__(self, *args, **kwargs):
         >>>         self.c.value = self.a.value * self.b.value
@@ -632,9 +632,9 @@ def vmap(
 
         >>> model = Model()
 
-        >>> r = bst.augment.vmap(
+        >>> r = brainstate.augment.vmap(
         >>>     model,
-        >>>     in_states=model.states(bst.ShortTermState),
+        >>>     in_states=model.states(brainstate.ShortTermState),
         >>>     out_states=model.c
         >>> )()
 

--- a/brainstate/compile/_conditions.py
+++ b/brainstate/compile/_conditions.py
@@ -203,9 +203,9 @@ def ifelse(conditions, branches, *operands, check_cond: bool = True):
     Examples
     --------
 
-    >>> import brainstate as bst
+    >>> import brainstate
     >>> def f(a):
-    >>>    return bst.compile.ifelse(conditions=[a > 10, a > 5, a > 2, a > 0],
+    >>>    return brainstate.compile.ifelse(conditions=[a > 10, a > 5, a > 2, a > 0],
     >>>                               branches=[lambda: 1,
     >>>                                         lambda: 2,
     >>>                                         lambda: 3,

--- a/brainstate/compile/_make_jaxpr.py
+++ b/brainstate/compile/_make_jaxpr.py
@@ -370,7 +370,7 @@ class StatefulFunction(PrettyObject):
                     static_args.append(arg)
                 else:
                     dyn_args.append(arg)
-            dyn_args = jax.tree.map(shaped_abstractify, jax.tree.leaves(dyn_args))
+            dyn_args = jax.tree.map(shaped_abstractify, dyn_args)
             static_kwargs, dyn_kwargs = [], []
             for k, v in kwargs.items():
                 if k in self.static_argnames:

--- a/brainstate/compile/_make_jaxpr.py
+++ b/brainstate/compile/_make_jaxpr.py
@@ -637,15 +637,15 @@ def make_jaxpr(
     instead give a few examples.
 
     >>> import jax
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>>
     >>> def f(x): return jax.numpy.sin(jax.numpy.cos(x))
     >>> print(f(3.0))
     -0.83602
-    >>> jaxpr, states = bst.compile.make_jaxpr(f)(3.0)
+    >>> jaxpr, states = brainstate.compile.make_jaxpr(f)(3.0)
     >>> jaxpr
     { lambda ; a:f32[]. let b:f32[] = cos a; c:f32[] = sin b in (c,) }
-    >>> jaxpr, states = bst.compile.make_jaxpr(jax.grad(f))(3.0)
+    >>> jaxpr, states = brainstate.compile.make_jaxpr(jax.grad(f))(3.0)
     >>> jaxpr
     { lambda ; a:f32[]. let
         b:f32[] = cos a

--- a/brainstate/compile/_progress_bar.py
+++ b/brainstate/compile/_progress_bar.py
@@ -53,7 +53,7 @@ class ProgressBar(object):
 
     .. code-block:: python
 
-                a = bst.State(1.)
+                a = brainstate.State(1.)
                 def loop_fn(x):
                     a.value = x.value + 1.
                     return jnp.sum(x ** 2)
@@ -61,7 +61,7 @@ class ProgressBar(object):
                 pbar = ProgressBar(desc=("Running {i} iterations, loss = {loss}",
                                          lambda i_carray_y: {"i": i_carray_y["i"], "loss": i_carray_y["y"]}))
 
-                bst.compile.for_loop(loop_fn, xs, pbar=pbar)
+                brainstate.compile.for_loop(loop_fn, xs, pbar=pbar)
 
     In this example, ``"i"`` denotes the iteration number and ``"loss"`` is computed from the output,
     the ``"carry"`` is the dynamic state in the loop, for example ``a.value`` in this case.

--- a/brainstate/environ.py
+++ b/brainstate/environ.py
@@ -76,9 +76,9 @@ def context(**kwargs):
 
     For instance::
 
-    >>> import brainstate as bst
-    >>> with bst.environ.context(dt=0.1) as env:
-    ...     dt = bst.environ.get('dt')
+    >>> import brainstate as brainstate
+    >>> with brainstate.environ.context(dt=0.1) as env:
+    ...     dt = brainstate.environ.get('dt')
     ...     print(env)
 
     """
@@ -424,10 +424,10 @@ def dftype() -> DTypeLike:
 
     For example, if the precision is set to 32, the default floating data type is ``np.float32``.
 
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> import numpy as np
-    >>> with bst.environ.context(precision=32):
-    ...    a = np.zeros(1, dtype=bst.environ.dftype())
+    >>> with brainstate.environ.context(precision=32):
+    ...    a = np.zeros(1, dtype=brainstate.environ.dftype())
     >>> print(a.dtype)
 
     Returns
@@ -448,10 +448,10 @@ def ditype() -> DTypeLike:
 
     For example, if the precision is set to 32, the default integer data type is ``np.int32``.
 
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> import numpy as np
-    >>> with bst.environ.context(precision=32):
-    ...    a = np.zeros(1, dtype=bst.environ.ditype())
+    >>> with brainstate.environ.context(precision=32):
+    ...    a = np.zeros(1, dtype=brainstate.environ.ditype())
     >>> print(a.dtype)
     int32
 
@@ -474,10 +474,10 @@ def dutype() -> DTypeLike:
 
     For example, if the precision is set to 32, the default unsigned integer data type is ``np.uint32``.
 
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> import numpy as np
-    >>> with bst.environ.context(precision=32):
-    ...   a = np.zeros(1, dtype=bst.environ.dutype())
+    >>> with brainstate.environ.context(precision=32):
+    ...   a = np.zeros(1, dtype=brainstate.environ.dutype())
     >>> print(a.dtype)
     uint32
 
@@ -499,10 +499,10 @@ def dctype() -> DTypeLike:
 
     For example, if the precision is set to 32, the default complex data type is ``np.complex64``.
 
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> import numpy as np
-    >>> with bst.environ.context(precision=32):
-    ...    a = np.zeros(1, dtype=bst.environ.dctype())
+    >>> with brainstate.environ.context(precision=32):
+    ...    a = np.zeros(1, dtype=brainstate.environ.dctype())
     >>> print(a.dtype)
     complex64
 
@@ -529,19 +529,19 @@ def register_default_behavior(key: str, behavior: Callable, replace_if_exist: bo
 
     For example, you can register a default behavior for the key 'dt' by::
 
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> def dt_behavior(dt):
     ...     print(f'Set the default dt to {dt}.')
     ...
-    >>> bst.environ.register_default_behavior('dt', dt_behavior)
+    >>> brainstate.environ.register_default_behavior('dt', dt_behavior)
 
     Then, when you set the default dt by `brainstate.environ.set(dt=0.1)`, the behavior
     `dt_behavior` will be called with
     `dt_behavior(0.1)`.
 
-    >>> bst.environ.set(dt=0.1)
+    >>> brainstate.environ.set(dt=0.1)
     Set the default dt to 0.1.
-    >>> with bst.environ.context(dt=0.2):
+    >>> with brainstate.environ.context(dt=0.2):
     ...     pass
     Set the default dt to 0.2.
     Set the default dt to 0.1.

--- a/brainstate/functional/_activations_test.py
+++ b/brainstate/functional/_activations_test.py
@@ -70,39 +70,39 @@ class NNFunctionsTest(jtu.JaxTestCase):
             check_dtypes=False)
 
     #   def testSquareplusGrad(self):
-    #     check_grads(bst.functional.squareplus, (1e-8,), order=4,
+    #     check_grads(brainstate.functional.squareplus, (1e-8,), order=4,
     #                 )
 
     #   def testSquareplusGradZero(self):
-    #     check_grads(bst.functional.squareplus, (0.,), order=1,
+    #     check_grads(brainstate.functional.squareplus, (0.,), order=1,
     #                 )
 
     #   def testSquareplusGradNegInf(self):
-    #     check_grads(bst.functional.squareplus, (-float('inf'),), order=1,
+    #     check_grads(brainstate.functional.squareplus, (-float('inf'),), order=1,
     #                 )
 
     #   def testSquareplusGradNan(self):
-    #     check_grads(bst.functional.squareplus, (float('nan'),), order=1,
+    #     check_grads(brainstate.functional.squareplus, (float('nan'),), order=1,
     #                 )
 
     #   @parameterized.parameters([float] + jtu.dtypes.floating)
     #   def testSquareplusZero(self, dtype):
-    #     self.assertEqual(dtype(1), bst.functional.squareplus(dtype(0), dtype(4)))
+    #     self.assertEqual(dtype(1), brainstate.functional.squareplus(dtype(0), dtype(4)))
     #
     # def testMishGrad(self):
-    #   check_grads(bst.functional.mish, (1e-8,), order=4,
+    #   check_grads(brainstate.functional.mish, (1e-8,), order=4,
     #               )
     #
     # def testMishGradZero(self):
-    #   check_grads(bst.functional.mish, (0.,), order=1,
+    #   check_grads(brainstate.functional.mish, (0.,), order=1,
     #               )
     #
     # def testMishGradNegInf(self):
-    #   check_grads(bst.functional.mish, (-float('inf'),), order=1,
+    #   check_grads(brainstate.functional.mish, (-float('inf'),), order=1,
     #               )
     #
     # def testMishGradNan(self):
-    #   check_grads(bst.functional.mish, (float('nan'),), order=1,
+    #   check_grads(brainstate.functional.mish, (float('nan'),), order=1,
     #               )
 
     @parameterized.parameters([float] + jtu.dtypes.floating)
@@ -137,7 +137,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
         self.assertAllClose(brainstate.functional.sparse_sigmoid(0.), .5, check_dtypes=False)
 
     #   def testSquareplusValue(self):
-    #     val = bst.functional.squareplus(1e3)
+    #     val = brainstate.functional.squareplus(1e3)
     #     self.assertAllClose(val, 1e3, check_dtypes=False, atol=1e-3)
 
     def testMishValue(self):
@@ -177,7 +177,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
          brainstate.functional.softplus,
          brainstate.functional.sparse_plus,
          brainstate.functional.sigmoid,
-         #  bst.functional.squareplus,
+         #  brainstate.functional.squareplus,
          brainstate.functional.mish)))
     def testDtypeMatchesInput(self, dtype, fn):
         x = jnp.zeros((), dtype=dtype)
@@ -306,7 +306,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
     def testCustomJVPLeak2(self):
         # https://github.com/google/jax/issues/8171
-        # The above test uses jax.bst.functional.sigmoid, as in the original #8171, but that
+        # The above test uses jax.brainstate.functional.sigmoid, as in the original #8171, but that
         # function no longer actually has a custom_jvp! So we inline the old def.
 
         @jax.custom_jvp

--- a/brainstate/graph/_graph_operation.py
+++ b/brainstate/graph/_graph_operation.py
@@ -473,8 +473,8 @@ def flatten(
 
     Example::
 
-        >>> import brainstate as bst
-        >>> node = bst.graph.Node()
+        >>> import brainstate as brainstate
+        >>> node = brainstate.graph.Node()
         >>> graph_def, state_mapping = flatten(node)
         >>> print(graph_def)
         >>> print(state_mapping)
@@ -709,15 +709,15 @@ def unflatten(
 
     Example::
 
-    >>> import brainstate as bst
-    >>> class MyNode(bst.graph.Node):
+    >>> import brainstate as brainstate
+    >>> class MyNode(brainstate.graph.Node):
     ...   def __init__(self):
-    ...      self.a = bst.nn.Linear(2, 3)
-    ...      self.b = bst.nn.Linear(3, 4)
-    ...      self.c = [bst.nn.Linear(4, 5), bst.nn.Linear(5, 6)]
-    ...      self.d = {'x': bst.nn.Linear(6, 7), 'y': bst.nn.Linear(7, 8)}
+    ...      self.a = brainstate.nn.Linear(2, 3)
+    ...      self.b = brainstate.nn.Linear(3, 4)
+    ...      self.c = [brainstate.nn.Linear(4, 5), brainstate.nn.Linear(5, 6)]
+    ...      self.d = {'x': brainstate.nn.Linear(6, 7), 'y': brainstate.nn.Linear(7, 8)}
     ...
-    >>> graphdef, statetree = bst.graph.flatten(MyNode())
+    >>> graphdef, statetree = brainstate.graph.flatten(MyNode())
     >>> statetree
     NestedDict({
       'a': {
@@ -764,7 +764,7 @@ def unflatten(
         }
       }
     })
-    >>> node = bst.graph.unflatten(graphdef, statetree)
+    >>> node = brainstate.graph.unflatten(graphdef, statetree)
     >>> node
     MyNode(
       a=Linear(
@@ -942,21 +942,21 @@ def pop_states(
 
     Example usage::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax.numpy as jnp
 
-      >>> class Model(bst.nn.Module):
+      >>> class Model(brainstate.nn.Module):
       ...   def __init__(self):
       ...     super().__init__()
-      ...     self.a = bst.nn.Linear(2, 3)
-      ...     self.b = bst.nn.LIF([10, 2])
+      ...     self.a = brainstate.nn.Linear(2, 3)
+      ...     self.b = brainstate.nn.LIF([10, 2])
 
       >>> model = Model()
-      >>> with bst.catch_new_states('new'):
-      ...    bst.nn.init_all_states(model)
+      >>> with brainstate.catch_new_states('new'):
+      ...    brainstate.nn.init_all_states(model)
 
       >>> assert len(model.states()) == 2
-      >>> model_states = bst.graph.pop_states(model, 'new')
+      >>> model_states = brainstate.graph.pop_states(model, 'new')
       >>> model_states
       NestedDict({
         'b': {
@@ -1046,16 +1046,16 @@ def treefy_split(
 
     Example usage::
 
-      >>> from joblib.testing import param    >>> import brainstate as bst
+      >>> from joblib.testing import param    >>> import brainstate as brainstate
       >>> import jax, jax.numpy as jnp
       ...
-      >>> class Foo(bst.graph.Node):
+      >>> class Foo(brainstate.graph.Node):
       ...   def __init__(self):
-      ...     self.a = bst.nn.BatchNorm1d([10, 2])
-      ...     self.b = bst.nn.Linear(2, 3)
+      ...     self.a = brainstate.nn.BatchNorm1d([10, 2])
+      ...     self.b = brainstate.nn.Linear(2, 3)
       ...
       >>> node = Foo()
-      >>> graphdef, params, others = bst.graph.treefy_split(node, bst.ParamState, ...)
+      >>> graphdef, params, others = brainstate.graph.treefy_split(node, brainstate.ParamState, ...)
       ...
       >>> params
       NestedDict({
@@ -1119,21 +1119,21 @@ def treefy_merge(
 
     Example usage::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax, jax.numpy as jnp
       ...
-      >>> class Foo(bst.graph.Node):
+      >>> class Foo(brainstate.graph.Node):
       ...   def __init__(self):
-      ...     self.a = bst.nn.BatchNorm1d([10, 2])
-      ...     self.b = bst.nn.Linear(2, 3)
+      ...     self.a = brainstate.nn.BatchNorm1d([10, 2])
+      ...     self.b = brainstate.nn.Linear(2, 3)
       ...
       >>> node = Foo()
-      >>> graphdef, params, others = bst.graph.treefy_split(node, bst.ParamState, ...)
+      >>> graphdef, params, others = brainstate.graph.treefy_split(node, brainstate.ParamState, ...)
       ...
-      >>> new_node = bst.graph.treefy_merge(graphdef, params, others)
+      >>> new_node = brainstate.graph.treefy_merge(graphdef, params, others)
       >>> assert isinstance(new_node, Foo)
-      >>> assert isinstance(new_node.b, bst.nn.BatchNorm1d)
-      >>> assert isinstance(new_node.a, bst.nn.Linear)
+      >>> assert isinstance(new_node.b, brainstate.nn.BatchNorm1d)
+      >>> assert isinstance(new_node.a, brainstate.nn.Linear)
 
     :func:`split` and :func:`merge` are primarily used to interact directly with JAX
     transformations, see
@@ -1302,22 +1302,22 @@ def treefy_states(
 
     Example usage::
 
-      >>> import brainstate as bst
-      >>> class Model(bst.nn.Module):
+      >>> import brainstate as brainstate
+      >>> class Model(brainstate.nn.Module):
       ...   def __init__(self):
       ...     super().__init__()
-      ...     self.l1 = bst.nn.Linear(2, 3)
-      ...     self.l2 = bst.nn.Linear(3, 4)
+      ...     self.l1 = brainstate.nn.Linear(2, 3)
+      ...     self.l2 = brainstate.nn.Linear(3, 4)
       ...   def __call__(self, x):
       ...     return self.l2(self.l1(x))
 
       >>> model = Model()
       >>> # get the learnable parameters from the batch norm and linear layer
-      >>> params = bst.graph.treefy_states(model, bst.ParamState)
+      >>> params = brainstate.graph.treefy_states(model, brainstate.ParamState)
       >>> # get them separately
-      >>> params, others = bst.graph.treefy_states(model, bst.ParamState, bst.ShortTermState)
+      >>> params, others = brainstate.graph.treefy_states(model, brainstate.ParamState, brainstate.ShortTermState)
       >>> # get them together
-      >>> states = bst.graph.treefy_states(model)
+      >>> states = brainstate.graph.treefy_states(model)
 
     Args:
       node: A graph node object.
@@ -1403,11 +1403,11 @@ def graphdef(node: Any, /) -> GraphDef[Any]:
 
     Example usage::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
 
-      >>> model = bst.nn.Linear(2, 3)
-      >>> graphdef, _ = bst.graph.treefy_split(model)
-      >>> assert graphdef == bst.graph.graphdef(model)
+      >>> model = brainstate.nn.Linear(2, 3)
+      >>> graphdef, _ = brainstate.graph.treefy_split(model)
+      >>> assert graphdef == brainstate.graph.graphdef(model)
 
     Args:
       node: A graph node object.
@@ -1426,8 +1426,8 @@ def clone(node: Node) -> Node:
 
     Example usage::
 
-      >>> import brainstate as bst
-      >>> model = bst.nn.Linear(2, 3)
+      >>> import brainstate as brainstate
+      >>> model = brainstate.nn.Linear(2, 3)
       >>> cloned_model = clone(model)
       >>> model.weight.value['bias'] += 1
       >>> assert (model.weight.value['bias'] != cloned_model.weight.value['bias']).all()
@@ -1456,15 +1456,15 @@ def call(
 
     Example::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax
       >>> import jax.numpy as jnp
       ...
-      >>> class StatefulLinear(bst.graph.Node):
+      >>> class StatefulLinear(brainstate.graph.Node):
       ...   def __init__(self, din, dout):
-      ...     self.w = bst.ParamState(bst.random.rand(din, dout))
-      ...     self.b = bst.ParamState(jnp.zeros((dout,)))
-      ...     self.count = bst.State(jnp.array(0, dtype=jnp.uint32))
+      ...     self.w = brainstate.ParamState(brainstate.random.rand(din, dout))
+      ...     self.b = brainstate.ParamState(jnp.zeros((dout,)))
+      ...     self.count = brainstate.State(jnp.array(0, dtype=jnp.uint32))
       ...
       ...   def increment(self):
       ...     self.count.value += 1
@@ -1474,18 +1474,18 @@ def call(
       ...     return x @ self.w.value + self.b.value
       ...
       >>> linear = StatefulLinear(3, 2)
-      >>> linear_state = bst.graph.treefy_split(linear)
+      >>> linear_state = brainstate.graph.treefy_split(linear)
       ...
       >>> @jax.jit
       ... def forward(x, linear_state):
-      ...   y, linear_state = bst.graph.call(linear_state)(x)
+      ...   y, linear_state = brainstate.graph.call(linear_state)(x)
       ...   return y, linear_state
       ...
       >>> x = jnp.ones((1, 3))
       >>> y, linear_state = forward(x, linear_state)
       >>> y, linear_state = forward(x, linear_state)
       ...
-      >>> linear = bst.graph.treefy_merge(*linear_state)
+      >>> linear = brainstate.graph.treefy_merge(*linear_state)
       >>> linear.count.value
       Array(2, dtype=uint32)
 
@@ -1494,11 +1494,11 @@ def call(
     is used to call the ``increment`` method of the ``StatefulLinear`` module
     at the ``b`` key of a ``nodes`` dictionary.
 
-      >>> class StatefulLinear(bst.graph.Node):
+      >>> class StatefulLinear(brainstate.graph.Node):
       ...   def __init__(self, din, dout):
-      ...     self.w = bst.ParamState(bst.random.rand(din, dout))
-      ...     self.b = bst.ParamState(jnp.zeros((dout,)))
-      ...     self.count = bst.State(jnp.array(0, dtype=jnp.uint32))
+      ...     self.w = brainstate.ParamState(brainstate.random.rand(din, dout))
+      ...     self.b = brainstate.ParamState(jnp.zeros((dout,)))
+      ...     self.count = brainstate.State(jnp.array(0, dtype=jnp.uint32))
       ...
       ...   def increment(self):
       ...     self.count.value += 1
@@ -1514,7 +1514,7 @@ def call(
       ...
       >>> node_state = treefy_split(nodes)
       >>> # use attribute access
-      >>> _, node_state = bst.graph.call(node_state)['b'].increment()
+      >>> _, node_state = brainstate.graph.call(node_state)['b'].increment()
       ...
       >>> nodes = treefy_merge(*node_state)
       >>> nodes['a'].count.value
@@ -1544,19 +1544,19 @@ def iter_leaf(
     root. Repeated nodes are visited only once. Leaves include static values.
 
     Example::
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax.numpy as jnp
       ...
-      >>> class Linear(bst.nn.Module):
+      >>> class Linear(brainstate.nn.Module):
       ...   def __init__(self, din, dout):
       ...     super().__init__()
-      ...     self.weight = bst.ParamState(bst.random.randn(din, dout))
-      ...     self.bias = bst.ParamState(bst.random.randn(dout))
+      ...     self.weight = brainstate.ParamState(brainstate.random.randn(din, dout))
+      ...     self.bias = brainstate.ParamState(brainstate.random.randn(dout))
       ...     self.a = 1
       ...
       >>> module = Linear(3, 4)
       ...
-      >>> for path, value in bst.graph.iter_leaf([module, module]):
+      >>> for path, value in brainstate.graph.iter_leaf([module, module]):
       ...   print(path, type(value).__name__)
       ...
       (0, 'a') int
@@ -1616,21 +1616,21 @@ def iter_node(
     root. Repeated nodes are visited only once. Leaves include static values.
 
     Example::
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax.numpy as jnp
       ...
-      >>> class Model(bst.nn.Module):
+      >>> class Model(brainstate.nn.Module):
       ...   def __init__(self):
       ...     super().__init__()
-      ...     self.a = bst.nn.Linear(1, 2)
-      ...     self.b = bst.nn.Linear(2, 3)
-      ...     self.c = [bst.nn.Linear(3, 4), bst.nn.Linear(4, 5)]
-      ...     self.d = {'x': bst.nn.Linear(5, 6), 'y': bst.nn.Linear(6, 7)}
-      ...     self.b.a = bst.nn.LIF(2)
+      ...     self.a = brainstate.nn.Linear(1, 2)
+      ...     self.b = brainstate.nn.Linear(2, 3)
+      ...     self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
+      ...     self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
+      ...     self.b.a = brainstate.nn.LIF(2)
       ...
       >>> model = Model()
       ...
-      >>> for path, node in bst.graph.iter_node([model, model]):
+      >>> for path, node in brainstate.graph.iter_node([model, model]):
       ...    print(path, node.__class__.__name__)
       ...
       (0, 'a') Linear

--- a/brainstate/graph/_graph_operation_test.py
+++ b/brainstate/graph/_graph_operation_test.py
@@ -443,7 +443,7 @@ class TestGraphOperation(unittest.TestCase):
         graphdef, statetree = brainstate.graph.flatten(MyNode())
         # print(graphdef)
         print(statetree)
-        # print(bst.graph.unflatten(graphdef, statetree))
+        # print(brainstate.graph.unflatten(graphdef, statetree))
 
     def test_split(self):
         class Foo(brainstate.graph.Node):
@@ -530,7 +530,7 @@ class TestGraphOperation(unittest.TestCase):
         print(graph_def)
         print(treefy_states)
 
-        # states = bst.graph.states(model)
+        # states = brainstate.graph.states(model)
         # print(states)
         # nest_states = states.to_nest()
         # print(nest_states)

--- a/brainstate/nn/_collective_ops.py
+++ b/brainstate/nn/_collective_ops.py
@@ -56,10 +56,10 @@ def call_order(level: int = 0, check_order_boundary: bool = True):
 
     The lower the level, the earlier the function is called.
 
-    >>> import brainstate as bst
-    >>> bst.nn.call_order(0)
-    >>> bst.nn.call_order(-1)
-    >>> bst.nn.call_order(-2)
+    >>> import brainstate as brainstate
+    >>> brainstate.nn.call_order(0)
+    >>> brainstate.nn.call_order(-1)
+    >>> brainstate.nn.call_order(-2)
 
     Parameters
     ----------

--- a/brainstate/nn/_dropout_test.py
+++ b/brainstate/nn/_dropout_test.py
@@ -60,9 +60,9 @@ class TestDropout(unittest.TestCase):
         np.testing.assert_almost_equal(non_zero_elements, expected_non_zero_elements)
 
     # def test_Dropout1d(self):
-    #     dropout_layer = bst.nn.Dropout1d(prob=0.5)
+    #     dropout_layer = brainstate.nn.Dropout1d(prob=0.5)
     #     input_data = np.random.randn(2, 3, 4)
-    #     with bst.environ.context(fit=True):
+    #     with brainstate.environ.context(fit=True):
     #         output_data = dropout_layer(input_data)
     #     self.assertEqual(input_data.shape, output_data.shape)
     #     self.assertTrue(np.any(output_data == 0))

--- a/brainstate/nn/_elementwise.py
+++ b/brainstate/nn/_elementwise.py
@@ -61,7 +61,7 @@ class Threshold(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate
         >>> m = nn.Threshold(0.1, 20)
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -97,7 +97,7 @@ class ReLU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.ReLU()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -106,7 +106,7 @@ class ReLU(ElementWiseBlock):
       An implementation of CReLU - https://arxiv.org/abs/1603.05201
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.ReLU()
         >>> x = random.randn(2).unsqueeze(0)
         >>> output = jax.numpy.concat((m(x), m(-x)))
@@ -151,7 +151,7 @@ class RReLU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.RReLU(0.1, 0.3)
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -205,7 +205,7 @@ class Hardtanh(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Hardtanh(-2, 2)
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -244,7 +244,7 @@ class ReLU6(Hardtanh, ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.ReLU6()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -269,7 +269,7 @@ class Sigmoid(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Sigmoid()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -299,7 +299,7 @@ class Hardsigmoid(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Hardsigmoid()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -325,7 +325,7 @@ class Tanh(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Tanh()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -386,7 +386,7 @@ class Mish(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Mish()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -418,7 +418,7 @@ class Hardswish(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Hardswish()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -452,7 +452,7 @@ class ELU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.ELU()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -489,7 +489,7 @@ class CELU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.CELU()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -530,7 +530,7 @@ class SELU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.SELU()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -559,7 +559,7 @@ class GLU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.GLU()
         >>> x = random.randn(4, 2)
         >>> output = m(x)
@@ -600,7 +600,7 @@ class GELU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.GELU()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -642,7 +642,7 @@ class Hardshrink(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Hardshrink()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -689,7 +689,7 @@ class LeakyReLU(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.LeakyReLU(0.1)
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -721,7 +721,7 @@ class LogSigmoid(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.LogSigmoid()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -749,7 +749,7 @@ class Softplus(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Softplus()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -781,7 +781,7 @@ class Softshrink(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Softshrink()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -843,9 +843,9 @@ class PReLU(ElementWiseBlock):
 
     Examples::
 
-        >>> import brainstate as bst
-        >>> m = bst.nn.PReLU()
-        >>> x = bst.random.randn(2)
+        >>> import brainstate as brainstate
+        >>> m = brainstate.nn.PReLU()
+        >>> x = brainstate.random.randn(2)
         >>> output = m(x)
     """
     __module__ = 'brainstate.nn'
@@ -876,7 +876,7 @@ class Softsign(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Softsign()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -900,7 +900,7 @@ class Tanhshrink(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Tanhshrink()
         >>> x = random.randn(2)
         >>> output = m(x)
@@ -937,7 +937,7 @@ class Softmin(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Softmin(dim=1)
         >>> x = random.randn(2, 3)
         >>> output = m(x)
@@ -990,7 +990,7 @@ class Softmax(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Softmax(dim=1)
         >>> x = random.randn(2, 3)
         >>> output = m(x)
@@ -1027,7 +1027,7 @@ class Softmax2d(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.Softmax2d()
         >>> # you softmax over the 2nd dimension
         >>> x = random.randn(2, 3, 12, 13)
@@ -1062,7 +1062,7 @@ class LogSoftmax(ElementWiseBlock):
     Examples::
 
         >>> import brainstate.nn as nn
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> m = nn.LogSoftmax(dim=1)
         >>> x = random.randn(2, 3)
         >>> output = m(x)

--- a/brainstate/nn/_linear.py
+++ b/brainstate/nn/_linear.py
@@ -361,9 +361,9 @@ class LoRA(Module):
 
     Example usage::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> import jax, jax.numpy as jnp
-        >>> layer = bst.nn.LoRA(3, 2, 4)
+        >>> layer = brainstate.nn.LoRA(3, 2, 4)
         >>> layer.weight.value
     {'lora_a': Array([[ 0.25141352, -0.09826107],
             [ 0.2328382 ,  0.38869813],
@@ -371,8 +371,8 @@ class LoRA(Module):
      'lora_b': Array([[-0.8372317 ,  0.21012013, -0.52999765, -0.31939325],
             [ 0.64234126, -0.42980042,  1.2549229 , -0.47134295]],      dtype=float32)}
         >>> # Wrap around existing layer
-        >>> linear = bst.nn.Linear(3, 4)
-        >>> wrapper = bst.nn.LoRA(3, 2, 4, base_module=linear)
+        >>> linear = brainstate.nn.Linear(3, 4)
+        >>> wrapper = brainstate.nn.LoRA(3, 2, 4, base_module=linear)
         >>> assert wrapper.base_module == linear
         >>> y = layer(jnp.ones((16, 3)))
         >>> y.shape

--- a/brainstate/nn/_module.py
+++ b/brainstate/nn/_module.py
@@ -128,9 +128,9 @@ class Module(Node, ParamDesc):
         Examples
         --------
 
-        >>> import brainstate as bst
-        >>> x = bst.random.rand((10, 10))
-        >>> l = bst.nn.Dropout(0.5)
+        >>> import brainstate as brainstate
+        >>> x = brainstate.random.rand((10, 10))
+        >>> l = brainstate.nn.Dropout(0.5)
         >>> y = x >> l
         """
         return self.__call__(other)
@@ -266,14 +266,14 @@ class Sequential(Module):
     --------
 
     >>> import jax
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> import brainstate.nn as nn
     >>>
     >>> # composing ANN models
     >>> l = nn.Sequential(nn.Linear(100, 10),
     >>>                   jax.nn.relu,
     >>>                   nn.Linear(10, 2))
-    >>> l(bst.random.random((256, 100)))
+    >>> l(brainstate.random.random((256, 100)))
 
     Args:
       modules_as_tuple: The children modules.

--- a/brainstate/nn/_module_test.py
+++ b/brainstate/nn/_module_test.py
@@ -77,7 +77,7 @@ class TestDelay(unittest.TestCase):
             self.assertTrue(jnp.allclose(rotation_delay.at('a'), jnp.ones((1,)) * i))
             self.assertTrue(jnp.allclose(rotation_delay.at('b'), jnp.maximum(jnp.ones((1,)) * i - n1, 0.)))
             self.assertTrue(jnp.allclose(rotation_delay.at('c'), jnp.maximum(jnp.ones((1,)) * i - n2, 0.)))
-        # bst.util.clear_buffer_memory()
+        # brainstate.util.clear_buffer_memory()
 
     def test_jit_erro(self):
         rotation_delay = brainstate.nn.Delay(jnp.ones([1]), time=2., delay_method='concat', interp_method='round')

--- a/brainstate/nn/_normalizations.py
+++ b/brainstate/nn/_normalizations.py
@@ -488,9 +488,9 @@ class LayerNorm(Module):
 
     Example usage::
 
-      >>> import brainstate as bst
-      >>> x = bst.random.normal(size=(3, 4, 5, 6))
-      >>> layer = bst.nn.LayerNorm(x.shape)
+      >>> import brainstate as brainstate
+      >>> x = brainstate.random.normal(size=(3, 4, 5, 6))
+      >>> layer = brainstate.nn.LayerNorm(x.shape)
       >>> layer.states()
       >>> y = layer(x)
 
@@ -616,9 +616,9 @@ class RMSNorm(Module):
 
     Example usage::
 
-      >>> import brainstate as bst
-      >>> x = bst.random.normal(size=(5, 6))
-      >>> layer = bst.nn.RMSNorm(num_features=6)
+      >>> import brainstate as brainstate
+      >>> x = brainstate.random.normal(size=(5, 6))
+      >>> layer = brainstate.nn.RMSNorm(num_features=6)
       >>> layer.states()
       >>> y = layer(x)
 
@@ -739,14 +739,14 @@ class GroupNorm(Module):
     Example usage::
 
       >>> import numpy as np
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       ...
-      >>> x = bst.random.normal(size=(3, 4, 5, 6))
-      >>> layer = bst.nn.GroupNorm(x.shape, num_groups=3)
+      >>> x = brainstate.random.normal(size=(3, 4, 5, 6))
+      >>> layer = brainstate.nn.GroupNorm(x.shape, num_groups=3)
       >>> layer.states()
       >>> y = layer(x)
-      >>> y = bst.nn.GroupNorm(x.shape, num_groups=1)(x)
-      >>> y2 = bst.nn.LayerNorm(x.shape, reduction_axes=(1, 2, 3))(x)
+      >>> y = brainstate.nn.GroupNorm(x.shape, num_groups=1)(x)
+      >>> y2 = brainstate.nn.LayerNorm(x.shape, reduction_axes=(1, 2, 3))(x)
       >>> np.testing.assert_allclose(y, y2)
 
     Attributes:

--- a/brainstate/nn/_normalizations_test.py
+++ b/brainstate/nn/_normalizations_test.py
@@ -51,21 +51,21 @@ class Test_Normalization(parameterized.TestCase):
     #   normalized_shape=(10, [5, 10])
     # )
     # def test_LayerNorm(self, normalized_shape):
-    #   net = bst.nn.LayerNorm(normalized_shape, )
-    #   input = bst.random.randn(20, 5, 10)
+    #   net = brainstate.nn.LayerNorm(normalized_shape, )
+    #   input = brainstate.random.randn(20, 5, 10)
     #   output = net(input)
     #
     # @parameterized.product(
     #   num_groups=[1, 2, 3, 6]
     # )
     # def test_GroupNorm(self, num_groups):
-    #   input = bst.random.randn(20, 10, 10, 6)
-    #   net = bst.nn.GroupNorm(num_groups=num_groups, num_channels=6, )
+    #   input = brainstate.random.randn(20, 10, 10, 6)
+    #   net = brainstate.nn.GroupNorm(num_groups=num_groups, num_channels=6, )
     #   output = net(input)
     #
     # def test_InstanceNorm(self):
-    #   input = bst.random.randn(20, 10, 10, 6)
-    #   net = bst.nn.InstanceNorm(num_channels=6, )
+    #   input = brainstate.random.randn(20, 10, 10, 6)
+    #   net = brainstate.nn.InstanceNorm(num_channels=6, )
     #   output = net(input)
 
 

--- a/brainstate/nn/_poolings.py
+++ b/brainstate/nn/_poolings.py
@@ -55,8 +55,8 @@ class Flatten(Module):
         end_axis: last dim to flatten (default = -1).
 
     Examples::
-        >>> import brainstate as bst
-        >>> inp = bst.random.randn(32, 1, 5, 5)
+        >>> import brainstate as brainstate
+        >>> inp = brainstate.random.randn(32, 1, 5, 5)
         >>> # With default parameters
         >>> m = Flatten()
         >>> output = m(inp)
@@ -334,10 +334,10 @@ class MaxPool1d(_MaxPool):
 
     Examples::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # pool of size=3, stride=2
         >>> m = MaxPool1d(3, stride=2, channel_axis=-1)
-        >>> input = bst.random.randn(20, 50, 16)
+        >>> input = brainstate.random.randn(20, 50, 16)
         >>> output = m(input)
         >>> output.shape
         (20, 24, 16)
@@ -418,12 +418,12 @@ class MaxPool2d(_MaxPool):
 
     Examples::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # pool of square window of size=3, stride=2
         >>> m = MaxPool2d(3, stride=2)
         >>> # pool of non-square window
         >>> m = MaxPool2d((3, 2), stride=(2, 1), channel_axis=-1)
-        >>> input = bst.random.randn(20, 50, 32, 16)
+        >>> input = brainstate.random.randn(20, 50, 32, 16)
         >>> output = m(input)
         >>> output.shape
         (20, 24, 31, 16)
@@ -509,12 +509,12 @@ class MaxPool3d(_MaxPool):
 
     Examples::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # pool of square window of size=3, stride=2
         >>> m = MaxPool3d(3, stride=2)
         >>> # pool of non-square window
         >>> m = MaxPool3d((3, 2, 2), stride=(2, 1, 2), channel_axis=-1)
-        >>> input = bst.random.randn(20, 50, 44, 31, 16)
+        >>> input = brainstate.random.randn(20, 50, 44, 31, 16)
         >>> output = m(input)
         >>> output.shape
         (20, 24, 43, 15, 16)
@@ -588,10 +588,10 @@ class AvgPool1d(_AvgPool):
 
     Examples::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # pool with window of size=3, stride=2
         >>> m = AvgPool1d(3, stride=2)
-        >>> input = bst.random.randn(20, 50, 16)
+        >>> input = brainstate.random.randn(20, 50, 16)
         >>> m(input).shape
         (20, 24, 16)
 
@@ -665,12 +665,12 @@ class AvgPool2d(_AvgPool):
 
     Examples::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # pool of square window of size=3, stride=2
         >>> m = AvgPool2d(3, stride=2)
         >>> # pool of non-square window
         >>> m = AvgPool2d((3, 2), stride=(2, 1))
-        >>> input = bst.random.randn(20, 50, 32, , 16)
+        >>> input = brainstate.random.randn(20, 50, 32, , 16)
         >>> output = m(input)
         >>> output.shape
         (20, 24, 31, 16)
@@ -753,12 +753,12 @@ class AvgPool3d(_AvgPool):
 
     Examples::
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # pool of square window of size=3, stride=2
         >>> m = AvgPool3d(3, stride=2)
         >>> # pool of non-square window
         >>> m = AvgPool3d((3, 2, 2), stride=(2, 1, 2))
-        >>> input = bst.random.randn(20, 50, 44, 31, 16)
+        >>> input = brainstate.random.randn(20, 50, 44, 31, 16)
         >>> output = m(input)
         >>> output.shape
         (20, 24, 43, 15, 16)
@@ -931,10 +931,10 @@ class AdaptiveAvgPool1d(_AdaptivePool):
 
     Examples:
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # target output size of 5
         >>> m = AdaptiveMaxPool1d(5)
-        >>> input = bst.random.randn(1, 64, 8)
+        >>> input = brainstate.random.randn(1, 64, 8)
         >>> output = m(input)
         >>> output.shape
         (1, 5, 8)
@@ -979,22 +979,22 @@ class AdaptiveAvgPool2d(_AdaptivePool):
 
     Examples:
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # target output size of 5x7
         >>> m = AdaptiveMaxPool2d((5, 7))
-        >>> input = bst.random.randn(1, 8, 9, 64)
+        >>> input = brainstate.random.randn(1, 8, 9, 64)
         >>> output = m(input)
         >>> output.shape
         (1, 5, 7, 64)
         >>> # target output size of 7x7 (square)
         >>> m = AdaptiveMaxPool2d(7)
-        >>> input = bst.random.randn(1, 10, 9, 64)
+        >>> input = brainstate.random.randn(1, 10, 9, 64)
         >>> output = m(input)
         >>> output.shape
         (1, 7, 7, 64)
         >>> # target output size of 10x7
         >>> m = AdaptiveMaxPool2d((None, 7))
-        >>> input = bst.random.randn(1, 10, 9, 64)
+        >>> input = brainstate.random.randn(1, 10, 9, 64)
         >>> output = m(input)
         >>> output.shape
         (1, 10, 7, 64)
@@ -1040,22 +1040,22 @@ class AdaptiveAvgPool3d(_AdaptivePool):
 
     Examples:
 
-        >>> import brainstate as bst
+        >>> import brainstate as brainstate
         >>> # target output size of 5x7x9
         >>> m = AdaptiveMaxPool3d((5, 7, 9))
-        >>> input = bst.random.randn(1, 8, 9, 10, 64)
+        >>> input = brainstate.random.randn(1, 8, 9, 10, 64)
         >>> output = m(input)
         >>> output.shape
         (1, 5, 7, 9, 64)
         >>> # target output size of 7x7x7 (cube)
         >>> m = AdaptiveMaxPool3d(7)
-        >>> input = bst.random.randn(1, 10, 9, 8, 64)
+        >>> input = brainstate.random.randn(1, 10, 9, 8, 64)
         >>> output = m(input)
         >>> output.shape
         (1, 7, 7, 7, 64)
         >>> # target output size of 7x9x8
         >>> m = AdaptiveMaxPool3d((7, None, None))
-        >>> input = bst.random.randn(1, 10, 9, 8, 64)
+        >>> input = brainstate.random.randn(1, 10, 9, 8, 64)
         >>> output = m(input)
         >>> output.shape
         (1, 7, 9, 8, 64)

--- a/brainstate/nn/_utils.py
+++ b/brainstate/nn/_utils.py
@@ -62,7 +62,7 @@ def count_parameters(
 
     Parameters:
     -----------
-    model : bst.nn.Module
+    model : brainstate.nn.Module
         The neural network model for which to count parameters.
 
     Returns:

--- a/brainstate/nn/metrics.py
+++ b/brainstate/nn/metrics.py
@@ -61,12 +61,12 @@ class Average(Metric):
     Example usage::
 
       >>> import jax.numpy as jnp
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
 
       >>> batch_loss = jnp.array([1, 2, 3, 4])
       >>> batch_loss2 = jnp.array([3, 2, 1, 0])
 
-      >>> metrics = bst.nn.metrics.Average()
+      >>> metrics = brainstate.nn.metrics.Average()
       >>> metrics.compute()
       Array(nan, dtype=float32)
       >>> metrics.update(values=batch_loss)
@@ -223,7 +223,7 @@ class Accuracy(Average):
 
     Example usage::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax, jax.numpy as jnp
 
       >>> logits = jax.random.normal(jax.random.key(0), (5, 2))
@@ -231,7 +231,7 @@ class Accuracy(Average):
       >>> logits2 = jax.random.normal(jax.random.key(1), (5, 2))
       >>> labels2 = jnp.array([0, 1, 1, 1, 1])
 
-      >>> metrics = bst.nn.metrics.Accuracy()
+      >>> metrics = brainstate.nn.metrics.Accuracy()
       >>> metrics.compute()
       Array(nan, dtype=float32)
       >>> metrics.update(logits=logits, labels=labels)

--- a/brainstate/optim/_optax_optimizer.py
+++ b/brainstate/optim/_optax_optimizer.py
@@ -36,29 +36,29 @@ class OptaxOptimizer(Optimizer):
 
       >>> import jax
       >>> import jax.numpy as jnp
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import optax
       ...
-      >>> class Model(bst.nn.Module):
+      >>> class Model(brainstate.nn.Module):
       ...   def __init__(self):
       ...     super().__init__()
-      ...     self.linear1 = bst.nn.Linear(2, 3)
-      ...     self.linear2 = bst.nn.Linear(3, 4)
+      ...     self.linear1 = brainstate.nn.Linear(2, 3)
+      ...     self.linear2 = brainstate.nn.Linear(3, 4)
       ...   def __call__(self, x):
       ...     return self.linear2(self.linear1(x))
       ...
-      >>> x = bst.random.randn(1, 2)
+      >>> x = brainstate.random.randn(1, 2)
       >>> y = jnp.ones((1, 4))
       ...
       >>> model = Model()
       >>> tx = optax.adam(1e-3)
-      >>> optimizer = bst.optim.OptaxOptimizer(tx)
-      >>> optimizer.register_trainable_weights(model.states(bst.ParamState))
+      >>> optimizer = brainstate.optim.OptaxOptimizer(tx)
+      >>> optimizer.register_trainable_weights(model.states(brainstate.ParamState))
       ...
       >>> loss_fn = lambda: ((model(x) - y) ** 2).mean()
       >>> loss_fn()
       Array(1.7055722, dtype=float32)
-      >>> grads = bst.augment.grad(loss_fn, model.states(bst.ParamState))()
+      >>> grads = brainstate.augment.grad(loss_fn, model.states(brainstate.ParamState))()
       >>> optimizer.update(grads)
       >>> loss_fn()
       Array(1.6925814, dtype=float32)

--- a/brainstate/random/_rand_funs.py
+++ b/brainstate/random/_rand_funs.py
@@ -78,8 +78,8 @@ def rand(*dn, key: Optional[SeedOrKey] = None, dtype: DTypeLike = None):
 
     Examples
     --------
-    >>> import brainstate as bst
-    >>> bst.random.rand(3,2)
+    >>> import brainstate as brainstate
+    >>> brainstate.random.rand(3,2)
     array([[ 0.14022471,  0.96360618],  #random
            [ 0.37601032,  0.25528411],  #random
            [ 0.49313049,  0.94909878]]) #random
@@ -135,31 +135,31 @@ def randint(low, high=None, size: Optional[Size] = None,
 
     Examples
     --------
-    >>> import brainstate as bst
-    >>> bst.random.randint(2, size=10)
+    >>> import brainstate as brainstate
+    >>> brainstate.random.randint(2, size=10)
     array([1, 0, 0, 0, 1, 1, 0, 0, 1, 0]) # random
-    >>> bst.random.randint(1, size=10)
+    >>> brainstate.random.randint(1, size=10)
     array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
     Generate a 2 x 4 array of ints between 0 and 4, inclusive:
 
-    >>> bst.random.randint(5, size=(2, 4))
+    >>> brainstate.random.randint(5, size=(2, 4))
     array([[4, 0, 2, 1], # random
            [3, 2, 2, 0]])
 
     Generate a 1 x 3 array with 3 different upper bounds
 
-    >>> bst.random.randint(1, [3, 5, 10])
+    >>> brainstate.random.randint(1, [3, 5, 10])
     array([2, 2, 9]) # random
 
     Generate a 1 by 3 array with 3 different lower bounds
 
-    >>> bst.random.randint([1, 5, 7], 10)
+    >>> brainstate.random.randint([1, 5, 7], 10)
     array([9, 8, 7]) # random
 
     Generate a 2 by 4 array using broadcasting with dtype of uint8
 
-    >>> bst.random.randint([1, 3, 5, 7], [[10], [20]], dtype=np.uint8)
+    >>> brainstate.random.randint([1, 3, 5, 7], [[10], [20]], dtype=np.uint8)
     array([[ 8,  6,  9,  7], # random
            [ 1, 16,  9, 12]], dtype=uint8)
     """
@@ -219,12 +219,12 @@ def random_integers(low,
 
     Examples
     --------
-    >>> import brainstate as bst
-    >>> bst.random.random_integers(5)
+    >>> import brainstate as brainstate
+    >>> brainstate.random.random_integers(5)
     4 # random
-    >>> type(bst.random.random_integers(5))
+    >>> type(brainstate.random.random_integers(5))
     <class 'numpy.int64'>
-    >>> bst.random.random_integers(5, size=(3,2))
+    >>> brainstate.random.random_integers(5, size=(3,2))
     array([[5, 4], # random
            [3, 3],
            [4, 5]])
@@ -233,13 +233,13 @@ def random_integers(low,
     numbers between 0 and 2.5, inclusive (*i.e.*, from the set
     :math:`{0, 5/8, 10/8, 15/8, 20/8}`):
 
-    >>> 2.5 * (bst.random.random_integers(5, size=(5,)) - 1) / 4.
+    >>> 2.5 * (brainstate.random.random_integers(5, size=(5,)) - 1) / 4.
     array([ 0.625,  1.25 ,  0.625,  0.625,  2.5  ]) # random
 
     Roll two six sided dice 1000 times and sum the results:
 
-    >>> d1 = bst.random.random_integers(1, 6, 1000)
-    >>> d2 = bst.random.random_integers(1, 6, 1000)
+    >>> d1 = brainstate.random.random_integers(1, 6, 1000)
+    >>> d2 = brainstate.random.random_integers(1, 6, 1000)
     >>> dsums = d1 + d2
 
     Display results as a histogram:
@@ -301,13 +301,13 @@ def randn(*dn, key: Optional[SeedOrKey] = None, dtype: DTypeLike = None):
 
     Examples
     --------
-    >>> import brainstate as bst
-    >>> bst.random.randn()
+    >>> import brainstate as brainstate
+    >>> brainstate.random.randn()
     2.1923875335537315  # random
 
     Two-by-four array of samples from N(3, 6.25):
 
-    >>> 3 + 2.5 * bst.random.randn(2, 4)
+    >>> 3 + 2.5 * brainstate.random.randn(2, 4)
     array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],   # random
            [ 0.39924804,  4.68456316,  4.99394529,  4.84057254]])  # random
     """
@@ -359,17 +359,17 @@ def random_sample(size: Optional[Size] = None, key: Optional[SeedOrKey] = None, 
 
     Examples
     --------
-    >>> import brainstate as bst
-    >>> bst.random.random_sample()
+    >>> import brainstate as brainstate
+    >>> brainstate.random.random_sample()
     0.47108547995356098 # random
-    >>> type(bst.random.random_sample())
+    >>> type(brainstate.random.random_sample())
     <class 'float'>
-    >>> bst.random.random_sample((5,))
+    >>> brainstate.random.random_sample((5,))
     array([ 0.30220482,  0.86820401,  0.1654503 ,  0.11659149,  0.54323428]) # random
 
     Three-by-two array of random numbers from [-5, 0):
 
-    >>> 5 * bst.random.random_sample((3, 2)) - 5
+    >>> 5 * brainstate.random.random_sample((3, 2)) - 5
     array([[-3.99149989, -0.52338984], # random
            [-2.99091858, -0.79479508],
            [-1.23204345, -1.75224494]])
@@ -450,34 +450,34 @@ def choice(a, size: Optional[Size] = None, replace=True, p=None,
     --------
     Generate a uniform random sample from np.arange(5) of size 3:
 
-    >>> import brainstate as bst
-    >>> bst.random.choice(5, 3)
+    >>> import brainstate as brainstate
+    >>> brainstate.random.choice(5, 3)
     array([0, 3, 4]) # random
     >>> #This is equivalent to brainpy.math.random.randint(0,5,3)
 
     Generate a non-uniform random sample from np.arange(5) of size 3:
 
-    >>> bst.random.choice(5, 3, p=[0.1, 0, 0.3, 0.6, 0])
+    >>> brainstate.random.choice(5, 3, p=[0.1, 0, 0.3, 0.6, 0])
     array([3, 3, 0]) # random
 
     Generate a uniform random sample from np.arange(5) of size 3 without
     replacement:
 
-    >>> bst.random.choice(5, 3, replace=False)
+    >>> brainstate.random.choice(5, 3, replace=False)
     array([3,1,0]) # random
     >>> #This is equivalent to brainpy.math.random.permutation(np.arange(5))[:3]
 
     Generate a non-uniform random sample from np.arange(5) of size
     3 without replacement:
 
-    >>> bst.random.choice(5, 3, replace=False, p=[0.1, 0, 0.3, 0.6, 0])
+    >>> brainstate.random.choice(5, 3, replace=False, p=[0.1, 0, 0.3, 0.6, 0])
     array([2, 3, 0]) # random
 
     Any of the above can be repeated with an arbitrary array-like
     instead of just integers. For instance:
 
     >>> aa_milne_arr = ['pooh', 'rabbit', 'piglet', 'Christopher']
-    >>> bst.random.choice(aa_milne_arr, 5, p=[0.5, 0.1, 0.1, 0.3])
+    >>> brainstate.random.choice(aa_milne_arr, 5, p=[0.5, 0.1, 0.1, 0.3])
     array(['pooh', 'pooh', 'pooh', 'Christopher', 'piglet'], # random
           dtype='<U11')
     """
@@ -519,15 +519,15 @@ def permutation(x,
 
     Examples
     --------
-    >>> import brainstate as bst
-    >>> bst.random.permutation(10)
+    >>> import brainstate as brainstate
+    >>> brainstate.random.permutation(10)
     array([1, 7, 4, 3, 0, 9, 2, 5, 8, 6]) # random
 
-    >>> bst.random.permutation([1, 4, 9, 12, 15])
+    >>> brainstate.random.permutation([1, 4, 9, 12, 15])
     array([15,  1,  9,  4, 12]) # random
 
     >>> arr = np.arange(9).reshape((3, 3))
-    >>> bst.random.permutation(arr)
+    >>> brainstate.random.permutation(arr)
     array([[6, 7, 8], # random
            [0, 1, 2],
            [3, 4, 5]])
@@ -557,16 +557,16 @@ def shuffle(x, axis=0, key: Optional[SeedOrKey] = None):
 
     Examples
     --------
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> arr = np.arange(10)
-    >>> bst.random.shuffle(arr)
+    >>> brainstate.random.shuffle(arr)
     >>> arr
     [1 7 5 2 9 4 3 6 0 8] # random
 
     Multi-dimensional arrays are only shuffled along the first axis:
 
     >>> arr = np.arange(9).reshape((3, 3))
-    >>> bst.random.shuffle(arr)
+    >>> brainstate.random.shuffle(arr)
     >>> arr
     array([[3, 4, 5], # random
            [6, 7, 8],

--- a/brainstate/random/_rand_funs_test.py
+++ b/brainstate/random/_rand_funs_test.py
@@ -562,6 +562,6 @@ class TestRandom(unittest.TestCase):
 
 # class TestRandomKey(unittest.TestCase):
 #   def test_clear_memory(self):
-#     bst.random.split_key()
-#     print(bst.random.DEFAULT.value)
-#     self.assertTrue(isinstance(bst.random.DEFAULT.value, np.ndarray))
+#     brainstate.random.split_key()
+#     print(brainstate.random.DEFAULT.value)
+#     self.assertTrue(isinstance(brainstate.random.DEFAULT.value, np.ndarray))

--- a/brainstate/random/_rand_seed.py
+++ b/brainstate/random/_rand_seed.py
@@ -183,16 +183,16 @@ def seed_context(seed_or_key: SeedOrKey):
 
     Examples:
 
-    >>> import brainstate as bst
-    >>> print(bst.random.rand(2))
+    >>> import brainstate as brainstate
+    >>> print(brainstate.random.rand(2))
     [0.57721865 0.9820676 ]
-    >>> print(bst.random.rand(2))
+    >>> print(brainstate.random.rand(2))
     [0.8511752  0.95312667]
-    >>> with bst.random.seed_context(42):
-    ...     print(bst.random.rand(2))
+    >>> with brainstate.random.seed_context(42):
+    ...     print(brainstate.random.rand(2))
     [0.95598125 0.4032725 ]
-    >>> with bst.random.seed_context(42):
-    ...     print(bst.random.rand(2))
+    >>> with brainstate.random.seed_context(42):
+    ...     print(brainstate.random.rand(2))
     [0.95598125 0.4032725 ]
 
     Args:

--- a/brainstate/surrogate.py
+++ b/brainstate/surrogate.py
@@ -106,11 +106,11 @@ class Surrogate(PrettyObject):
     Examples
     --------
 
-    >>> import brainstate as bst
+    >>> import brainstate as brainstate
     >>> import brainstate.nn as nn
     >>> import jax.numpy as jnp
 
-    >>> class MySurrogate(bst.surrogate.Surrogate):
+    >>> class MySurrogate(brainstate.surrogate.Surrogate):
     ...   def __init__(self, alpha=1.):
     ...     super().__init__()
     ...     self.alpha = alpha
@@ -236,11 +236,11 @@ def sigmoid(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-2, 2, 1000)
        >>> for alpha in [1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.sigmoid)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.sigmoid)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -355,11 +355,11 @@ def piecewise_quadratic(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.piecewise_quadratic)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.piecewise_quadratic)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -522,11 +522,11 @@ def piecewise_exp(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.piecewise_exp)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.piecewise_exp)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -621,11 +621,11 @@ def soft_sign(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.soft_sign)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.soft_sign)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -706,11 +706,11 @@ def arctan(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.arctan)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.arctan)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -804,11 +804,11 @@ def nonzero_sign_log(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.nonzero_sign_log)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.nonzero_sign_log)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -893,11 +893,11 @@ def erf(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.nonzero_sign_log)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.nonzero_sign_log)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -1000,12 +1000,12 @@ def piecewise_leaky_relu(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for c in [0.01, 0.05, 0.1]:
        >>>   for w in [1., 2.]:
-       >>>     grads1 = bst.augment.vector_grad(bst.surrogate.piecewise_leaky_relu)(xs, c=c, w=w)
+       >>>     grads1 = brainstate.augment.vector_grad(brainstate.surrogate.piecewise_leaky_relu)(xs, c=c, w=w)
        >>>     plt.plot(xs, grads1, label=f'x={c}, w={w}')
        >>> plt.legend()
        >>> plt.show()
@@ -1113,12 +1113,12 @@ def squarewave_fourier_series(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for n in [2, 4, 8]:
-       >>>   f = bst.surrogate.SquarewaveFourierSeries(n=n)
-       >>>   grads1 = bst.augment.vector_grad(f)(xs)
+       >>>   f = brainstate.surrogate.SquarewaveFourierSeries(n=n)
+       >>>   grads1 = brainstate.augment.vector_grad(f)(xs)
        >>>   plt.plot(xs, grads1, label=f'n={n}')
        >>> plt.legend()
        >>> plt.show()
@@ -1214,12 +1214,12 @@ def s2nn(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
-       >>> grads = bst.augment.vector_grad(bst.surrogate.s2nn)(xs, 4., 1.)
+       >>> grads = brainstate.augment.vector_grad(brainstate.surrogate.s2nn)(xs, 4., 1.)
        >>> plt.plot(xs, grads, label=r'$\alpha=4, \beta=1$')
-       >>> grads = bst.augment.vector_grad(bst.surrogate.s2nn)(xs, 8., 2.)
+       >>> grads = brainstate.augment.vector_grad(brainstate.surrogate.s2nn)(xs, 8., 2.)
        >>> plt.plot(xs, grads, label=r'$\alpha=8, \beta=2$')
        >>> plt.legend()
        >>> plt.show()
@@ -1315,11 +1315,11 @@ def q_pseudo_spike(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.q_pseudo_spike)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.q_pseudo_spike)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha=$' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -1413,10 +1413,10 @@ def leaky_relu(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
-       >>> grads = bst.augment.vector_grad(bst.surrogate.leaky_relu)(xs, 0., 1.)
+       >>> grads = brainstate.augment.vector_grad(brainstate.surrogate.leaky_relu)(xs, 0., 1.)
        >>> plt.plot(xs, grads, label=r'$\alpha=0., \beta=1.$')
        >>> plt.legend()
        >>> plt.show()
@@ -1517,10 +1517,10 @@ def log_tailed_relu(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
-       >>> grads = bst.augment.vector_grad(bst.surrogate.leaky_relu)(xs, 0., 1.)
+       >>> grads = brainstate.augment.vector_grad(brainstate.surrogate.leaky_relu)(xs, 0., 1.)
        >>> plt.plot(xs, grads, label=r'$\alpha=0., \beta=1.$')
        >>> plt.legend()
        >>> plt.show()
@@ -1596,12 +1596,12 @@ def relu_grad(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for s in [0.5, 1.]:
        >>>   for w in [1, 2.]:
-       >>>     grads = bst.augment.vector_grad(bst.surrogate.relu_grad)(xs, s, w)
+       >>>     grads = brainstate.augment.vector_grad(brainstate.surrogate.relu_grad)(xs, s, w)
        >>>     plt.plot(xs, grads, label=r'$\alpha=$' + f'{s}, width={w}')
        >>> plt.legend()
        >>> plt.show()
@@ -1678,11 +1678,11 @@ def gaussian_grad(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for s in [0.5, 1., 2.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.gaussian_grad)(xs, s, 0.5)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.gaussian_grad)(xs, s, 0.5)
        >>>   plt.plot(xs, grads, label=r'$\alpha=0.5, \sigma=$' + str(s))
        >>> plt.legend()
        >>> plt.show()
@@ -1773,10 +1773,10 @@ def multi_gaussian_grad(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
-       >>> grads = bst.augment.vector_grad(bst.surrogate.multi_gaussian_grad)(xs)
+       >>> grads = brainstate.augment.vector_grad(brainstate.surrogate.multi_gaussian_grad)(xs)
        >>> plt.plot(xs, grads)
        >>> plt.show()
 
@@ -1855,11 +1855,11 @@ def inv_square_grad(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-1, 1, 1000)
        >>> for alpha in [1., 10., 100.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.inv_square_grad)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.inv_square_grad)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()
@@ -1929,11 +1929,11 @@ def slayer_grad(
 
        >>> import jax
        >>> import brainstate.nn as nn
-       >>> import brainstate as bst
+       >>> import brainstate as brainstate
        >>> import matplotlib.pyplot as plt
        >>> xs = jax.numpy.linspace(-3, 3, 1000)
        >>> for alpha in [0.5, 1., 2., 4.]:
-       >>>   grads = bst.augment.vector_grad(bst.surrogate.slayer_grad)(xs, alpha)
+       >>>   grads = brainstate.augment.vector_grad(brainstate.surrogate.slayer_grad)(xs, alpha)
        >>>   plt.plot(xs, grads, label=r'$\alpha$=' + str(alpha))
        >>> plt.legend()
        >>> plt.show()

--- a/brainstate/util/pretty_pytree.py
+++ b/brainstate/util/pretty_pytree.py
@@ -373,19 +373,19 @@ class NestedDict(PrettyDict):
 
         Example usage::
 
-          >>> import brainstate as bst
+          >>> import brainstate as brainstate
 
-          >>> class Model(bst.nn.Module):
+          >>> class Model(brainstate.nn.Module):
           ...   def __init__(self):
           ...     super().__init__()
-          ...     self.batchnorm = bst.nn.BatchNorm1d([10, 3])
-          ...     self.linear = bst.nn.Linear(2, 3)
+          ...     self.batchnorm = brainstate.nn.BatchNorm1d([10, 3])
+          ...     self.linear = brainstate.nn.Linear(2, 3)
           ...   def __call__(self, x):
           ...     return self.linear(self.batchnorm(x))
 
           >>> model = Model()
-          >>> state_map = bst.graph.treefy_states(model)
-          >>> param, others = state_map.treefy_split(bst.ParamState, ...)
+          >>> state_map = brainstate.graph.treefy_states(model)
+          >>> param, others = state_map.treefy_split(brainstate.ParamState, ...)
 
         Arguments:
           first: The first filter
@@ -495,14 +495,14 @@ class FlattedDict(PrettyDict):
 
     Example usage::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax.numpy as jnp
       >>>
-      >>> class Model(bst.nn.Module):
+      >>> class Model(brainstate.nn.Module):
       ...   def __init__(self):
       ...     super().__init__()
-      ...     self.batchnorm = bst.nn.BatchNorm1d([10, 3])
-      ...     self.linear = bst.nn.Linear(2, 3)
+      ...     self.batchnorm = brainstate.nn.BatchNorm1d([10, 3])
+      ...     self.linear = brainstate.nn.Linear(2, 3)
       ...   def __call__(self, x):
       ...     return self.linear(self.batchnorm(x))
       >>>

--- a/brainstate/util/pretty_pytree_test.py
+++ b/brainstate/util/pretty_pytree_test.py
@@ -13,31 +13,30 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import annotations
 
 import unittest
 
 import jax
 from absl.testing import absltest
 
-import brainstate as bst
+import brainstate
 
 
 class TestNestedMapping(absltest.TestCase):
     def test_create_state(self):
-        state = bst.util.NestedDict({'a': bst.ParamState(1), 'b': {'c': bst.ParamState(2)}})
+        state = brainstate.util.NestedDict({'a': brainstate.ParamState(1), 'b': {'c': brainstate.ParamState(2)}})
 
         assert state['a'].value == 1
         assert state['b']['c'].value == 2
 
     def test_get_attr(self):
-        state = bst.util.NestedDict({'a': bst.ParamState(1), 'b': {'c': bst.ParamState(2)}})
+        state = brainstate.util.NestedDict({'a': brainstate.ParamState(1), 'b': {'c': brainstate.ParamState(2)}})
 
         assert state.a.value == 1
         assert state.b['c'].value == 2
 
     def test_set_attr(self):
-        state = bst.util.NestedDict({'a': bst.ParamState(1), 'b': {'c': bst.ParamState(2)}})
+        state = brainstate.util.NestedDict({'a': brainstate.ParamState(1), 'b': {'c': brainstate.ParamState(2)}})
 
         state.a.value = 3
         state.b['c'].value = 4
@@ -46,36 +45,36 @@ class TestNestedMapping(absltest.TestCase):
         assert state['b']['c'].value == 4
 
     def test_set_attr_variables(self):
-        state = bst.util.NestedDict({'a': bst.ParamState(1), 'b': {'c': bst.ParamState(2)}})
+        state = brainstate.util.NestedDict({'a': brainstate.ParamState(1), 'b': {'c': brainstate.ParamState(2)}})
 
         state.a.value = 3
         state.b['c'].value = 4
 
-        assert isinstance(state.a, bst.ParamState)
+        assert isinstance(state.a, brainstate.ParamState)
         assert state.a.value == 3
-        assert isinstance(state.b['c'], bst.ParamState)
+        assert isinstance(state.b['c'], brainstate.ParamState)
         assert state.b['c'].value == 4
 
     def test_add_nested_attr(self):
-        state = bst.util.NestedDict({'a': bst.ParamState(1), 'b': {'c': bst.ParamState(2)}})
-        state.b['d'] = bst.ParamState(5)
+        state = brainstate.util.NestedDict({'a': brainstate.ParamState(1), 'b': {'c': brainstate.ParamState(2)}})
+        state.b['d'] = brainstate.ParamState(5)
 
         assert state['b']['d'].value == 5
 
     def test_delete_nested_attr(self):
-        state = bst.util.NestedDict({'a': bst.ParamState(1), 'b': {'c': bst.ParamState(2)}})
+        state = brainstate.util.NestedDict({'a': brainstate.ParamState(1), 'b': {'c': brainstate.ParamState(2)}})
         del state['b']['c']
 
         assert 'c' not in state['b']
 
     def test_integer_access(self):
-        class Foo(bst.nn.Module):
+        class Foo(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.layers = [bst.nn.Linear(1, 2), bst.nn.Linear(2, 3)]
+                self.layers = [brainstate.nn.Linear(1, 2), brainstate.nn.Linear(2, 3)]
 
         module = Foo()
-        state_refs = bst.graph.treefy_states(module)
+        state_refs = brainstate.graph.treefy_states(module)
 
         assert module.layers[0].weight.value['weight'].shape == (1, 2)
         assert state_refs.layers[0]['weight'].value['weight'].shape == (1, 2)
@@ -83,8 +82,8 @@ class TestNestedMapping(absltest.TestCase):
         assert state_refs.layers[1]['weight'].value['weight'].shape == (2, 3)
 
     def test_pure_dict(self):
-        module = bst.nn.Linear(4, 5)
-        state_map = bst.graph.treefy_states(module)
+        module = brainstate.nn.Linear(4, 5)
+        state_map = brainstate.graph.treefy_states(module)
         pure_dict = state_map.to_pure_dict()
         assert isinstance(pure_dict, dict)
         assert isinstance(pure_dict['weight'].value['weight'], jax.Array)
@@ -93,27 +92,27 @@ class TestNestedMapping(absltest.TestCase):
 
 class TestSplit(unittest.TestCase):
     def test_split(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.batchnorm = bst.nn.BatchNorm1d([10, 3])
-                self.linear = bst.nn.Linear([10, 3], [10, 4])
+                self.batchnorm = brainstate.nn.BatchNorm1d([10, 3])
+                self.linear = brainstate.nn.Linear([10, 3], [10, 4])
 
             def __call__(self, x):
                 return self.linear(self.batchnorm(x))
 
-        with bst.environ.context(fit=True):
+        with brainstate.environ.context(fit=True):
             model = Model()
-            x = bst.random.randn(1, 10, 3)
+            x = brainstate.random.randn(1, 10, 3)
             y = model(x)
             self.assertEqual(y.shape, (1, 10, 4))
 
-        state_map = bst.graph.treefy_states(model)
+        state_map = brainstate.graph.treefy_states(model)
 
         with self.assertRaises(ValueError):
-            params, others = state_map.split(bst.ParamState)
+            params, others = state_map.split(brainstate.ParamState)
 
-        params, others = state_map.split(bst.ParamState, ...)
+        params, others = state_map.split(brainstate.ParamState, ...)
         print()
         print(params)
         print(others)
@@ -124,37 +123,37 @@ class TestSplit(unittest.TestCase):
 
 class TestStateMap2(unittest.TestCase):
     def test1(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.batchnorm = bst.nn.BatchNorm1d([10, 3])
-                self.linear = bst.nn.Linear([10, 3], [10, 4])
+                self.batchnorm = brainstate.nn.BatchNorm1d([10, 3])
+                self.linear = brainstate.nn.Linear([10, 3], [10, 4])
 
             def __call__(self, x):
                 return self.linear(self.batchnorm(x))
 
-        with bst.environ.context(fit=True):
+        with brainstate.environ.context(fit=True):
             model = Model()
-            state_map = bst.graph.treefy_states(model).to_flat()
-            state_map = bst.util.NestedDict(state_map)
+            state_map = brainstate.graph.treefy_states(model).to_flat()
+            state_map = brainstate.util.NestedDict(state_map)
 
 
 class TestFlattedMapping(unittest.TestCase):
     def test1(self):
-        class Model(bst.nn.Module):
+        class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.batchnorm = bst.nn.BatchNorm1d([10, 3])
-                self.linear = bst.nn.Linear([10, 3], [10, 4])
+                self.batchnorm = brainstate.nn.BatchNorm1d([10, 3])
+                self.linear = brainstate.nn.Linear([10, 3], [10, 4])
 
             def __call__(self, x):
                 return self.linear(self.batchnorm(x))
 
         model = Model()
         # print(model.states())
-        # print(bst.graph.states(model))
-        self.assertTrue(model.states() == bst.graph.states(model))
+        # print(brainstate.graph.states(model))
+        self.assertTrue(model.states() == brainstate.graph.states(model))
 
         print(model.nodes())
-        # print(bst.graph.nodes(model))
-        self.assertTrue(model.nodes() == bst.graph.nodes(model))
+        # print(brainstate.graph.nodes(model))
+        self.assertTrue(model.nodes() == brainstate.graph.nodes(model))

--- a/brainstate/util/struct.py
+++ b/brainstate/util/struct.py
@@ -56,16 +56,16 @@ def dataclass(clz: T, **kwargs) -> T:
     The ``dataclass`` decorator makes it easy to define custom classes that can be
     passed safely to Jax. For example::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax
       >>> from typing import Any, Callable
 
-      >>> @bst.util.dataclass
+      >>> @brainstate.util.dataclass
       ... class Model:
       ...   params: Any
       ...   # use pytree_node=False to indicate an attribute should not be touched
       ...   # by Jax transformations.
-      ...   apply_fn: Callable = bst.util.field(pytree_node=False)
+      ...   apply_fn: Callable = brainstate.util.field(pytree_node=False)
 
       ...   def __apply__(self, *args):
       ...     return self.apply_fn(*args)
@@ -97,7 +97,7 @@ def dataclass(clz: T, **kwargs) -> T:
     This way the simple constructor used by ``jax.tree_util`` is
     preserved. Consider the following example::
 
-      >>> @bst.util.dataclass
+      >>> @brainstate.util.dataclass
       ... class DirectionAndScaleKernel:
       ...   direction: jax.Array
       ...   scale: jax.Array
@@ -189,15 +189,15 @@ class PyTreeNode:
 
     Example::
 
-      >>> import brainstate as bst
+      >>> import brainstate as brainstate
       >>> import jax
       >>> from typing import Any, Callable
 
-      >>> class Model(bst.util.PyTreeNode):
+      >>> class Model(brainstate.util.PyTreeNode):
       ...   params: Any
       ...   # use pytree_node=False to indicate an attribute should not be touched
       ...   # by Jax transformations.
-      ...   apply_fn: Callable = bst.util.field(pytree_node=False)
+      ...   apply_fn: Callable = brainstate.util.field(pytree_node=False)
 
       ...   def __apply__(self, *args):
       ...     return self.apply_fn(*args)

--- a/docs/examples/ann_training-en.ipynb
+++ b/docs/examples/ann_training-en.ipynb
@@ -199,7 +199,7 @@
     "  def __init__(self, din, dhidden, dout):\n",
     "    super().__init__()\n",
     "    self.count = Count(jnp.array(0))    # Count how many times model is called\n",
-    "    self.linear1 = Linear(din, dhidden)          # brainstate有常规层的实现，可以直接写 self.linear1 = bst.nn.Linear(din, dhidden)\n",
+    "    self.linear1 = Linear(din, dhidden)          # brainstate有常规层的实现，可以直接写 self.linear1 = brainstate.nn.Linear(din, dhidden)\n",
     "    self.linear2 = Linear(dhidden, dout)\n",
     "    self.flatten = brainstate.nn.Flatten(start_axis=1)   # Flatten images to 1D\n",
     "    self.relu = brainstate.nn.ReLU()   # ReLU activation function\n",

--- a/docs/examples/ann_training-zh.ipynb
+++ b/docs/examples/ann_training-zh.ipynb
@@ -199,7 +199,7 @@
     "  def __init__(self, din, dhidden, dout):\n",
     "    super().__init__()\n",
     "    self.count = Count(jnp.array(0))    # Count how many times model is called\n",
-    "    self.linear1 = Linear(din, dhidden)          # brainstate有常规层的实现，可以直接写 self.linear1 = bst.nn.Linear(din, dhidden)\n",
+    "    self.linear1 = Linear(din, dhidden)          # brainstate有常规层的实现，可以直接写 self.linear1 = brainstate.nn.Linear(din, dhidden)\n",
     "    self.linear2 = Linear(dhidden, dout)\n",
     "    self.flatten = brainstate.nn.Flatten(start_axis=1)   # Flatten images to 1D\n",
     "    self.relu = brainstate.nn.ReLU()   # ReLU activation function\n",

--- a/docs/examples/snn_simulation-en.ipynb
+++ b/docs/examples/snn_simulation-en.ipynb
@@ -68,9 +68,7 @@
    "id": "051f8f24",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# bst.environ.set(platform='gpu')"
-   ]
+   "source": "# brainstate.environ.set(platform='gpu')"
   },
   {
    "cell_type": "code",
@@ -224,7 +222,7 @@
    "source": [
     "def run(t, inp):\n",
     "    # Run the simulation for a given time 't' and input current 'inp'\n",
-    "    # `bst.environ.context` sets the environment context for this simulation step\n",
+    "    # `brainstate.environ.context` sets the environment context for this simulation step\n",
     "    with brainstate.environ.context(t=t, dt=dt):\n",
     "        hh(inp)  # Update the Hodgkin-Huxley model using the input current at time 't'\n",
     "    \n",
@@ -289,7 +287,7 @@
     "# Define the simulation times, from 0 to 100 ms with a time step of 'dt'\n",
     "times = u.math.arange(0. * u.ms, 100. * u.ms, dt)\n",
     "\n",
-    "# Run the simulation using `bst.compile.for_loop`:\n",
+    "# Run the simulation using `brainstate.compile.for_loop`:\n",
     "# - `run` function is called iteratively with each time step and random input current\n",
     "# - Random input current between 1 and 10 uA/cm² is generated at each time step\n",
     "# - `pbar` is used to show a progress bar during the simulation\n",
@@ -624,7 +622,7 @@
     "# Define the time array from 0 to 1000 ms with a step size of dt\n",
     "times = u.math.arange(0. * u.ms, 1000. * u.ms, brainstate.environ.get_dt())\n",
     "\n",
-    "# Run the simulation using `bst.compile.for_loop`, iterating over each time step\n",
+    "# Run the simulation using `brainstate.compile.for_loop`, iterating over each time step\n",
     "# The `lambda t: net.update(Ib)` applies the `update` method of the network `net`\n",
     "# for each time step, with `Ib` as the input current at each time step.\n",
     "spikes = brainstate.compile.for_loop(\n",

--- a/docs/examples/snn_simulation-zh.ipynb
+++ b/docs/examples/snn_simulation-zh.ipynb
@@ -64,9 +64,7 @@
      "start_time": "2025-05-11T02:51:18.537056Z"
     }
    },
-   "source": [
-    "# bst.environ.set(platform='gpu')"
-   ],
+   "source": "# brainstate.environ.set(platform='gpu')",
    "outputs": [],
    "execution_count": 2
   },
@@ -240,7 +238,7 @@
    "source": [
     "def run(t, inp):\n",
     "    # Run the simulation for a given time 't' and input current 'inp'\n",
-    "    # `bst.environ.context` sets the environment context for this simulation step\n",
+    "    # `brainstate.environ.context` sets the environment context for this simulation step\n",
     "    with brainstate.environ.context(t=t, dt=dt):\n",
     "        hh(inp)  # Update the Hodgkin-Huxley model using the input current at time 't'\n",
     "    \n",
@@ -273,7 +271,7 @@
     "# Define the simulation times, from 0 to 100 ms with a time step of 'dt'\n",
     "times = u.math.arange(0. * u.ms, 100. * u.ms, dt)\n",
     "\n",
-    "# Run the simulation using `bst.compile.for_loop`:\n",
+    "# Run the simulation using `brainstate.compile.for_loop`:\n",
     "# - `run` function is called iteratively with each time step and random input current\n",
     "# - Random input current between 1 and 10 uA/cm² is generated at each time step\n",
     "# - `pbar` is used to show a progress bar during the simulation\n",
@@ -641,7 +639,7 @@
     "# Define the time array from 0 to 1000 ms with a step size of dt\n",
     "times = u.math.arange(0. * u.ms, 1000. * u.ms, brainstate.environ.get_dt())\n",
     "\n",
-    "# Run the simulation using `bst.compile.for_loop`, iterating over each time step\n",
+    "# Run the simulation using `brainstate.compile.for_loop`, iterating over each time step\n",
     "# The `lambda t: net.update(Ib)` applies the `update` method of the network `net`\n",
     "# for each time step, with `Ib` as the input current at each time step.\n",
     "spikes = brainstate.compile.for_loop(\n",

--- a/examples/106_COBA_HH_2007.py
+++ b/examples/106_COBA_HH_2007.py
@@ -26,7 +26,7 @@ import numpy as np
 
 import brainstate
 
-# bst.environ.set(precision='bf16')
+# brainstate.environ.set(precision='bf16')
 
 num_exc = 3200
 num_inh = 800

--- a/examples/107_gamma_oscillation_1996.py
+++ b/examples/107_gamma_oscillation_1996.py
@@ -105,7 +105,7 @@ class GammaNet(brainstate.nn.DynamicsGroup):
     def __init__(self, num: int = 100):
         super().__init__()
         self.neu = HH(num)
-        # self.syn = bst.nn.GABAa(num, alpha=12 / (u.ms * u.mM), beta=0.1 / u.ms)
+        # self.syn = brainstate.nn.GABAa(num, alpha=12 / (u.ms * u.mM), beta=0.1 / u.ms)
         self.syn = Synapse(num)
         self.proj = brainstate.nn.CurrentProj(
             self.syn.prefetch('g'),

--- a/examples/110_Susin_Destexhe_2021_gamma_oscillation_AI.py
+++ b/examples/110_Susin_Destexhe_2021_gamma_oscillation_AI.py
@@ -171,7 +171,7 @@ def simulate_ai_net():
 
         # # spike raster plot
         # spikes = returns['FS.spike']
-        # fig, gs = bts.visualize.get_figure(1, 1, 4., 5.)
+        # fig, gs = braintools.visualize.get_figure(1, 1, 4., 5.)
         # fig.add_subplot(gs[0, 0])
         # times2 = times.to_decimal(u.ms)
         # t_indices, n_indices = u.math.where(spikes)

--- a/examples/200_surrogate_grad_lif.py
+++ b/examples/200_surrogate_grad_lif.py
@@ -124,7 +124,7 @@ with brainstate.environ.context(dt=1.0 * u.ms):
 
     # # optax optimizer
     # import optax
-    # optimizer = bst.optim.OptaxOptimizer(net.states(bst.ParamState), optax.adam(1e-3))
+    # optimizer = brainstate.optim.OptaxOptimizer(net.states(brainstate.ParamState), optax.adam(1e-3))
 
     def loss_fn():
         predictions = brainstate.compile.for_loop(net.update, x_data)

--- a/examples/301_brainscale_for_rnns.py
+++ b/examples/301_brainscale_for_rnns.py
@@ -386,7 +386,7 @@ class Trainer(object):
 
 def network_training():
     # environment setting
-    # bst.environ.set(dt=args.dt)
+    # brainstate.environ.set(dt=args.dt)
 
     # get file path to output
     now = time.strftime('%Y-%m-%d %H-%M-%S', time.localtime(int(round(time.time() * 1000)) / 1000))


### PR DESCRIPTION
## Summary by Sourcery

Standardize import alias usage by replacing shorthand alias "bst" with the actual module name "brainstate" across examples, docstrings, tests, and notebooks for consistency.

Enhancements:
- Replace all occurrences of the "bst" alias with "brainstate" in code examples, docstrings, comments, and notebooks for clarity.

Documentation:
- Update documentation examples and Jupyter notebooks to import and reference the module as "brainstate" instead of "bst".

Tests:
- Adjust test files and internal test examples to use "brainstate" imports in place of the "bst" alias.