### PR TITLE
Refactor ArrayImpl: Standardize `ArrayLike` and add unit tests

### DIFF
--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -527,8 +527,8 @@ class State(Generic[A], PrettyObject):
 
         return k, v
 
-    def __eq__(self, other: object) -> bool:
-        return type(self) is type(other) and vars(other) == vars(self)
+    # def __eq__(self, other: object) -> bool:
+    #     return type(self) is type(other) and vars(other) == vars(self)
 
     def __hash__(self):
         """

--- a/brainstate/mixin.py
+++ b/brainstate/mixin.py
@@ -27,6 +27,7 @@ import jax.numpy as jnp
 import numpy as np
 
 T = TypeVar('T')
+ArrayLike = jax.typing.ArrayLike
 
 __all__ = [
     'Mixin',
@@ -139,7 +140,7 @@ class ParamDescriber(metaclass=NoSubclassMeta):
         return self._identifier
 
     @identifier.setter
-    def identifier(self, value):
+    def identifier(self, value: ArrayLike):
         raise AttributeError('Cannot set the identifier.')
 
 
@@ -371,7 +372,7 @@ class Training(Mode):
 
 
 class ArrayImpl(Mixin):
-    value: jax.typing.ArrayLike
+    value: ArrayLike
 
     def __hash__(self):
         return hash(self.value)
@@ -425,12 +426,12 @@ class ArrayImpl(Mixin):
             return self.value
         return self.value[index]
 
-    def __setitem__(self, index, value):
+    def __setitem__(self, index, value: ArrayLike):
         if isinstance(value, np.ndarray):
             value = u.math.asarray(value)
 
         # update
-        self_value = self.value
+        self_value = u.math.asarray(self.value)
         self.value = self_value.at[index].set(value)
 
     # ---------- #
@@ -647,7 +648,7 @@ class ArrayImpl(Mixin):
         """Return indices of the minimum values along the given axis."""
         return self.value.argmin(axis=axis)
 
-    def argpartition(self, kth, axis=-1, kind='introselect', order=None):
+    def argpartition(self, kth, axis: int = -1, kind: str = 'introselect', order=None):
         """Returns the indices that would partition this array."""
         return self.value.argpartition(kth=kth, axis=axis, kind=kind, order=order)
 
@@ -718,7 +719,7 @@ class ArrayImpl(Mixin):
         """Dot product of two arrays."""
         return self.value.dot(b)
 
-    def fill(self, value):
+    def fill(self, value: ArrayLike):
         """Fill the array with a scalar value."""
         self.value = u.math.ones_like(self.value) * value
 
@@ -836,9 +837,6 @@ class ArrayImpl(Mixin):
         """Return an array formed from the elements of a at the given indices."""
         return self.value.take(indices=indices, axis=axis, mode=mode)
 
-    def tobytes(self):
-        return self.value.tobytes()
-
     def tolist(self):
         return self.value.tolist()
 
@@ -927,7 +925,7 @@ class ArrayImpl(Mixin):
     # PyTorch compatibility
     # ----------------------
 
-    def unsqueeze(self, dim: int) -> 'Array':
+    def unsqueeze(self, dim: int) -> ArrayLike:
         """
         Array.unsqueeze(dim) -> Array, or so called Tensor
         equals
@@ -937,10 +935,10 @@ class ArrayImpl(Mixin):
         """
         return u.math.expand_dims(self.value, dim)
 
-    def expand_dims(self, axis: Union[int, Sequence[int]]) -> 'Array':
+    def expand_dims(self, axis: Union[int, Sequence[int]]) -> ArrayLike:
         return u.math.expand_dims(self.value, axis)
 
-    def expand_as(self, array: Union['Array', jax.Array, np.ndarray]) -> 'Array':
+    def expand_as(self, array: ArrayLike) -> ArrayLike:
         return u.math.broadcast_to(self.value, array)
 
     def pow(self, index: int):
@@ -948,19 +946,19 @@ class ArrayImpl(Mixin):
 
     def addr(
         self,
-        vec1: Union['Array', jax.Array, np.ndarray],
-        vec2: Union['Array', jax.Array, np.ndarray],
+        vec1: ArrayLike,
+        vec2: ArrayLike,
         *,
         beta: float = 1.0,
         alpha: float = 1.0,
-    ) -> Optional['Array']:
+    ) -> Optional[ArrayLike]:
         r = alpha * u.math.outer(vec1, vec2) + beta * self.value
         return r
 
     def addr_(
         self,
-        vec1: Union['Array', jax.Array, np.ndarray],
-        vec2: Union['Array', jax.Array, np.ndarray],
+        vec1: ArrayLike,
+        vec2: ArrayLike,
         *,
         beta: float = 1.0,
         alpha: float = 1.0
@@ -969,10 +967,10 @@ class ArrayImpl(Mixin):
         self.value = r
         return self
 
-    def outer(self, other: Union['Array', jax.Array, np.ndarray]) -> 'Array':
+    def outer(self, other: ArrayLike) -> ArrayLike:
         return u.math.outer(self.value, other.value)
 
-    def abs(self) -> Optional['Array']:
+    def abs(self) -> Optional[ArrayLike]:
         r = u.math.abs(self.value)
         return r
 
@@ -983,11 +981,11 @@ class ArrayImpl(Mixin):
         self.value = u.math.abs(self.value)
         return self
 
-    def add_(self, value):
+    def add_(self, value: ArrayLike):
         self.value += value
         return self
 
-    def absolute(self) -> Optional['Array']:
+    def absolute(self) -> Optional[ArrayLike]:
         """
         alias of Array.abs
         """
@@ -999,17 +997,17 @@ class ArrayImpl(Mixin):
         """
         return self.abs_()
 
-    def mul(self, value):
+    def mul(self, value: ArrayLike):
         return self.value * value
 
-    def mul_(self, value):
+    def mul_(self, value: ArrayLike):
         """
         In-place version of :meth:`~Array.mul`.
         """
         self.value *= value
         return self
 
-    def multiply(self, value):  # real signature unknown; restored from __doc__
+    def multiply(self, value: ArrayLike):  # real signature unknown; restored from __doc__
         """
         multiply(value) -> Tensor
 
@@ -1017,7 +1015,7 @@ class ArrayImpl(Mixin):
         """
         return self.value * value
 
-    def multiply_(self, value):  # real signature unknown; restored from __doc__
+    def multiply_(self, value: ArrayLike):  # real signature unknown; restored from __doc__
         """
         multiply_(value) -> Tensor
 
@@ -1026,7 +1024,7 @@ class ArrayImpl(Mixin):
         self.value *= value
         return self
 
-    def sin(self) -> Optional['Array']:
+    def sin(self) -> Optional[ArrayLike]:
         r = u.math.sin(self.value)
         return r
 
@@ -1038,7 +1036,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.cos(self.value)
         return self
 
-    def cos(self) -> Optional['Array']:
+    def cos(self) -> Optional[ArrayLike]:
         r = u.math.cos(self.value)
         return r
 
@@ -1046,7 +1044,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.tan(self.value)
         return self
 
-    def tan(self) -> Optional['Array']:
+    def tan(self) -> Optional[ArrayLike]:
         r = u.math.tan(self.value)
         return r
 
@@ -1054,7 +1052,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.sinh(self.value)
         return self
 
-    def sinh(self) -> Optional['Array']:
+    def sinh(self) -> Optional[ArrayLike]:
         r = u.math.sinh(self.value)
         return r
 
@@ -1062,7 +1060,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.cosh(self.value)
         return self
 
-    def cosh(self) -> Optional['Array']:
+    def cosh(self) -> Optional[ArrayLike]:
         r = u.math.cosh(self.value)
         return r
 
@@ -1070,7 +1068,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.tanh(self.value)
         return self
 
-    def tanh(self) -> Optional['Array']:
+    def tanh(self) -> Optional[ArrayLike]:
         r = u.math.tanh(self.value)
         return r
 
@@ -1078,7 +1076,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.arcsin(self.value)
         return self
 
-    def arcsin(self) -> Optional['Array']:
+    def arcsin(self) -> Optional[ArrayLike]:
         r = u.math.arcsin(self.value)
         return r
 
@@ -1086,7 +1084,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.arccos(self.value)
         return self
 
-    def arccos(self) -> Optional['Array']:
+    def arccos(self) -> Optional[ArrayLike]:
         r = u.math.arccos(self.value)
         return r
 
@@ -1094,15 +1092,15 @@ class ArrayImpl(Mixin):
         self.value = u.math.arctan(self.value)
         return self
 
-    def arctan(self) -> Optional['Array']:
+    def arctan(self) -> Optional[ArrayLike]:
         r = u.math.arctan(self.value)
         return r
 
     def clamp(
         self,
-        min_value: Optional[Union['Array', jax.Array, np.ndarray]] = None,
-        max_value: Optional[Union['Array', jax.Array, np.ndarray]] = None,
-    ) -> Optional['Array']:
+        min_value: Optional[ArrayLike] = None,
+        max_value: Optional[ArrayLike] = None,
+    ) -> Optional[ArrayLike]:
         """
         return the value between min_value and max_value,
         if min_value is None, then no lower bound,
@@ -1113,8 +1111,8 @@ class ArrayImpl(Mixin):
 
     def clamp_(
         self,
-        min_value: Optional[Union['Array', jax.Array, np.ndarray]] = None,
-        max_value: Optional[Union['Array', jax.Array, np.ndarray]] = None
+        min_value: Optional[ArrayLike] = None,
+        max_value: Optional[ArrayLike] = None
     ):
         """
         return the value between min_value and max_value,
@@ -1126,8 +1124,8 @@ class ArrayImpl(Mixin):
 
     def clip_(
         self,
-        min_value: Optional[Union['Array', jax.Array, np.ndarray]] = None,
-        max_value: Optional[Union['Array', jax.Array, np.ndarray]] = None
+        min_value: Optional[ArrayLike] = None,
+        max_value: Optional[ArrayLike] = None
     ):
         """
         alias for clamp_
@@ -1135,10 +1133,10 @@ class ArrayImpl(Mixin):
         self.value = self.clip(min_value, max_value)
         return self
 
-    def clone(self) -> 'Array':
+    def clone(self) -> ArrayLike:
         return self.value.copy()
 
-    def expand(self, *sizes) -> 'Array':
+    def expand(self, *sizes) -> ArrayLike:
         """
         Expand an array to a new shape.
 
@@ -1178,7 +1176,7 @@ class ArrayImpl(Mixin):
         self.value = u.math.zeros_like(self.value)
         return self
 
-    def fill_(self, value):
+    def fill_(self, value: ArrayLike):
         self.fill(value)
         return self
 

--- a/brainstate/mixin_test.py
+++ b/brainstate/mixin_test.py
@@ -14,60 +14,452 @@
 # ==============================================================================
 
 import unittest
+import jax
+import jax.numpy as jnp
+import numpy as np
 
-import brainstate as bc
+import brainstate
 
 
 class TestMixin(unittest.TestCase):
     def test_mixin(self):
-        self.assertTrue(bc.mixin.Mixin)
-        self.assertTrue(bc.mixin.ParamDesc)
-        self.assertTrue(bc.mixin.ParamDescriber)
-        self.assertTrue(bc.mixin.JointTypes)
-        self.assertTrue(bc.mixin.OneOfTypes)
-        self.assertTrue(bc.mixin.Mode)
-        self.assertTrue(bc.mixin.Batching)
-        self.assertTrue(bc.mixin.Training)
+        self.assertTrue(brainstate.mixin.Mixin)
+        self.assertTrue(brainstate.mixin.ParamDesc)
+        self.assertTrue(brainstate.mixin.ParamDescriber)
+        self.assertTrue(brainstate.mixin.JointTypes)
+        self.assertTrue(brainstate.mixin.OneOfTypes)
+        self.assertTrue(brainstate.mixin.Mode)
+        self.assertTrue(brainstate.mixin.Batching)
+        self.assertTrue(brainstate.mixin.Training)
 
 
 class TestMode(unittest.TestCase):
     def test_JointMode(self):
-        a = bc.mixin.JointMode(bc.mixin.Batching(), bc.mixin.Training())
-        self.assertTrue(a.is_a(bc.mixin.JointTypes[bc.mixin.Batching, bc.mixin.Training]))
-        self.assertTrue(a.has(bc.mixin.Batching))
-        self.assertTrue(a.has(bc.mixin.Training))
-        b = bc.mixin.JointMode(bc.mixin.Batching())
-        self.assertTrue(b.is_a(bc.mixin.JointTypes[bc.mixin.Batching]))
-        self.assertTrue(b.is_a(bc.mixin.Batching))
-        self.assertTrue(b.has(bc.mixin.Batching))
+        a = brainstate.mixin.JointMode(brainstate.mixin.Batching(), brainstate.mixin.Training())
+        self.assertTrue(a.is_a(brainstate.mixin.JointTypes[brainstate.mixin.Batching, brainstate.mixin.Training]))
+        self.assertTrue(a.has(brainstate.mixin.Batching))
+        self.assertTrue(a.has(brainstate.mixin.Training))
+        b = brainstate.mixin.JointMode(brainstate.mixin.Batching())
+        self.assertTrue(b.is_a(brainstate.mixin.JointTypes[brainstate.mixin.Batching]))
+        self.assertTrue(b.is_a(brainstate.mixin.Batching))
+        self.assertTrue(b.has(brainstate.mixin.Batching))
 
     def test_Training(self):
-        a = bc.mixin.Training()
-        self.assertTrue(a.is_a(bc.mixin.Training))
-        self.assertTrue(a.is_a(bc.mixin.JointTypes[bc.mixin.Training]))
-        self.assertTrue(a.has(bc.mixin.Training))
-        self.assertTrue(a.has(bc.mixin.JointTypes[bc.mixin.Training]))
-        self.assertFalse(a.is_a(bc.mixin.Batching))
-        self.assertFalse(a.has(bc.mixin.Batching))
+        a = brainstate.mixin.Training()
+        self.assertTrue(a.is_a(brainstate.mixin.Training))
+        self.assertTrue(a.is_a(brainstate.mixin.JointTypes[brainstate.mixin.Training]))
+        self.assertTrue(a.has(brainstate.mixin.Training))
+        self.assertTrue(a.has(brainstate.mixin.JointTypes[brainstate.mixin.Training]))
+        self.assertFalse(a.is_a(brainstate.mixin.Batching))
+        self.assertFalse(a.has(brainstate.mixin.Batching))
 
     def test_Batching(self):
-        a = bc.mixin.Batching()
-        self.assertTrue(a.is_a(bc.mixin.Batching))
-        self.assertTrue(a.is_a(bc.mixin.JointTypes[bc.mixin.Batching]))
-        self.assertTrue(a.has(bc.mixin.Batching))
-        self.assertTrue(a.has(bc.mixin.JointTypes[bc.mixin.Batching]))
+        a = brainstate.mixin.Batching()
+        self.assertTrue(a.is_a(brainstate.mixin.Batching))
+        self.assertTrue(a.is_a(brainstate.mixin.JointTypes[brainstate.mixin.Batching]))
+        self.assertTrue(a.has(brainstate.mixin.Batching))
+        self.assertTrue(a.has(brainstate.mixin.JointTypes[brainstate.mixin.Batching]))
 
-        self.assertFalse(a.is_a(bc.mixin.Training))
-        self.assertFalse(a.has(bc.mixin.Training))
+        self.assertFalse(a.is_a(brainstate.mixin.Training))
+        self.assertFalse(a.has(brainstate.mixin.Training))
 
     def test_Mode(self):
-        a = bc.mixin.Mode()
-        self.assertTrue(a.is_a(bc.mixin.Mode))
-        self.assertTrue(a.is_a(bc.mixin.JointTypes[bc.mixin.Mode]))
-        self.assertTrue(a.has(bc.mixin.Mode))
-        self.assertTrue(a.has(bc.mixin.JointTypes[bc.mixin.Mode]))
+        a = brainstate.mixin.Mode()
+        self.assertTrue(a.is_a(brainstate.mixin.Mode))
+        self.assertTrue(a.is_a(brainstate.mixin.JointTypes[brainstate.mixin.Mode]))
+        self.assertTrue(a.has(brainstate.mixin.Mode))
+        self.assertTrue(a.has(brainstate.mixin.JointTypes[brainstate.mixin.Mode]))
 
-        self.assertFalse(a.is_a(bc.mixin.Training))
-        self.assertFalse(a.has(bc.mixin.Training))
-        self.assertFalse(a.is_a(bc.mixin.Batching))
-        self.assertFalse(a.has(bc.mixin.Batching))
+        self.assertFalse(a.is_a(brainstate.mixin.Training))
+        self.assertFalse(a.has(brainstate.mixin.Training))
+        self.assertFalse(a.is_a(brainstate.mixin.Batching))
+        self.assertFalse(a.has(brainstate.mixin.Batching))
+
+
+class Array(brainstate.State, brainstate.mixin.ArrayImpl):
+    pass
+
+
+class TestArray(unittest.TestCase):
+    def setUp(self):
+        # Basic arrays for testing
+        self.np_array = np.array([1, 2, 3])
+        self.jax_array = jnp.array([1, 2, 3])
+        # Create ArrayImpl instances
+        self.array_impl_np = Array(self.np_array)
+        self.array_impl_np.value = self.np_array
+        self.array_impl_jax = Array(self.jax_array)
+        self.array_impl_jax.value = self.jax_array
+        # More complex arrays for advanced testing
+        self.ones_2d = np.ones((2, 3))
+        self.array_impl_2d = Array(self.ones_2d)
+        self.array_impl_2d.value = self.ones_2d
+        # Scalar array
+        self.scalar = np.array(5.0)
+        self.array_impl_scalar = Array(self.scalar)
+        self.array_impl_scalar.value = self.scalar
+
+    def test_basic_properties(self):
+        # Test dtype property
+        self.assertEqual(self.array_impl_np.dtype, self.np_array.dtype)
+        self.assertEqual(self.array_impl_jax.dtype, self.jax_array.dtype)
+
+        # Test shape property
+        self.assertEqual(self.array_impl_np.shape, self.np_array.shape)
+        self.assertEqual(self.array_impl_jax.shape, self.jax_array.shape)
+
+        # Test ndim property
+        self.assertEqual(self.array_impl_np.ndim, self.np_array.ndim)
+        self.assertEqual(self.array_impl_2d.ndim, self.ones_2d.ndim)
+
+        # Test size property
+        self.assertEqual(self.array_impl_np.size, self.np_array.size)
+        self.assertEqual(self.array_impl_2d.size, self.ones_2d.size)
+
+        # Test real property (should work for real arrays)
+        np.testing.assert_array_equal(self.array_impl_np.real, self.np_array.real)
+
+        # Test T property (transpose)
+        np.testing.assert_array_equal(self.array_impl_2d.T, self.ones_2d.T)
+
+    def test_unary_operations(self):
+        # Test __neg__
+        np.testing.assert_array_equal(-self.array_impl_np, -self.np_array)
+
+        # Test __pos__
+        np.testing.assert_array_equal(+self.array_impl_np, +self.np_array)
+
+        # Test __abs__
+        neg_array = Array(np.array([-1, 2, -3]))
+        np.testing.assert_array_equal(abs(neg_array), np.abs(neg_array.value))
+
+        # Test __invert__ (bitwise NOT)
+        uint_array = Array(np.array([1, 2, 3], dtype=np.uint8))
+        np.testing.assert_array_equal(~uint_array, ~uint_array.value)
+
+    def test_binary_operations(self):
+        # Test __add__ and __radd__
+        np.testing.assert_array_equal(self.array_impl_np + 2, self.np_array + 2)
+        np.testing.assert_array_equal(2 + self.array_impl_np, 2 + self.np_array)
+
+        # Test __sub__ and __rsub__
+        np.testing.assert_array_equal(self.array_impl_np - 1, self.np_array - 1)
+        np.testing.assert_array_equal(5 - self.array_impl_np, 5 - self.np_array)
+
+        # Test __mul__ and __rmul__
+        np.testing.assert_array_equal(self.array_impl_np * 2, self.np_array * 2)
+        np.testing.assert_array_equal(2 * self.array_impl_np, 2 * self.np_array)
+
+        # Test __truediv__ and __rtruediv__
+        np.testing.assert_array_almost_equal(self.array_impl_np / 2, self.np_array / 2)
+        np.testing.assert_array_almost_equal(6 / self.array_impl_np, 6 / self.np_array)
+
+        # Test __pow__ and __rpow__
+        np.testing.assert_array_equal(self.array_impl_np ** 2, self.np_array ** 2)
+        np.testing.assert_array_equal(2 ** self.array_impl_np, 2 ** self.np_array)
+
+        # Test __matmul__
+        a = Array(np.array([[1, 2], [3, 4]]))
+        b = Array(np.array([[5, 6], [7, 8]]))
+        np.testing.assert_array_equal(a @ b, a.value @ b.value)
+
+    def test_inplace_operations(self):
+        # Test __iadd__
+        test_array = Array(np.array([1, 2, 3]))
+        test_array += 1
+        np.testing.assert_array_equal(test_array.value, np.array([2, 3, 4]))
+
+        # Test __isub__
+        test_array = Array(np.array([1, 2, 3]))
+        test_array -= 1
+        np.testing.assert_array_equal(test_array.value, np.array([0, 1, 2]))
+
+        # Test __imul__
+        test_array = Array(np.array([1, 2, 3]))
+        test_array *= 2
+        np.testing.assert_array_equal(test_array.value, np.array([2, 4, 6]))
+
+        # Test __itruediv__
+        test_array = Array(np.array([2, 4, 6]))
+        test_array /= 2
+        np.testing.assert_array_equal(test_array.value, np.array([1, 2, 3]))
+
+    def test_iterator(self):
+        # Test __iter__
+        values = [x for x in self.array_impl_np]
+        expected_values = [x for x in self.np_array]
+        self.assertEqual(values, expected_values)
+
+    def test_misc_methods(self):
+        # Test fill method
+        test_array = Array(np.array([1, 2, 3]))
+        test_array.fill(5)
+        np.testing.assert_array_equal(test_array.value, np.array([5, 5, 5]))
+
+        # Test flatten method
+        flattened = self.array_impl_2d.flatten()
+        np.testing.assert_array_equal(flattened, self.ones_2d.flatten())
+
+        # Test item method
+        scalar_impl = Array(np.array(5.0))
+        self.assertEqual(scalar_impl.item(), 5.0)
+
+        # Test view method
+        view_array = Array(np.array([1, 2, 3], dtype=np.int32))
+        int_view = view_array.view(np.int32)
+        self.assertEqual(int_view.dtype, np.int32)
+
+
+class TestArray2(unittest.TestCase):
+    def setUp(self):
+        # Basic arrays for testing
+        self.np_array = np.array([1, 2, 3])
+        self.jax_array = jnp.array([1, 2, 3])
+        # Create ArrayImpl instances
+        self.array_impl_np = Array(self.np_array)
+        self.array_impl_jax = Array(self.jax_array)
+        # More complex arrays for advanced testing
+        self.ones_2d = np.ones((2, 3))
+        self.array_impl_2d = Array(self.ones_2d)
+        # Scalar array
+        self.scalar = np.array(5.0)
+        self.array_impl_scalar = Array(self.scalar)
+
+    def test_basic_properties(self):
+        # Test dtype property
+        self.assertEqual(self.array_impl_np.dtype, self.np_array.dtype)
+        self.assertEqual(self.array_impl_jax.dtype, self.jax_array.dtype)
+
+        # Test shape property
+        self.assertEqual(self.array_impl_np.shape, self.np_array.shape)
+        self.assertEqual(self.array_impl_jax.shape, self.jax_array.shape)
+
+        # Test ndim property
+        self.assertEqual(self.array_impl_np.ndim, self.np_array.ndim)
+        self.assertEqual(self.array_impl_2d.ndim, self.ones_2d.ndim)
+
+        # Test real property (should work for real arrays)
+        np.testing.assert_array_equal(self.array_impl_np.real, self.np_array.real)
+
+    def test_unary_operations(self):
+        # Test __neg__
+        np.testing.assert_array_equal(-self.array_impl_np, -self.np_array)
+
+        # Test __pos__
+        np.testing.assert_array_equal(+self.array_impl_np, +self.np_array)
+
+        # Test __abs__
+        neg_array = Array(np.array([-1, 2, -3]))
+        np.testing.assert_array_equal(abs(neg_array), np.abs(neg_array.value))
+
+        # Test __invert__ (bitwise NOT)
+        uint_array = Array(np.array([1, 2, 3], dtype=np.uint8))
+        np.testing.assert_array_equal(~uint_array, ~uint_array.value)
+
+    def test_binary_operations(self):
+        # Test __add__ and __radd__
+        np.testing.assert_array_equal(self.array_impl_np + 2, self.np_array + 2)
+        np.testing.assert_array_equal(2 + self.array_impl_np, 2 + self.np_array)
+
+        # Test __sub__ and __rsub__
+        np.testing.assert_array_equal(self.array_impl_np - 1, self.np_array - 1)
+        np.testing.assert_array_equal(5 - self.array_impl_np, 5 - self.np_array)
+
+        # Test __mul__ and __rmul__
+        np.testing.assert_array_equal(self.array_impl_np * 2, self.np_array * 2)
+        np.testing.assert_array_equal(2 * self.array_impl_np, 2 * self.np_array)
+
+        # Test __truediv__ and __rtruediv__
+        np.testing.assert_array_almost_equal(self.array_impl_np / 2, self.np_array / 2)
+        np.testing.assert_array_almost_equal(6 / self.array_impl_np, 6 / self.np_array)
+
+        # Test __pow__ and __rpow__
+        np.testing.assert_array_equal(self.array_impl_np ** 2, self.np_array ** 2)
+        np.testing.assert_array_equal(2 ** self.array_impl_np, 2 ** self.np_array)
+
+        # Test __matmul__
+        a = Array(np.array([[1, 2], [3, 4]]))
+        b = Array(np.array([[5, 6], [7, 8]]))
+        np.testing.assert_array_equal(a @ b, a.value @ b.value)
+
+    def test_inplace_operations(self):
+        # Test __iadd__
+        test_array = Array(np.array([1, 2, 3]))
+        test_array += 1
+        np.testing.assert_array_equal(test_array.value, np.array([2, 3, 4]))
+
+        # Test __isub__
+        test_array = Array(np.array([1, 2, 3]))
+        test_array -= 1
+        np.testing.assert_array_equal(test_array.value, np.array([0, 1, 2]))
+
+        # Test __imul__
+        test_array = Array(np.array([1, 2, 3]))
+        test_array *= 2
+        np.testing.assert_array_equal(test_array.value, np.array([2, 4, 6]))
+
+        # Test __itruediv__
+        test_array = Array(np.array([2, 4, 6]))
+        test_array /= 2
+        np.testing.assert_array_equal(test_array.value, np.array([1, 2, 3]))
+
+    def test_iterator(self):
+        # Test __iter__
+        values = [x for x in self.array_impl_np]
+        expected_values = [x for x in self.np_array]
+        self.assertEqual(values, expected_values)
+
+    def test_misc_methods(self):
+        # Test fill method
+        test_array = Array(np.array([1, 2, 3]))
+        test_array.fill(5)
+        np.testing.assert_array_equal(test_array.value, np.array([5, 5, 5]))
+
+        # Test flatten method
+        flattened = self.array_impl_2d.flatten()
+        np.testing.assert_array_equal(flattened, self.ones_2d.flatten())
+
+        # Test item method
+        scalar_impl = Array(np.array(5.0))
+        self.assertEqual(scalar_impl.item(), 5.0)
+
+        # Test view method
+        view_array = Array(np.array([1, 2, 3], dtype=np.int32))
+        int_view = view_array.view(np.int32)
+        self.assertEqual(int_view.dtype, np.int32)
+
+    def test_advanced_indexing(self):
+        # Test basic indexing
+        arr = Array(np.array([1, 2, 3, 4, 5]))
+        self.assertEqual(arr[0], 1)
+        self.assertEqual(arr[-1], 5)
+        np.testing.assert_array_equal(arr[1:4], np.array([2, 3, 4]))
+
+        # Test boolean indexing
+        bool_mask = np.array([True, False, True, False, True])
+        np.testing.assert_array_equal(arr[bool_mask], np.array([1, 3, 5]))
+
+        # Test integer array indexing
+        idx = np.array([0, 2, 4])
+        np.testing.assert_array_equal(arr[idx], np.array([1, 3, 5]))
+
+        # Test assignment via indexing
+        arr = Array(np.array([1, 2, 3, 4, 5]))
+        arr[1:4] = 10
+        np.testing.assert_array_equal(arr.value, np.array([1, 10, 10, 10, 5]))
+
+    def test_comparison_operators(self):
+        arr = Array(np.array([1, 2, 3]))
+
+        # Test ==, !=, <, <=, >, >=
+        np.testing.assert_array_equal(arr == 2, np.array([False, True, False]))
+        np.testing.assert_array_equal(arr != 2, np.array([True, False, True]))
+        np.testing.assert_array_equal(arr < 2, np.array([True, False, False]))
+        np.testing.assert_array_equal(arr <= 2, np.array([True, True, False]))
+        np.testing.assert_array_equal(arr > 2, np.array([False, False, True]))
+        np.testing.assert_array_equal(arr >= 2, np.array([False, True, True]))
+
+        # Test array vs array comparisons
+        arr2 = Array(np.array([2, 2, 2]))
+        np.testing.assert_array_equal(arr == arr2, np.array([False, True, False]))
+
+    def test_jax_integration(self):
+        # Test JAX transformations with Array
+        arr = Array(jnp.array([1.0, 2.0, 3.0]))
+
+        # Test jit compilation
+        @jax.jit
+        def square(x):
+            return x * x
+
+        result = square(arr)
+        self.assertIsInstance(result, jax.Array)
+        np.testing.assert_array_equal(result, jnp.array([1.0, 4.0, 9.0]))
+
+        # Test grad with Array
+        @jax.grad
+        def sum_squares(x):
+            return jnp.sum(x * x)
+
+        grad_result = sum_squares(arr)
+        self.assertIsInstance(grad_result, jax.Array)
+        np.testing.assert_array_equal(grad_result, jnp.array([2.0, 4.0, 6.0]))
+
+    def test_edge_cases(self):
+        # Test empty array
+        empty_arr = Array(np.array([]))
+        self.assertEqual(empty_arr.shape, (0,))
+        self.assertEqual(empty_arr.ndim, 1)
+
+        # Test very large array
+        large_arr = Array(np.ones((1000,)))
+        self.assertEqual(large_arr.shape, (1000,))
+
+        # Test high-dimensional array
+        high_dim = Array(np.zeros((2, 3, 4, 5)))
+        self.assertEqual(high_dim.ndim, 4)
+        self.assertEqual(high_dim.shape, (2, 3, 4, 5))
+
+    def test_error_handling(self):
+        # Test setting value with different tree structure
+        arr = Array(np.array([1, 2, 3]))
+
+        # Test invalid operations
+        with self.assertRaises(TypeError):
+            # Attempt to add incompatible types
+            arr + "string"
+
+    def test_copy_and_clone(self):
+        # Test copy method
+        arr = Array(np.array([1, 2, 3]))
+        arr_copy = arr.copy()
+
+        # Check they have the same value but are different objects
+        np.testing.assert_array_equal(arr.value, arr_copy.value)
+        self.assertIsNot(arr, arr_copy)
+
+        # Modify the copy and check original is unchanged
+        arr_copy.value = np.array([4, 5, 6])
+        np.testing.assert_array_equal(arr.value, np.array([1, 2, 3]))
+
+        # Test replace method
+        arr_replaced = arr.replace(value=np.array([7, 8, 9]))
+        np.testing.assert_array_equal(arr_replaced.value, np.array([7, 8, 9]))
+        # Original should remain unchanged
+        np.testing.assert_array_equal(arr.value, np.array([1, 2, 3]))
+
+    def test_state_integration(self):
+        # Test State methods
+        arr = Array(np.array([1, 2, 3]), name="test_array")
+        self.assertEqual(arr.name, "test_array")
+
+        # Test numel method
+        self.assertEqual(arr.numel(), 3)
+        self.assertEqual(self.array_impl_2d.numel(), 6)  # 2x3 array
+
+        # Test stack level operations
+        original_level = arr.stack_level
+        arr.increase_stack_level()
+        self.assertEqual(arr.stack_level, original_level + 1)
+        arr.decrease_stack_level()
+        self.assertEqual(arr.stack_level, original_level)
+
+    def test_brainstate_integration(self):
+        # Test value_call method
+        arr = Array(np.array([1, 2, 3]))
+        result = arr.value_call(lambda x: x * 2)
+        np.testing.assert_array_equal(result, np.array([2, 4, 6]))
+
+        # Test with brainstate functions
+        import brainstate as bs
+
+        # Test check_state_value_tree context manager
+        with bs.check_state_value_tree():
+            # This should work since tree structure is the same
+            arr.value = np.array([4, 5, 6])
+
+            # This should fail
+            with self.assertRaises(ValueError):
+                arr.value = (np.array([1, 2, 3]),)
+
+


### PR DESCRIPTION
## Summary by Sourcery

Refactor ArrayImpl to standardize type hints with a new ArrayLike alias, streamline method signatures, and remove deprecated functionality, while adding a suite of unit tests validating array behavior, JAX integration, and state features.

New Features:
- Added comprehensive unit tests for ArrayImpl covering properties, operations, indexing, state integration, and JAX compatibility.

Enhancements:
- Refactored ArrayImpl to use a unified ArrayLike type alias for all array-related method signatures and return types.
- Removed deprecated tobytes method.
- Updated internal value handling to use u.math.asarray.
- Refactored tests to import brainstate module directly instead of using alias.

Chores:
- Commented out State.__eq__ method to prevent unintended equality semantics.