### PR TITLE
Enhance Delay for multi-dimensional inputs and enforce dimensionless steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ cython_debug/
 /docs/apis/deprecated/generated/
 /dist-hist/
 /.VSCodeCounter/
+/.claude/

--- a/brainstate/nn/_delay.py
+++ b/brainstate/nn/_delay.py
@@ -45,6 +45,7 @@ def _get_delay(delay_time):
         if delay_time is None:
             return 0. * environ.get_dt(), 0
         delay_step = delay_time / environ.get_dt()
+        assert u.get_dim(delay_step) == u.DIMENSIONLESS
         delay_step = jnp.ceil(delay_step).astype(environ.ditype())
     return delay_time, delay_step
 
@@ -239,20 +240,20 @@ class Delay(Module):
             >>> delay_obj.register_delay(jnp.array([2.0, 3.0]), 0, 1)  # Vector delay with indices
         """
         assert len(delay_time) >= 1, 'You should provide at least one delay time.'
-        delay_size = u.math.size(delay_time[0])
         for dt in delay_time[1:]:
             assert jnp.issubdtype(u.math.get_dtype(dt), jnp.integer), f'The index should be integer. But got {dt}.'
-        for dt in delay_time:
-            if u.math.ndim(dt) == 0:
-                pass
-            elif u.math.ndim(dt) == 1:
-                if u.math.size(dt) != delay_size:
-                    raise ValueError(
-                        f'The delay time should be a scalar or a vector with the same size. '
-                        f'But got {delay_time}. The delay time {dt} has size {u.math.size(dt)}'
-                    )
-            else:
-                raise ValueError(f'The delay time should be a scalar/vector. But got {dt}.')
+        # delay_size = u.math.size(delay_time[0])
+        # for dt in delay_time:
+        #     if u.math.ndim(dt) == 0:
+        #         pass
+        #     elif u.math.ndim(dt) == 1:
+        #         if u.math.size(dt) != delay_size:
+        #             raise ValueError(
+        #                 f'The delay time should be a scalar or a vector with the same size. '
+        #                 f'But got {delay_time}. The delay time {dt} has size {u.math.size(dt)}'
+        #             )
+        #     else:
+        #         raise ValueError(f'The delay time should be a scalar/vector. But got {dt}.')
         if delay_time[0] is None:
             return None
         time, delay_step = _get_delay(delay_time[0])

--- a/brainstate/nn/_delay_test.py
+++ b/brainstate/nn/_delay_test.py
@@ -182,3 +182,57 @@ class TestDelay(unittest.TestCase):
             self.assertTrue(jnp.allclose(rotation_delay.at('a'), concat_delay.at('a'), ))
             self.assertTrue(jnp.allclose(rotation_delay.at('b'), concat_delay.at('b'), ))
             self.assertTrue(jnp.allclose(rotation_delay.at('c'), concat_delay.at('c'), ))
+
+    def test_delay_2d(self):
+        with brainstate.environ.context(dt=0.1, i=0):
+            rotation_delay = brainstate.nn.Delay(jnp.arange(2))
+            index = (brainstate.random.uniform(0., 10., (2, 2)),
+                     brainstate.random.randint(0, 2, (2, 2)))
+            rotation_delay.register_entry('a', *index)
+            rotation_delay.init_state()
+            data = rotation_delay.at('a')
+            print(index[0])
+            print(index[1])
+            print(data)
+            assert data.shape == (2, 2)
+
+    def test_delay_time2(self):
+        with brainstate.environ.context(dt=0.1, i=0):
+            rotation_delay = brainstate.nn.Delay(jnp.arange(2))
+            index = (brainstate.random.uniform(0., 10., (2, 2)),
+                     1)
+            rotation_delay.register_entry('a', *index)
+            rotation_delay.init_state()
+            data = rotation_delay.at('a')
+            print(index[0])
+            print(index[1])
+            print(data)
+            assert data.shape == (2, 2)
+
+    def test_delay_time3(self):
+        with brainstate.environ.context(dt=0.1, i=0):
+            rotation_delay = brainstate.nn.Delay(jnp.zeros((2, 2)))
+            index = (brainstate.random.uniform(0., 10., (2, 2)),
+                     1,
+                     brainstate.random.randint(0, 2, (2, 2)))
+            rotation_delay.register_entry('a', *index)
+            rotation_delay.init_state()
+            data = rotation_delay.at('a')
+            print(index[0])
+            print(index[1])
+            print(data)
+            assert data.shape == (2, 2)
+
+    def test_delay_time4(self):
+        with brainstate.environ.context(dt=0.1, i=0):
+            rotation_delay = brainstate.nn.Delay(jnp.zeros((2, 2)))
+            index = (brainstate.random.uniform(0., 10., (2, 2)),
+                     1,
+                     brainstate.random.randint(0, 2, (2, 2)))
+            rotation_delay.register_entry('a', *index)
+            rotation_delay.init_state()
+            data = rotation_delay.at('a')
+            print(index[0])
+            print(index[1])
+            print(data)
+            assert data.shape == (2, 2)


### PR DESCRIPTION
## Summary by Sourcery

Relax Delay shape validations, enforce dimensionless delay steps, and add tests for multi-dimensional and mixed-index delay scenarios.

Enhancements:
- Add assertion in _get_delay to ensure computed delay steps are dimensionless
- Remove strict size and dimension checks in register_delay to support multi-dimensional delay inputs

Tests:
- Add test_delay_2d to verify 2D delay outputs
- Add test_delay_time2 for scalar time with 2D random indices
- Add test_delay_time3 for 2D state input with scalar time and 2D indices
- Add test_delay_time4 to revalidate 2D state delays with mixed indices