### PR TITLE
fix(nn): initialize update_every before register_entry

### DIFF
--- a/brainstate/nn/_delay.py
+++ b/brainstate/nn/_delay.py
@@ -538,20 +538,11 @@ class Delay(Module):
             raise TypeError(f'init should be Array, Callable, or None. But got {init}')
         self._init = init
 
-        # delay entries
-        self._registered_entries = dict()
-        if entries is not None:
-            for entry, time_and_idx in entries.items():
-                if isinstance(time_and_idx, (tuple, list)):
-                    self.register_entry(entry, *time_and_idx)
-                else:
-                    self.register_entry(entry, time_and_idx)
-
         # unit handling
         self.take_aware_unit = take_aware_unit
         self._unit = None
 
-        # Validate and convert update_every
+        # Validate and convert update_every (must be set before register_entry is called)
         with jax.ensure_compile_time_eval():
             if update_every is not None:
                 if update_every < environ.get_dt():
@@ -561,6 +552,15 @@ class Delay(Module):
             else:
                 self.update_every = None
                 self.update_every_step = 1
+
+        # delay entries
+        self._registered_entries = dict()
+        if entries is not None:
+            for entry, time_and_idx in entries.items():
+                if isinstance(time_and_idx, (tuple, list)):
+                    self.register_entry(entry, *time_and_idx)
+                else:
+                    self.register_entry(entry, time_and_idx)
 
         # Thread safety locks (lazy initialization)
         self._update_lock = threading.RLock()


### PR DESCRIPTION
## Summary
- fix AttributeError in Delay.__init__ caused by register_entry() reading self.update_every before initialization
- move update_every / update_every_step initialization before entry registration
- keep behavior unchanged except fixing initialization order

## Root Cause
register_entry -> register_delay accesses self.update_every, but in 0.2.10 this field was assigned after register_entry(...) for preconfigured entries.

## Validation
- inspected init execution order in brainstate/nn/_delay.py
- confirmed self.update_every is now set before any register_entry(...) calls

## Summary by Sourcery

Bug Fixes:
- Prevent AttributeError in Delay.__init__ by initializing update_every and related state before calling register_entry for preconfigured entries.