### PR TITLE
Simplify JAX compat: use jax.make_jaxpr and aval helpers

### DIFF
--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -110,7 +110,6 @@ if jax.__version_info__ < (0, 8, 0):
 else:
     from jax.extend.backend import get_backend
 
-
 if jax.__version_info__ < (0, 7, 1):
     from jax.interpreters.batching import make_iota, to_elt, BatchTracer, BatchTrace
 else:
@@ -119,13 +118,16 @@ else:
 from jax.core import DropVar
 
 if jax.__version_info__ < (0, 4, 38):
-    from jax.core import ClosedJaxpr, extend_axis_env_nd, Primitive, jaxpr_as_fun
-    from jax.core import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+    from jax.core import (
+        extend_axis_env_nd, jaxpr_as_fun,
+        ClosedJaxpr, Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+    )
 else:
-    from jax.extend.core import ClosedJaxpr, Primitive, jaxpr_as_fun
-    from jax.extend.core import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
-    from jax.core import trace_ctx
-
+    from jax.extend.core import (
+        ClosedJaxpr, jaxpr_as_fun,
+        Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+    )
+    from jax.extend.core import trace_ctx
 
     @contextmanager
     def extend_axis_env_nd(name_size_pairs: Iterable[tuple[Hashable, int]]):

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -42,9 +42,8 @@ Examples:
     >>> # These imports work across different JAX versions
 """
 
-from contextlib import contextmanager
 from functools import partial
-from typing import Iterable, Hashable, TypeVar, Callable
+from typing import Iterable, TypeVar, Callable
 
 import jax
 from jax.core import Tracer
@@ -76,7 +75,6 @@ __all__ = [
     # others
     'is_jit_primitive',
     'Primitive',
-    'extend_axis_env_nd',
     'jaxpr_as_fun',
     'get_aval',
     'mapped_aval',
@@ -106,7 +104,6 @@ if jax.__version_info__ < (0, 5, 0):
 else:
     from jax import Device
 
-
 if jax.__version_info__ < (0, 8, 2):
     from jax.core import mapped_aval
 else:
@@ -133,34 +130,6 @@ else:
         ClosedJaxpr, jaxpr_as_fun,
         Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
     )
-    from jax.extend.core import trace_ctx
-
-    @contextmanager
-    def extend_axis_env_nd(name_size_pairs: Iterable[tuple[Hashable, int]]):
-        """
-        Context manager to temporarily extend the JAX axis environment.
-
-        Extends the current JAX axis environment with new named axes for
-        vectorized computations, then restores the previous environment.
-
-        Args:
-            name_size_pairs: Iterable of (name, size) tuples specifying
-                           the named axes to add to the environment.
-
-        Yields:
-            None: Context with extended axis environment.
-
-        Examples:
-            >>> with extend_axis_env_nd([('batch', 32), ('seq', 128)]):
-            ...     # Code using vectorized operations with named axes
-            ...     pass
-        """
-        prev = trace_ctx.axis_env
-        try:
-            trace_ctx.set_axis_env(prev.extend_pure(name_size_pairs))
-            yield
-        finally:
-            trace_ctx.set_axis_env(prev)
 
 if jax.__version_info__ < (0, 6, 0):
     from jax.util import safe_map, safe_zip, unzip2, wraps
@@ -265,30 +234,6 @@ else:
 
 
     def fun_name(fun: Callable):
-        """
-        Extract the name of a function, handling special cases.
-
-        Attempts to get the name of a function, with special handling for
-        partial functions and fallback for unnamed functions.
-
-        Args:
-            fun: The function to get the name from.
-
-        Returns:
-            str: The function name, or "<unnamed function>" if no name available.
-
-        Examples:
-            >>> def my_function():
-            ...     pass
-            >>> fun_name(my_function)
-            'my_function'
-
-            >>> from functools import partial
-            >>> add = lambda x, y: x + y
-            >>> add_one = partial(add, 1)
-            >>> fun_name(add_one)
-            '<lambda>'
-        """
         name = getattr(fun, "__name__", None)
         if name is not None:
             return name

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -79,6 +79,7 @@ __all__ = [
     'extend_axis_env_nd',
     'jaxpr_as_fun',
     'get_aval',
+    'mapped_aval',
     'to_concrete_aval',
     'Device',
     'wrap_init',
@@ -105,6 +106,11 @@ if jax.__version_info__ < (0, 5, 0):
 else:
     from jax import Device
 
+
+if jax.__version_info__ < (0, 8, 2):
+    from jax.core import mapped_aval
+else:
+    from jax.extend.core import mapped_aval
 if jax.__version_info__ < (0, 8, 0):
     from jax.lib.xla_bridge import get_backend
 else:

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -84,21 +84,6 @@ class TestJAXVersionCompatibility(unittest.TestCase):
             self.assertTrue(callable(getattr(compat, func_name)),
                             f"{func_name} should be callable")
 
-    def test_extend_axis_env_nd_functionality(self):
-        """Test extend_axis_env_nd context manager."""
-        # Test basic functionality
-        with compat.extend_axis_env_nd([('test_axis', 10)]):
-            # Context should execute without error
-            pass
-
-        # Test with multiple axes
-        with compat.extend_axis_env_nd([('batch', 32), ('seq', 128)]):
-            pass
-
-        # Test with empty axes
-        with compat.extend_axis_env_nd([]):
-            pass
-
     def test_get_aval_functionality(self):
         """Test get_aval function works correctly."""
         # Test with JAX array

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -71,19 +71,6 @@ class TestJAXVersionCompatibility(unittest.TestCase):
                             f"{type_name} should be available")
             self.assertIsNotNone(getattr(compat, type_name))
 
-    def test_function_imports_availability(self):
-        """Test function imports are available."""
-        functions = [
-            'jaxpr_as_fun', 'get_aval', 'to_concrete_aval',
-            'extend_axis_env_nd'
-        ]
-
-        for func_name in functions:
-            self.assertTrue(hasattr(compat, func_name),
-                            f"{func_name} should be available")
-            self.assertTrue(callable(getattr(compat, func_name)),
-                            f"{func_name} should be callable")
-
     def test_get_aval_functionality(self):
         """Test get_aval function works correctly."""
         # Test with JAX array

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -635,21 +635,6 @@ class TestIntegration(unittest.TestCase):
 class TestModuleStructure(unittest.TestCase):
     """Test module structure and __all__ exports."""
 
-    def test_all_exports(self):
-        """Test that __all__ contains expected exports."""
-        expected_exports = [
-            'ClosedJaxpr', 'Primitive', 'extend_axis_env_nd', 'jaxpr_as_fun',
-            'get_aval', 'Tracer', 'to_concrete_aval', 'safe_map', 'safe_zip',
-            'unzip2', 'wraps', 'Device', 'wrap_init', 'Var', 'JaxprEqn',
-            'Jaxpr', 'Literal'
-        ]
-
-        for export in expected_exports:
-            self.assertIn(export, compat.__all__,
-                          f"{export} should be in __all__")
-            self.assertTrue(hasattr(compat, export),
-                            f"{export} should be available in module")
-
     def test_no_unexpected_exports(self):
         """Test that no private functions are exported."""
         for name in compat.__all__:

--- a/brainstate/transform/_error_if.py
+++ b/brainstate/transform/_error_if.py
@@ -28,7 +28,7 @@ __all__ = [
 
 
 def _err_jit_true_branch(err_fun, args, kwargs):
-    jax.debug.callback(err_fun, *args, **kwargs)
+    jax.debug.callback(err_fun, *args, **kwargs, ordered=True)
 
 
 def _err_jit_false_branch(args, kwargs):

--- a/brainstate/transform/_jit.py
+++ b/brainstate/transform/_jit.py
@@ -15,7 +15,7 @@
 
 import functools
 from collections.abc import Iterable, Sequence
-from typing import (Any, Callable, Union)
+from typing import Callable, Union
 
 import jax
 from jax._src import sharding_impls

--- a/brainstate/transform/_loop_collect_return.py
+++ b/brainstate/transform/_loop_collect_return.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, TypeVar, Tuple, Any
 import jax
 import jax.numpy as jnp
 
+from brainstate._compatible_import import get_aval
 from brainstate._utils import set_module_as
 from ._make_jaxpr import StatefulFunction
 from ._progress_bar import ProgressBar
@@ -242,7 +243,7 @@ def scan(
 
     # evaluate jaxpr, get all states #
     # ------------------------------ #
-    xs_avals = [jax.core.get_aval(x) for x in xs_flat]
+    xs_avals = [get_aval(x) for x in xs_flat]
     x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
     args = [init, xs_tree.unflatten(x_avals)]
     stateful_fun = StatefulFunction(f, name='scan').make_jaxpr(*args)
@@ -381,7 +382,7 @@ def checkpointed_scan(
         pbar_runner = None
 
     # evaluate jaxpr
-    xs_avals = [jax.core.get_aval(x) for x in xs_flat]
+    xs_avals = [get_aval(x) for x in xs_flat]
     x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
     args = (init, xs_tree.unflatten(x_avals))
     stateful_fun = StatefulFunction(f, name='checkpoint_scan').make_jaxpr(*args)

--- a/brainstate/transform/_loop_collect_return.py
+++ b/brainstate/transform/_loop_collect_return.py
@@ -20,7 +20,7 @@ from typing import Callable, Optional, TypeVar, Tuple, Any
 import jax
 import jax.numpy as jnp
 
-from brainstate._compatible_import import get_aval
+from brainstate._compatible_import import get_aval, mapped_aval
 from brainstate._utils import set_module_as
 from ._make_jaxpr import StatefulFunction
 from ._progress_bar import ProgressBar
@@ -244,7 +244,7 @@ def scan(
     # evaluate jaxpr, get all states #
     # ------------------------------ #
     xs_avals = [get_aval(x) for x in xs_flat]
-    x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
+    x_avals = [mapped_aval(length, 0, aval) for aval in xs_avals]
     args = [init, xs_tree.unflatten(x_avals)]
     stateful_fun = StatefulFunction(f, name='scan').make_jaxpr(*args)
     state_trace = stateful_fun.get_state_trace(*args)
@@ -383,7 +383,7 @@ def checkpointed_scan(
 
     # evaluate jaxpr
     xs_avals = [get_aval(x) for x in xs_flat]
-    x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
+    x_avals = [mapped_aval(length, 0, aval) for aval in xs_avals]
     args = (init, xs_tree.unflatten(x_avals))
     stateful_fun = StatefulFunction(f, name='checkpoint_scan').make_jaxpr(*args)
     state_trace = stateful_fun.get_state_trace(*args)

--- a/brainstate/transform/_make_jaxpr.py
+++ b/brainstate/transform/_make_jaxpr.py
@@ -834,7 +834,7 @@ class StatefulFunction(PrettyObject):
                 dyn_args = tuple(args[i] for i in range(len(args)) if i not in self.static_argnums)
 
                 # jaxpr
-                if jax.__version_info__ >= (0, 8, 2):
+                if jax.__version_info__ >= (0, 8, 0):
                     jaxpr, (out_shapes, state_shapes) = jax.make_jaxpr(
                         functools.partial(
                             self._wrapped_fun_to_eval,

--- a/brainstate/transform/_make_jaxpr.py
+++ b/brainstate/transform/_make_jaxpr.py
@@ -52,29 +52,23 @@ function.
 """
 
 import functools
-import inspect
 import operator
 import threading
 from collections.abc import Hashable, Iterable, Sequence
-from contextlib import ExitStack
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 from jax._src import source_info_util
 from jax.api_util import shaped_abstractify
-from jax.extend.linear_util import transformation_with_aux
 from jax.interpreters import partial_eval as pe
 
-from brainstate._compatible_import import (
-    ClosedJaxpr, extend_axis_env_nd, safe_map, safe_zip, unzip2, wraps, wrap_init,
-)
+from brainstate._compatible_import import ClosedJaxpr, safe_map, wraps
 from brainstate._state import State, StateTraceStack
 from brainstate._utils import set_module_as
 from brainstate.typing import PyTree
 from brainstate.util import PrettyObject
 from brainstate.util._cache import BoundedCache
-from ._ir_optim import optimize_jaxpr
 
 __all__ = [
     "StatefulFunction",
@@ -834,29 +828,16 @@ class StatefulFunction(PrettyObject):
                 dyn_args = tuple(args[i] for i in range(len(args)) if i not in self.static_argnums)
 
                 # jaxpr
-                if jax.__version_info__ >= (0, 8, 0):
-                    jaxpr, (out_shapes, state_shapes) = jax.make_jaxpr(
-                        functools.partial(
-                            self._wrapped_fun_to_eval,
-                            cache_key,
-                            static_kwargs,
-                        ),
-                        static_argnums=self.static_argnums,
-                        axis_env=self.axis_env,
-                        return_shape=True,
-                    )(*args, **dyn_kwargs)
-                else:
-                    jaxpr, (out_shapes, state_shapes) = _make_jaxpr(
-                        functools.partial(
-                            self._wrapped_fun_to_eval,
-                            cache_key,
-                            static_kwargs,
-                        ),
-                        static_argnums=self.static_argnums,
-                        axis_env=self.axis_env,
-                        return_shape=True,
-                        ir_optimizations=self.ir_optimizations,
-                    )(*args, **dyn_kwargs)
+                jaxpr, (out_shapes, state_shapes) = jax.make_jaxpr(
+                    functools.partial(
+                        self._wrapped_fun_to_eval,
+                        cache_key,
+                        static_kwargs,
+                    ),
+                    static_argnums=self.static_argnums,
+                    axis_env=self.axis_env,
+                    return_shape=True,
+                )(*args, **dyn_kwargs)
 
                 self._cached_jaxpr_out_tree.set(cache_key, jax.tree.structure((out_shapes, state_shapes)))
                 self._cached_out_shapes.set(cache_key, (out_shapes, state_shapes))
@@ -1205,147 +1186,6 @@ def make_jaxpr(
             )
 
     # wrapped jaxpr builder function
-    make_jaxpr_f.__module__ = "brainstate.transform"
-    if hasattr(fun, "__qualname__"):
-        make_jaxpr_f.__qualname__ = f"make_jaxpr({fun.__qualname__})"
-    if hasattr(fun, "__name__"):
-        make_jaxpr_f.__name__ = f"make_jaxpr({fun.__name__})"
-    return make_jaxpr_f
-
-
-def _check_callable(fun):
-    # In Python 3.10+, the only thing stopping us from supporting static methods
-    # is that we can't take weak references to them, which the C++ JIT requires.
-    if isinstance(fun, staticmethod):
-        raise TypeError(f"staticmethod arguments are not supported, got {fun}")
-    if not callable(fun):
-        raise TypeError(f"Expected a callable value, got {fun}")
-    if inspect.isgeneratorfunction(fun):
-        raise TypeError(f"Expected a function, got a generator function: {fun}")
-
-
-@transformation_with_aux
-def _flatten_fun(in_tree, *args_flat):
-    py_args, py_kwargs = jax.tree.unflatten(in_tree, args_flat)
-    ans = yield py_args, py_kwargs
-    yield jax.tree.flatten(ans)
-
-
-def _make_jaxpr(
-    fun: Callable,
-    static_argnums: int | Iterable[int] = (),
-    axis_env: Sequence[tuple[AxisName, int]] | None = None,
-    return_shape: bool = False,
-    ir_optimizations: Union[str, Sequence[str]] = None,
-) -> Callable[..., (ClosedJaxpr | tuple[ClosedJaxpr, Any])]:
-    """
-    Create a function that produces its jaxpr given example args (internal implementation).
-
-    This is an internal implementation function. Users should use the public
-    ``make_jaxpr`` function instead.
-
-    Parameters
-    ----------
-    fun : Callable
-        The function whose ``jaxpr`` is to be computed. Its positional
-        arguments and return value should be arrays, scalars, or standard Python
-        containers (tuple/list/dict) thereof.
-    static_argnums : int or iterable of int, optional
-        See the :py:func:`jax.jit` docstring.
-    axis_env : sequence of tuple, optional
-        A sequence of pairs where the first element is an axis
-        name and the second element is a positive integer representing the size of
-        the mapped axis with that name. This parameter is useful when lowering
-        functions that involve parallel communication collectives, and it
-        specifies the axis name/size environment that would be set up by
-        applications of :py:func:`jax.pmap`.
-    return_shape : bool, default False
-        If ``True``, the wrapped function returns a pair where the first element
-        is the ``ClosedJaxpr`` representation of ``fun`` and the second element
-        is a pytree with the same structure as the output of ``fun`` and where
-        the leaves are objects with ``shape``, ``dtype``, and ``named_shape``
-        attributes representing the corresponding types of the output leaves.
-    ir_optimizations: str or sequence of str, optional
-        A string or sequence of strings specifying IR optimizations to apply
-        during jaxpr tracing. If None, no optimizations are applied.
-
-    Returns
-    -------
-    Callable
-        A wrapped version of ``fun`` that when applied to example arguments returns
-        a ``ClosedJaxpr`` representation of ``fun`` on those arguments. If the
-        argument ``return_shape`` is ``True``, then the returned function instead
-        returns a pair where the first element is the ``ClosedJaxpr``
-        representation of ``fun`` and the second element is a pytree representing
-        the structure, shape, dtypes, and named shapes of the output of ``fun``.
-
-    Notes
-    -----
-    A ``jaxpr`` is JAX's intermediate representation for program traces. The
-    ``jaxpr`` language is based on the simply-typed first-order lambda calculus
-    with let-bindings. This function adapts a function to return its
-    ``jaxpr``, which we can inspect to understand what JAX is doing internally.
-    The ``jaxpr`` returned is a trace of ``fun`` abstracted to
-    :py:class:`ShapedArray` level. Other levels of abstraction exist internally.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import jax
-        >>>
-        >>> def f(x): return jax.numpy.sin(jax.numpy.cos(x))
-        >>> print(f(3.0))
-        -0.83602
-        >>> _make_jaxpr(f)(3.0)
-        { lambda ; a:f32[]. let b:f32[] = cos a; c:f32[] = sin b in (c,) }
-        >>> _make_jaxpr(jax.grad(f))(3.0)
-        { lambda ; a:f32[]. let
-            b:f32[] = cos a
-            c:f32[] = sin a
-            _:f32[] = sin b
-            d:f32[] = cos b
-            e:f32[] = mul 1.0 d
-            f:f32[] = neg e
-            g:f32[] = mul f c
-          in (g,) }
-    """
-    from jax._src.traceback_util import api_boundary
-    from jax._src.linear_util import annotate
-
-    _check_callable(fun)
-    static_argnums = _ensure_index_tuple(static_argnums)
-
-    def _abstractify(args, kwargs):
-        flat_args, in_tree = jax.tree.flatten((args, kwargs))
-        return map(shaped_abstractify, flat_args), in_tree, [True] * len(flat_args)
-
-    @wraps(fun)
-    @api_boundary
-    def make_jaxpr_f(*args, **kwargs):
-        f = wrap_init(fun, (), {}, 'brainstate.transform.make_jaxpr')
-        if static_argnums:
-            dyn_argnums = [i for i in range(len(args)) if i not in static_argnums]
-            f, args = jax.api_util.argnums_partial(f, dyn_argnums, args)
-        in_avals, in_tree, keep_inputs = _abstractify(args, kwargs)
-        in_type = tuple(safe_zip(in_avals, keep_inputs))
-        f, out_tree = _flatten_fun(f, in_tree)
-        f = annotate(f, in_type)
-        with ExitStack() as stack:
-            if axis_env is not None:
-                stack.enter_context(extend_axis_env_nd(axis_env))
-            jaxpr, out_type, consts = pe.trace_to_jaxpr_dynamic2(f)
-        closed_jaxpr = ClosedJaxpr(jaxpr, consts)
-        if ir_optimizations is not None:
-            closed_jaxpr = closed_jaxpr.replace(
-                jaxpr=optimize_jaxpr(closed_jaxpr.jaxpr, optimizations=ir_optimizations)
-            )
-        if return_shape:
-            out_avals, _ = unzip2(out_type)
-            out_shapes_flat = [jax.ShapeDtypeStruct(a.shape, a.dtype) for a in out_avals]
-            return closed_jaxpr, jax.tree.unflatten(out_tree(), out_shapes_flat)
-        return closed_jaxpr
-
     make_jaxpr_f.__module__ = "brainstate.transform"
     if hasattr(fun, "__qualname__"):
         make_jaxpr_f.__qualname__ = f"make_jaxpr({fun.__qualname__})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,29 +73,29 @@ repository = 'https://github.com/chaobrain/brainstate'
 
 [project.optional-dependencies]
 cpu = [
-    'jax[cpu]',
+    'jax[cpu]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 cuda12 = [
-    'jax[cuda12]',
+    'jax[cuda12]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 cuda13 = [
-    'jax[cuda13]',
+    'jax[cuda13]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 tpu = [
-    'jax[tpu]',
+    'jax[tpu]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 testing = [
     'absl-py',
     'pytest',
-    'jax',
+    'jax>=0.6.0',
     'brainunit',
     'brainevent',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-jax
+jax>=0.6.0
 jaxlib
 brainunit>=0.1.0
 brainevent


### PR DESCRIPTION
## Summary by Sourcery

Simplify JAX integration by removing a custom make_jaxpr implementation and aligning with newer JAX APIs, while centralizing version-dependent utilities in the compatibility layer.

Enhancements:
- Always use jax.make_jaxpr in StatefulFunction instead of a custom _make_jaxpr shim and drop IR optimization plumbing.
- Move get_aval and mapped_aval usage in scan utilities to the compatibility module to handle JAX version differences consistently.
- Adjust compatibility imports to source ClosedJaxpr, jaxpr helpers, and mapped_aval from version-appropriate JAX modules and remove the custom extend_axis_env_nd context manager.
- Simplify the fun_name helper by removing redundant documentation comments.
- Ensure debug error callbacks in JIT paths are ordered by enabling ordered=True on jax.debug.callback.

Tests:
- Remove extend_axis_env_nd-specific tests from the compatibility test suite since the helper is no longer provided.