### PR TITLE
Refactor graph ops, update JAX/Python requirements, improve tests

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.10"
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -110,7 +110,6 @@ if jax.__version_info__ < (0, 8, 0):
 else:
     from jax.extend.backend import get_backend
 
-
 if jax.__version_info__ < (0, 7, 1):
     from jax.interpreters.batching import make_iota, to_elt, BatchTracer, BatchTrace
 else:
@@ -119,13 +118,16 @@ else:
 from jax.core import DropVar
 
 if jax.__version_info__ < (0, 4, 38):
-    from jax.core import ClosedJaxpr, extend_axis_env_nd, Primitive, jaxpr_as_fun
-    from jax.core import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+    from jax.core import (
+        extend_axis_env_nd, jaxpr_as_fun,
+        ClosedJaxpr, Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+    )
 else:
-    from jax.extend.core import ClosedJaxpr, Primitive, jaxpr_as_fun
-    from jax.extend.core import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
-    from jax.core import trace_ctx
-
+    from jax.extend.core import (
+        ClosedJaxpr, jaxpr_as_fun,
+        Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+    )
+    from jax.extend.core import trace_ctx
 
     @contextmanager
     def extend_axis_env_nd(name_size_pairs: Iterable[tuple[Hashable, int]]):

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -42,9 +42,8 @@ Examples:
     >>> # These imports work across different JAX versions
 """
 
-from contextlib import contextmanager
 from functools import partial
-from typing import Iterable, Hashable, TypeVar, Callable
+from typing import Iterable, TypeVar, Callable
 
 import jax
 from jax.core import Tracer
@@ -76,7 +75,6 @@ __all__ = [
     # others
     'is_jit_primitive',
     'Primitive',
-    'extend_axis_env_nd',
     'jaxpr_as_fun',
     'get_aval',
     'mapped_aval',
@@ -106,7 +104,6 @@ if jax.__version_info__ < (0, 5, 0):
 else:
     from jax import Device
 
-
 if jax.__version_info__ < (0, 8, 2):
     from jax.core import mapped_aval
 else:
@@ -133,34 +130,6 @@ else:
         ClosedJaxpr, jaxpr_as_fun,
         Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
     )
-    from jax.extend.core import trace_ctx
-
-    @contextmanager
-    def extend_axis_env_nd(name_size_pairs: Iterable[tuple[Hashable, int]]):
-        """
-        Context manager to temporarily extend the JAX axis environment.
-
-        Extends the current JAX axis environment with new named axes for
-        vectorized computations, then restores the previous environment.
-
-        Args:
-            name_size_pairs: Iterable of (name, size) tuples specifying
-                           the named axes to add to the environment.
-
-        Yields:
-            None: Context with extended axis environment.
-
-        Examples:
-            >>> with extend_axis_env_nd([('batch', 32), ('seq', 128)]):
-            ...     # Code using vectorized operations with named axes
-            ...     pass
-        """
-        prev = trace_ctx.axis_env
-        try:
-            trace_ctx.set_axis_env(prev.extend_pure(name_size_pairs))
-            yield
-        finally:
-            trace_ctx.set_axis_env(prev)
 
 if jax.__version_info__ < (0, 6, 0):
     from jax.util import safe_map, safe_zip, unzip2, wraps
@@ -265,30 +234,6 @@ else:
 
 
     def fun_name(fun: Callable):
-        """
-        Extract the name of a function, handling special cases.
-
-        Attempts to get the name of a function, with special handling for
-        partial functions and fallback for unnamed functions.
-
-        Args:
-            fun: The function to get the name from.
-
-        Returns:
-            str: The function name, or "<unnamed function>" if no name available.
-
-        Examples:
-            >>> def my_function():
-            ...     pass
-            >>> fun_name(my_function)
-            'my_function'
-
-            >>> from functools import partial
-            >>> add = lambda x, y: x + y
-            >>> add_one = partial(add, 1)
-            >>> fun_name(add_one)
-            '<lambda>'
-        """
         name = getattr(fun, "__name__", None)
         if name is not None:
             return name

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -79,6 +79,7 @@ __all__ = [
     'extend_axis_env_nd',
     'jaxpr_as_fun',
     'get_aval',
+    'mapped_aval',
     'to_concrete_aval',
     'Device',
     'wrap_init',
@@ -105,6 +106,11 @@ if jax.__version_info__ < (0, 5, 0):
 else:
     from jax import Device
 
+
+if jax.__version_info__ < (0, 8, 2):
+    from jax.core import mapped_aval
+else:
+    from jax.extend.core import mapped_aval
 if jax.__version_info__ < (0, 8, 0):
     from jax.lib.xla_bridge import get_backend
 else:

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -84,21 +84,6 @@ class TestJAXVersionCompatibility(unittest.TestCase):
             self.assertTrue(callable(getattr(compat, func_name)),
                             f"{func_name} should be callable")
 
-    def test_extend_axis_env_nd_functionality(self):
-        """Test extend_axis_env_nd context manager."""
-        # Test basic functionality
-        with compat.extend_axis_env_nd([('test_axis', 10)]):
-            # Context should execute without error
-            pass
-
-        # Test with multiple axes
-        with compat.extend_axis_env_nd([('batch', 32), ('seq', 128)]):
-            pass
-
-        # Test with empty axes
-        with compat.extend_axis_env_nd([]):
-            pass
-
     def test_get_aval_functionality(self):
         """Test get_aval function works correctly."""
         # Test with JAX array

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -71,19 +71,6 @@ class TestJAXVersionCompatibility(unittest.TestCase):
                             f"{type_name} should be available")
             self.assertIsNotNone(getattr(compat, type_name))
 
-    def test_function_imports_availability(self):
-        """Test function imports are available."""
-        functions = [
-            'jaxpr_as_fun', 'get_aval', 'to_concrete_aval',
-            'extend_axis_env_nd'
-        ]
-
-        for func_name in functions:
-            self.assertTrue(hasattr(compat, func_name),
-                            f"{func_name} should be available")
-            self.assertTrue(callable(getattr(compat, func_name)),
-                            f"{func_name} should be callable")
-
     def test_get_aval_functionality(self):
         """Test get_aval function works correctly."""
         # Test with JAX array

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -635,21 +635,6 @@ class TestIntegration(unittest.TestCase):
 class TestModuleStructure(unittest.TestCase):
     """Test module structure and __all__ exports."""
 
-    def test_all_exports(self):
-        """Test that __all__ contains expected exports."""
-        expected_exports = [
-            'ClosedJaxpr', 'Primitive', 'extend_axis_env_nd', 'jaxpr_as_fun',
-            'get_aval', 'Tracer', 'to_concrete_aval', 'safe_map', 'safe_zip',
-            'unzip2', 'wraps', 'Device', 'wrap_init', 'Var', 'JaxprEqn',
-            'Jaxpr', 'Literal'
-        ]
-
-        for export in expected_exports:
-            self.assertIn(export, compat.__all__,
-                          f"{export} should be in __all__")
-            self.assertTrue(hasattr(compat, export),
-                            f"{export} should be available in module")
-
     def test_no_unexpected_exports(self):
         """Test that no private functions are exported."""
         for name in compat.__all__:

--- a/brainstate/graph/_context.py
+++ b/brainstate/graph/_context.py
@@ -14,14 +14,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
 
 from __future__ import annotations
 
 import contextlib
 import dataclasses
 import threading
-from typing import (Any, Tuple, List)
+from typing import Any
 
 from typing_extensions import Unpack
 
@@ -45,11 +44,14 @@ __all__ = [
 
 @dataclasses.dataclass
 class GraphContext(threading.local):
+    """Thread-local stacks of active split/merge contexts.
+
+    Inheriting from ``threading.local`` ensures each thread has its own
+    independent context stacks, making nested transforms safe under parallelism.
     """
-    A context manager for handling complex state updates.
-    """
-    ref_index_stack: List[SplitContext] = dataclasses.field(default_factory=list)
-    index_ref_stack: List[MergeContext] = dataclasses.field(default_factory=list)
+
+    ref_index_stack: list[SplitContext] = dataclasses.field(default_factory=list)
+    index_ref_stack: list[MergeContext] = dataclasses.field(default_factory=list)
 
 
 GRAPH_CONTEXT = GraphContext()
@@ -57,12 +59,11 @@ GRAPH_CONTEXT = GraphContext()
 
 @dataclasses.dataclass
 class SplitContext:
-    """
-    A context manager for handling graph splitting.
-    """
+    """Context for splitting graph nodes, tracking shared references."""
+
     ref_index: RefMap[Any, Index]
 
-    def treefy_split(self, node: A, *filters: Filter) -> Tuple[GraphDef[A], Unpack[Tuple[NestedDict, ...]]]:
+    def treefy_split(self, node: A, *filters: Filter) -> tuple[GraphDef[A], Unpack[tuple[NestedDict, ...]]]:
         graphdef, statetree = flatten(node, self.ref_index)
         state_mappings = _split_state(statetree, filters)
         return graphdef, *state_mappings
@@ -70,13 +71,10 @@ class SplitContext:
 
 @contextlib.contextmanager
 def split_context():
-    """
-    A context manager for handling graph splitting.
-    """
+    """Context manager for splitting multiple graph nodes sharing a reference index."""
     index_ref: RefMap[Any, Index] = RefMap()
     flatten_ctx = SplitContext(index_ref)
     GRAPH_CONTEXT.ref_index_stack.append(flatten_ctx)
-
     try:
         yield flatten_ctx, index_ref
     finally:
@@ -86,9 +84,8 @@ def split_context():
 
 @dataclasses.dataclass
 class MergeContext:
-    """
-    A context manager for handling graph merging.
-    """
+    """Context for merging graph nodes, tracking shared references."""
+
     index_ref: dict[Index, Any]
 
     def treefy_merge(
@@ -96,22 +93,18 @@ class MergeContext:
         graphdef: GraphDef[A],
         state_mapping: NestedDict,
         /,
-        *state_mappings: NestedDict
+        *state_mappings: NestedDict,
     ) -> A:
         state_mapping = NestedDict.merge(state_mapping, *state_mappings)
-        node = unflatten(graphdef, state_mapping, index_ref=self.index_ref)
-        return node
+        return unflatten(graphdef, state_mapping, index_ref=self.index_ref)
 
 
 @contextlib.contextmanager
 def merge_context():
-    """
-    A context manager for handling graph merging.
-    """
+    """Context manager for merging multiple graph nodes sharing a reference index."""
     index_ref: dict[Index, Any] = {}
     unflatten_ctx = MergeContext(index_ref)
     GRAPH_CONTEXT.index_ref_stack.append(unflatten_ctx)
-
     try:
         yield unflatten_ctx, dict(unflatten_ctx.index_ref)
     finally:

--- a/brainstate/graph/_convert.py
+++ b/brainstate/graph/_convert.py
@@ -1,17 +1,3 @@
-# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
 # The file is adapted from the Flax library (https://github.com/google/flax).
 # The credit should go to the Flax authors.
 #
@@ -28,9 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
 
-from typing import Any, Callable, Iterable, TypeVar, Hashable, Optional, Tuple, List, Dict
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any, TypeVar
 
 import jax
 
@@ -54,8 +42,7 @@ __all__ = [
 
 Node = TypeVar('Node')
 Leaf = TypeVar('Leaf')
-
-KeyEntry = TypeVar('KeyEntry', bound=Hashable)
+KeyEntry = TypeVar('KeyEntry')
 KeyPath = tuple[KeyEntry, ...]
 Prefix = Any
 RandomState = None
@@ -70,15 +57,15 @@ def _get_rand_state() -> type:
 
 
 def check_consistent_aliasing(
-    node: Tuple[Any, ...],
-    prefix: Tuple[Any, ...],
+    node: tuple[Any, ...],
+    prefix: tuple[Any, ...],
     /,
     *,
-    node_prefixes: Optional[RefMap[Any, List[Tuple[PathParts, Any]]]] = None,
-):
+    node_prefixes: RefMap[Any, list[tuple[PathParts, Any]]] | None = None,
+) -> None:
+    """Check that shared nodes have consistent prefixes across all paths."""
     node_prefixes = RefMap() if node_prefixes is None else node_prefixes
 
-    # collect all paths and prefixes for each node
     for path, value in iter_graph(node):
         if _is_graph_node(value) or isinstance(value, State):
             if isinstance(value, GraphNode):
@@ -90,52 +77,34 @@ def check_consistent_aliasing(
                     lambda: f'Trying to extract graph node from different trace level, got {value!r}'
                 )
             if value in node_prefixes:
-                paths_prefixes = node_prefixes[value]
-                paths_prefixes.append((path, prefix))
+                node_prefixes[value].append((path, prefix))
             else:
                 node_prefixes[value] = [(path, prefix)]
 
-    # check for inconsistent aliasing
     node_msgs = []
     for node, paths_prefixes in node_prefixes.items():
         unique_prefixes = {prefix for _, prefix in paths_prefixes}
         if len(unique_prefixes) > 1:
-            path_prefix_repr = '\n'.join([f'  {"/".join(map(str, path)) if path else "<root>"}: {prefix}'
-                                          for path, prefix in paths_prefixes])
-            nodes_msg = f'Node: {type(node)}\n{path_prefix_repr}'
-            node_msgs.append(nodes_msg)
+            path_prefix_repr = '\n'.join([
+                f'  {"/".join(map(str, path)) if path else "<root>"}: {prefix}'
+                for path, prefix in paths_prefixes
+            ])
+            node_msgs.append(f'Node: {type(node)}\n{path_prefix_repr}')
 
     if node_msgs:
-        raise ValueError('Inconsistent aliasing detected. The '
-                         'following nodes have different prefixes:\n'
-                         + '\n'.join(node_msgs))
+        raise ValueError(
+            'Inconsistent aliasing detected. The following nodes have different prefixes:\n'
+            + '\n'.join(node_msgs)
+        )
 
-
-# -----------------------------
-# to_tree/from_tree
-# -----------------------------
 
 def broadcast_prefix(
     prefix_tree: Any,
     full_tree: Any,
-    prefix_is_leaf: Optional[Callable[[Any], bool]] = None,
-    tree_is_leaf: Optional[Callable[[Any], bool]] = None,
-) -> List[Any]:
-    """
-    Broadcasts a prefix tree to a full tree.
-
-    Args:
-      prefix_tree: A prefix tree.
-      full_tree: A full tree.
-      prefix_is_leaf: A function that checks if a prefix is a leaf.
-      tree_is_leaf: A function that checks if a tree is a leaf.
-
-    Returns:
-      A list of prefixes.
-    """
-    # If prefix_tree is not a tree prefix of full_tree, this code can raise a
-    # ValueError; use prefix_errors to find disagreements and raise more precise
-    # error messages.
+    prefix_is_leaf: Callable[[Any], bool] | None = None,
+    tree_is_leaf: Callable[[Any], bool] | None = None,
+) -> list[Any]:
+    """Broadcast a prefix tree to match the leaves of a full tree."""
     result = []
     num_leaves = lambda t: jax.tree_util.tree_structure(t, is_leaf=tree_is_leaf).num_leaves
     add_leaves = lambda x, subtree: result.extend([x] * num_leaves(subtree))
@@ -144,6 +113,12 @@ def broadcast_prefix(
 
 
 class NodeStates(PyTreeNode):
+    """A JAX pytree wrapper that carries both a GraphDef and one or more state mappings.
+
+    Used by ``graph_to_tree`` / ``tree_to_graph`` to represent graph nodes as
+    pure pytrees so that JAX transforms (vmap, jit, etc.) can operate on them.
+    """
+
     _graphdef: GraphDef[Any] | None
     states: tuple[GraphStateMapping, ...]
     metadata: Any = field(pytree_node=False)
@@ -168,19 +143,19 @@ class NodeStates(PyTreeNode):
         /,
         *states: GraphStateMapping,
         metadata: Any = None,
-    ):
+    ) -> NodeStates:
         return cls(_graphdef=graphdef, states=(state, *states), metadata=metadata)
 
     @classmethod
-    def from_states(cls, state: GraphStateMapping, *states: GraphStateMapping):
+    def from_states(cls, state: GraphStateMapping, *states: GraphStateMapping) -> NodeStates:
         return cls(_graphdef=None, states=(state, *states), metadata=None)
 
     @classmethod
-    def from_prefixes(cls, prefixes: Iterable[Any], /, *, metadata: Any = None):
+    def from_prefixes(cls, prefixes: Iterable[Any], /, *, metadata: Any = None) -> NodeStates:
         return cls(_graphdef=None, states=tuple(prefixes), metadata=metadata)
 
 
-def _default_split_fn(ctx: SplitContext, path: KeyPath, prefix: Prefix, leaf: Leaf):
+def _default_split_fn(ctx: SplitContext, path: KeyPath, prefix: Prefix, leaf: Leaf) -> NodeStates:
     return NodeStates.from_split(*ctx.treefy_split(leaf))
 
 
@@ -192,20 +167,16 @@ def graph_to_tree(
     split_fn: Callable[[SplitContext, KeyPath, Prefix, Leaf], Any] = _default_split_fn,
     map_non_graph_nodes: bool = False,
     check_aliasing: bool = True,
-) -> Tuple[PyTree, Dict[KeyPath, SeedOrKey]]:
-    """
-    Convert a tree of pytree objects to a tree of TreeNode objects.
-    """
+) -> tuple[PyTree, dict[KeyPath, SeedOrKey]]:
+    """Convert a pytree that may contain graph nodes into a pure pytree of NodeStates."""
     leaf_prefixes = broadcast_prefix(prefix, may_have_graph_nodes, prefix_is_leaf=lambda x: x is None)
     leaf_keys, treedef = jax.tree_util.tree_flatten_with_path(may_have_graph_nodes)
 
-    # Check that the number of keys and prefixes match
     assert len(leaf_keys) == len(leaf_prefixes)
 
-    # Split the tree
     with split_context() as (ctx, index_ref):
         leaves_out = []
-        node_prefixes = RefMap[Any, list[tuple[PathParts, Any]]]()
+        node_prefixes: RefMap[Any, list[tuple[PathParts, Any]]] = RefMap()
         for (keypath, leaf), leaf_prefix in zip(leaf_keys, leaf_prefixes):
             if _is_graph_node(leaf):
                 if check_aliasing:
@@ -215,15 +186,16 @@ def graph_to_tree(
                 if map_non_graph_nodes:
                     leaf = split_fn(ctx, keypath, leaf_prefix, leaf)
                 leaves_out.append(leaf)
-        pass
 
-    find_states = states(index_ref._mapping)
+    # Build a dict mirroring RefMap's content via the public API, then extract
+    # State objects from it.  We must not access the private ._mapping attribute.
+    public_map = {id(k): (k, v) for k, v in index_ref.items()}
+    find_states = states(public_map)
     pytree_out = jax.tree.unflatten(treedef, leaves_out)
     return pytree_out, find_states
 
 
-def _is_tree_node(x):
-    """Check if x is a TreeNode."""
+def _is_tree_node(x: Any) -> bool:
     return isinstance(x, NodeStates)
 
 
@@ -243,20 +215,7 @@ def tree_to_graph(
     is_leaf: Callable[[Leaf], bool] = _is_tree_node,
     map_non_graph_nodes: bool = False,
 ) -> Any:
-    """
-    Convert a tree of TreeNode objects to a tree of pytree objects.
-
-    Args:
-      tree: A tree of TreeNode objects.
-      prefix: A tree of prefixes.
-      merge_fn: A function that merges a TreeNode object.
-      is_node_leaf: A function that checks if a leaf is a TreeNode.
-      is_leaf: A function that checks if a leaf is a TreeNode.
-      map_non_graph_nodes: A boolean indicating whether to map non-graph nodes.
-
-    Returns:
-      A tree of pytree objects.
-    """
+    """Convert a pytree of NodeStates back into graph nodes."""
     _prefix_is_leaf = lambda x: x is None or is_leaf(x)
     leaf_prefixes = broadcast_prefix(prefix, tree, prefix_is_leaf=_prefix_is_leaf, tree_is_leaf=is_leaf)
     leaf_keys, treedef = jax.tree_util.tree_flatten_with_path(tree, is_leaf=is_leaf)
@@ -266,13 +225,10 @@ def tree_to_graph(
         leaves_out = []
         for (keypath, leaf), leaf_prefix in zip(leaf_keys, leaf_prefixes):
             if is_node_leaf(leaf):
-                leaf_out = merge_fn(ctx, keypath, leaf_prefix, leaf)
-                leaves_out.append(leaf_out)
+                leaves_out.append(merge_fn(ctx, keypath, leaf_prefix, leaf))
             else:
                 if map_non_graph_nodes:
                     leaf = merge_fn(ctx, keypath, leaf_prefix, leaf)
                 leaves_out.append(leaf)
 
-    find_states = states(index_ref)
-    pytree_out = jax.tree.unflatten(treedef, leaves_out)
-    return pytree_out
+    return jax.tree.unflatten(treedef, leaves_out)

--- a/brainstate/graph/_node.py
+++ b/brainstate/graph/_node.py
@@ -15,9 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from abc import ABCMeta
 from copy import deepcopy
-from typing import Any, Type, TypeVar, Tuple, TYPE_CHECKING, Callable
+from typing import Any, TypeVar, TYPE_CHECKING, Callable
 
 from brainstate._error import TraceContextError
 from brainstate._state import State, TreefyState
@@ -30,7 +32,6 @@ __all__ = [
 ]
 
 G = TypeVar('G', bound='Node')
-A = TypeVar('A')
 
 
 class GraphNodeMeta(ABCMeta):
@@ -42,55 +43,14 @@ class GraphNodeMeta(ABCMeta):
 
 
 class Node(PrettyObject, metaclass=GraphNodeMeta):
-    """
-    Base class for all graph nodes in the BrainState framework.
+    """Base class for all graph nodes in the BrainState framework."""
 
-    This class serves as the foundation for creating computational graph nodes
-    that can be used in neural network architectures and other graph-based
-    computations.
-
-    Attributes
-    ----------
-    graph_invisible_attrs : tuple
-        Tuple of attribute names that should be excluded from graph
-        serialization and flattening operations.
-
-    Methods
-    -------
-    __deepcopy__(memo=None)
-        Creates a deep copy of the node preserving its graph structure
-        and state.
-
-    Notes
-    -----
-    The class provides the following features:
-
-    - Automatic registration with the graph system via metaclass
-    - Deep copy support for creating independent node instances
-    - Pretty printing for better debugging and visualization
-    - State management integration with TreefyState
-    - Attribute visibility control via graph_invisible_attrs
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> from copy import deepcopy
-        >>> class MyNode(Node):
-        ...     def __init__(self, value):
-        ...         self.value = value
-        >>> node = MyNode(10)
-        >>> copied_node = deepcopy(node)
-        >>> print(node.value)
-        10
-    """
     __module__ = 'brainstate.graph'
 
-    graph_invisible_attrs = ()
+    graph_invisible_attrs: tuple[str, ...] = ()
 
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
-
         register_graph_node_type(
             type=cls,
             flatten=_node_flatten,
@@ -107,70 +67,29 @@ class Node(PrettyObject, metaclass=GraphNodeMeta):
         return treefy_merge(graphdef, state)
 
     def check_valid_context(self, error_msg: Callable[[], str]) -> None:
-        """
-        Check if the current context is valid for the object to be mutated.
-        """
+        """Check if the current context is valid for mutation."""
         if not self._trace_state.is_valid():
             raise TraceContextError(error_msg())
 
 
 # -------------------------------
-# Graph Definition
+# Graph node helper functions
 # -------------------------------
 
 
-def _node_flatten(node: Node) -> Tuple[Tuple[Tuple[str, Any], ...], Tuple[Type]]:
-    """
-    Flatten a node into its constituent parts for serialization.
-
-    Parameters
-    ----------
-    node : Node
-        The Node instance to flatten.
-
-    Returns
-    -------
-    tuple
-        A tuple containing:
-        - Sorted list of (key, value) pairs for visible attributes
-        - Tuple containing the node's type
-    """
+def _node_flatten(node: Node) -> tuple[list[tuple[str, Any]], tuple[type]]:
     graph_invisible_attrs = getattr(node, 'graph_invisible_attrs', ())
-    # graph_invisible_attrs = tuple(graph_invisible_attrs) + ('_trace_state',)
     nodes = sorted(
         (key, value) for key, value in vars(node).items()
-        if (key not in graph_invisible_attrs)
+        if key not in graph_invisible_attrs
     )
     return nodes, (type(node),)
 
 
 def _node_set_key(node: Node, key: Key, value: Any) -> None:
-    """
-    Set an attribute on a node with special handling for State objects.
-
-    Parameters
-    ----------
-    node : Node
-        The Node instance to modify.
-    key : Key
-        The attribute name to set.
-    value : Any
-        The value to set.
-
-    Raises
-    ------
-    KeyError
-        If the key is not a string.
-
-    Notes
-    -----
-    If the attribute already exists as a State object and the new value
-    is a TreefyState, the state is updated via reference rather than
-    replaced.
-    """
     if not isinstance(key, str):
         raise KeyError(f'Invalid key: {key!r}')
-    elif (
+    if (
         hasattr(node, key)
         and isinstance(state := getattr(node, key), State)
         and isinstance(value, TreefyState)
@@ -181,68 +100,15 @@ def _node_set_key(node: Node, key: Key, value: Any) -> None:
 
 
 def _node_pop_key(node: Node, key: Key) -> Any:
-    """
-    Remove and return an attribute from a node.
-
-    Parameters
-    ----------
-    node : Node
-        The Node instance to modify.
-    key : Key
-        The attribute name to remove.
-
-    Returns
-    -------
-    Any
-        The value of the removed attribute.
-
-    Raises
-    ------
-    KeyError
-        If the key is not a string.
-    """
     if not isinstance(key, str):
         raise KeyError(f'Invalid key: {key!r}')
     return vars(node).pop(key)
 
 
-def _node_create_empty(static: tuple[Type[G], ...]) -> G:
-    """
-    Create an empty node instance without calling __init__.
-
-    Parameters
-    ----------
-    static : tuple[Type[G], ...]
-        Tuple containing the node type to instantiate.
-
-    Returns
-    -------
-    G
-        A new uninitialized instance of the node type.
-
-    Notes
-    -----
-    This function is used internally by the graph system to create
-    nodes without invoking their initialization logic.
-    """
+def _node_create_empty(static: tuple[type[G], ...]) -> G:
     node_type, = static
-    node = object.__new__(node_type)
-    return node
+    return object.__new__(node_type)
 
 
 def _node_clear(node: Node) -> None:
-    """
-    Clear all attributes from a node.
-
-    Parameters
-    ----------
-    node : Node
-        The Node instance to clear.
-
-    Notes
-    -----
-    This removes all attributes from the node's instance dictionary,
-    effectively resetting it to an empty state.
-    """
-    module_vars = vars(node)
-    module_vars.clear()
+    vars(node).clear()

--- a/brainstate/graph/_operation.py
+++ b/brainstate/graph/_operation.py
@@ -18,10 +18,8 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import (
-    Any, Callable, Generic, Iterable, Iterator, Mapping, MutableMapping,
-    Sequence, Type, TypeVar, Union, Hashable, Tuple, Dict, Optional
-)
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence
+from typing import Any, Generic, TypeVar
 
 import jax
 import numpy as np
@@ -46,7 +44,7 @@ from brainstate.util.struct import FrozenDict
 __all__ = [
     'register_graph_node_type',
 
-    # state management in the given graph or node
+    # state management
     'pop_states',
     'nodes',
     'states',
@@ -63,7 +61,7 @@ __all__ = [
     'clone',
     'graphdef',
 
-    # others
+    # data structures
     'RefMap',
     'GraphDef',
     'NodeDef',
@@ -74,24 +72,18 @@ MAX_INT = np.iinfo(np.int32).max
 
 A = TypeVar('A')
 B = TypeVar('B')
-C = TypeVar('C')
 F = TypeVar('F', bound=Callable)
-
-HA = TypeVar('HA', bound=Hashable)
-HB = TypeVar('HB', bound=Hashable)
-
-Index = int
-Names = Sequence[int]
-Node = TypeVar('Node')
+HA = TypeVar('HA')
+HB = TypeVar('HB')
+N = TypeVar('N')       # generic node type (distinct from the Node base class)
 Leaf = TypeVar('Leaf')
 AuxData = TypeVar('AuxData')
 
+Index = int
 StateLeaf = TreefyState[Any]
 NodeLeaf = State[Any]
 GraphStateMapping = NestedDict
 
-
-# --------------------------------------------------------
 
 def _is_state_leaf(x: Any) -> TypeGuard[StateLeaf]:
     return isinstance(x, TreefyState)
@@ -102,37 +94,12 @@ def _is_node_leaf(x: Any) -> TypeGuard[NodeLeaf]:
 
 
 class RefMap(MutableMapping[A, B], MappingReprMixin[A, B]):
-    """
-    A mapping that uses object id as the hash for the keys.
+    """A mapping that uses object identity (id) as the hash key."""
 
-    This mapping is useful when we want to keep track of objects
-    that are being referenced by other objects.
-
-    Parameters
-    ----------
-    mapping : Mapping[A, B] or Iterable[Tuple[A, B]], optional
-        A mapping or iterable of key-value pairs.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> obj1 = object()
-        >>> obj2 = object()
-        >>> ref_map = brainstate.graph.RefMap()
-        >>> ref_map[obj1] = 'value1'
-        >>> ref_map[obj2] = 'value2'
-        >>> print(obj1 in ref_map)
-        True
-        >>> print(ref_map[obj1])
-        value1
-
-    """
     __module__ = 'brainstate.graph'
 
-    def __init__(self, mapping: Union[Mapping[A, B], Iterable[Tuple[A, B]]] = ()) -> None:
-        self._mapping: Dict[int, Tuple[A, B]] = {}
+    def __init__(self, mapping: Mapping[A, B] | Iterable[tuple[A, B]] = ()) -> None:
+        self._mapping: dict[int, tuple[A, B]] = {}
         self.update(mapping)
 
     def __getitem__(self, key: A) -> B:
@@ -158,103 +125,52 @@ class RefMap(MutableMapping[A, B], MappingReprMixin[A, B]):
 
 
 @dataclasses.dataclass(frozen=True)
-class NodeImplBase(Generic[Node, Leaf, AuxData]):
-    type: type
-    flatten: Callable[[Node], tuple[Sequence[tuple[Key, Leaf]], AuxData]]
+class NodeImplBase(Generic[N, Leaf, AuxData]):
+    """Base descriptor for a node type, holding its type and flatten function."""
 
-    def node_dict(self, node: Node) -> dict[Key, Leaf]:
+    type: type
+    flatten: Callable[[N], tuple[Sequence[tuple[Key, Leaf]], AuxData]]
+
+    def node_dict(self, node: N) -> dict[Key, Leaf]:
         nodes, _ = self.flatten(node)
         return dict(nodes)
 
 
 @dataclasses.dataclass(frozen=True)
-class GraphNodeImpl(NodeImplBase[Node, Leaf, AuxData]):
-    set_key: Callable[[Node, Key, Leaf], None]
-    pop_key: Callable[[Node, Key], Leaf]
-    create_empty: Callable[[AuxData], Node]
-    clear: Callable[[Node], None]
+class GraphNodeImpl(NodeImplBase[N, Leaf, AuxData]):
+    """Node implementation for registered graph nodes (supports mutation and identity tracking)."""
 
-    def init(self, node: Node, items: Tuple[Tuple[Key, Leaf], ...]) -> None:
+    set_key: Callable[[N, Key, Leaf], None]
+    pop_key: Callable[[N, Key], Leaf]
+    create_empty: Callable[[AuxData], N]
+    clear: Callable[[N], None]
+
+    def init(self, node: N, items: tuple[tuple[Key, Leaf], ...]) -> None:
         for key, value in items:
             self.set_key(node, key, value)
 
 
 @dataclasses.dataclass(frozen=True)
-class PyTreeNodeImpl(NodeImplBase[Node, Leaf, AuxData]):
-    unflatten: Callable[[tuple[tuple[Key, Leaf], ...], AuxData], Node]
+class PyTreeNodeImpl(NodeImplBase[N, Leaf, AuxData]):
+    """Node implementation for JAX pytree nodes (lists, dicts, tuples — immutable structure)."""
+
+    unflatten: Callable[[tuple[tuple[Key, Leaf], ...], AuxData], N]
 
 
-NodeImpl = Union[GraphNodeImpl[Node, Leaf, AuxData], PyTreeNodeImpl[Node, Leaf, AuxData]]
-
-# --------------------------------------------------------
-# Graph Node implementation: start
-# --------------------------------------------------------
+NodeImpl = GraphNodeImpl[N, Leaf, AuxData] | PyTreeNodeImpl[N, Leaf, AuxData]
 
 _node_impl_for_type: dict[type, NodeImpl] = {}
 
 
 def register_graph_node_type(
     type: type,
-    flatten: Callable[[Node], tuple[Sequence[tuple[Key, Leaf]], AuxData]],
-    set_key: Callable[[Node, Key, Leaf], None],
-    pop_key: Callable[[Node, Key], Leaf],
-    create_empty: Callable[[AuxData], Node],
-    clear: Callable[[Node], None],
-):
-    """
-    Register a graph node type.
-
-    Parameters
-    ----------
-    type : type
-        The type of the node.
-    flatten : Callable[[Node], tuple[Sequence[tuple[Key, Leaf]], AuxData]]
-        A function that flattens the node into a sequence of key-value pairs.
-    set_key : Callable[[Node, Key, Leaf], None]
-        A function that sets a key in the node.
-    pop_key : Callable[[Node, Key], Leaf]
-        A function that pops a key from the node.
-    create_empty : Callable[[AuxData], Node]
-        A function that creates an empty node.
-    clear : Callable[[Node], None]
-        A function that clears the node.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> # Custom node type implementation
-        >>> class CustomNode:
-        ...     def __init__(self):
-        ...         self.data = {}
-        ...
-        >>> def flatten_custom(node):
-        ...     return list(node.data.items()), None
-        ...
-        >>> def set_key_custom(node, key, value):
-        ...     node.data[key] = value
-        ...
-        >>> def pop_key_custom(node, key):
-        ...     return node.data.pop(key)
-        ...
-        >>> def create_empty_custom(metadata):
-        ...     return CustomNode()
-        ...
-        >>> def clear_custom(node):
-        ...     node.data.clear()
-        ...
-        >>> # Register the custom node type
-        >>> brainstate.graph.register_graph_node_type(
-        ...     CustomNode,
-        ...     flatten_custom,
-        ...     set_key_custom,
-        ...     pop_key_custom,
-        ...     create_empty_custom,
-        ...     clear_custom
-        ... )
-
-    """
+    flatten: Callable[[N], tuple[Sequence[tuple[Key, Leaf]], AuxData]],
+    set_key: Callable[[N, Key, Leaf], None],
+    pop_key: Callable[[N, Key], Leaf],
+    create_empty: Callable[[AuxData], N],
+    clear: Callable[[N], None],
+) -> None:
+    """Register a custom graph node type with the graph system."""
     _node_impl_for_type[type] = GraphNodeImpl(
         type=type,
         flatten=flatten,
@@ -263,11 +179,6 @@ def register_graph_node_type(
         create_empty=create_empty,
         clear=clear,
     )
-
-
-# --------------------------------------------------------
-# Graph node implementation: end
-# --------------------------------------------------------
 
 
 def _is_node(x: Any) -> bool:
@@ -282,32 +193,31 @@ def _is_graph_node(x: Any) -> bool:
     return type(x) in _node_impl_for_type
 
 
-def _is_node_type(x: Type[Any]) -> bool:
+def _is_node_type(x: type[Any]) -> bool:
     return x in _node_impl_for_type or x is PytreeType
 
 
 def _get_node_impl(x: Any) -> NodeImpl:
     if isinstance(x, State):
         raise ValueError(f'State is not a node: {x}')
-
     node_type = type(x)
     if node_type not in _node_impl_for_type:
         if _is_pytree_node(x):
             return PYTREE_NODE_IMPL
-        else:
-            raise ValueError(f'Unknown node type: {x}')
-
+        raise ValueError(f'Unknown node type: {x}')
     return _node_impl_for_type[node_type]
 
 
-def get_node_impl_for_type(x: Type[Any]) -> NodeImpl:
+def get_node_impl_for_type(x: type[Any]) -> NodeImpl:
     if x is PytreeType:
         return PYTREE_NODE_IMPL
     return _node_impl_for_type[x]
 
 
-class HashableMapping(Mapping[HA, HB], Hashable):
-    def __init__(self, mapping: Union[Mapping[HA, HB], Iterable[tuple[HA, HB]]]) -> None:
+class HashableMapping(Mapping[HA, HB]):
+    """An immutable, hashable mapping."""
+
+    def __init__(self, mapping: Mapping[HA, HB] | Iterable[tuple[HA, HB]]) -> None:
         self._mapping = dict(mapping)
 
     def __contains__(self, key: object) -> bool:
@@ -332,78 +242,38 @@ class HashableMapping(Mapping[HA, HB], Hashable):
         return repr(self._mapping)
 
 
-class GraphDef(Generic[Node]):
-    """
-    A base dataclass that denotes the graph structure of a :class:`Node`.
+class GraphDef(Generic[N]):
+    """Base class representing the static graph structure of a node."""
 
-    It contains two main components:
-    - type: The type of the node.
-    - index: The index of the node in the graph.
-
-    It has two concrete subclasses:
-
-    - :class:`NodeRef`: A reference to a node in the graph.
-    - :class:`NodeDef`: A dataclass that denotes the graph structure of a :class:`Node` or a :class:`State`.
-
-    Attributes
-    ----------
-    type : Type[Node]
-        The type of the node.
-    index : int
-        The index of the node in the graph.
-
-    """
-    type: Type[Node]
+    type: type[N]
     index: int
 
 
 @dataclasses.dataclass(frozen=True, repr=False)
-class NodeDef(GraphDef[Node], PrettyRepr):
-    """
-    A dataclass that denotes the tree structure of a node, either :class:`Node` or :class:`State`.
+class NodeDef(GraphDef[N], PrettyRepr):
+    """Graph structure of a node, containing all static information for reconstruction."""
 
-    Attributes
-    ----------
-    type : Type[Node]
-        Type of the node.
-    index : int
-        Index of the node in the graph.
-    attributes : Tuple[Key, ...]
-        Attributes for the node.
-    subgraphs : HashableMapping[Key, NodeDef[Any] | NodeRef[Any]]
-        Mapping of subgraph definitions.
-    static_fields : HashableMapping
-        Mapping of static fields.
-    leaves : HashableMapping[Key, NodeRef[Any] | None]
-        Mapping of leaf nodes.
-    metadata : Hashable
-        Metadata associated with the node.
-    index_mapping : FrozenDict[Index, Index] | None
-        Index mapping for node references.
-
-    """
-
-    type: Type[Node]  # type of the node
-    index: int  # index of the node in the graph
-    attributes: Tuple[Key, ...]  # attributes for the node
+    type: type[N]
+    index: int
+    attributes: tuple[Key, ...]
     subgraphs: HashableMapping[Key, NodeDef[Any] | NodeRef[Any]]
     static_fields: HashableMapping
     leaves: HashableMapping[Key, NodeRef[Any] | None]
-    metadata: Hashable
+    metadata: Any
     index_mapping: FrozenDict[Index, Index] | None
 
     @classmethod
     def create(
         cls,
-        type: Type[Node],
+        type: type[N],
         index: int,
         attributes: tuple[Key, ...],
         subgraphs: Iterable[tuple[Key, NodeDef[Any] | NodeRef[Any]]],
         static_fields: Iterable[tuple],
         leaves: Iterable[tuple[Key, NodeRef[Any] | None]],
-        metadata: Hashable,
+        metadata: Any,
         index_mapping: Mapping[Index, Index] | None,
-    ):
+    ) -> NodeDef[N]:
         return cls(
             type=type,
             index=index,
@@ -417,7 +287,6 @@ class NodeDef(GraphDef[Node], PrettyRepr):
 
     def __pretty_repr__(self):
         yield PrettyType(type=type(self))
-
         yield PrettyAttr('type', self.type.__name__)
         yield PrettyAttr('index', self.index)
         yield PrettyAttr('attributes', self.attributes)
@@ -432,21 +301,10 @@ jax.tree_util.register_static(NodeDef)
 
 
 @dataclasses.dataclass(frozen=True, repr=False)
-class NodeRef(GraphDef[Node], PrettyRepr):
-    """
-    A reference to a node in the graph.
+class NodeRef(GraphDef[N], PrettyRepr):
+    """A reference to an already-seen node in the graph (used for shared/circular refs)."""
 
-    The node can be instances of :class:`Node` or :class:`State`.
-
-    Attributes
-    ----------
-    type : Type[Node]
-        The type of the node being referenced.
-    index : int
-        The index of the node in the graph.
-
-    """
-    type: Type[Node]
+    type: type[N]
     index: int
 
     def __pretty_repr__(self):
@@ -459,97 +317,55 @@ jax.tree_util.register_static(NodeRef)
 
 
 # --------------------------------------------------------
-# Graph operations: start
+# Graph flatten / unflatten
 # --------------------------------------------------------
 
 
 def _graph_flatten(
     path: PathParts,
     ref_index: RefMap[Any, Index],
-    flatted_state_mapping: Dict[PathParts, StateLeaf],
+    flatted_state_mapping: dict[PathParts, StateLeaf],
     node: Any,
     treefy_state: bool = False,
-) -> Union[NodeDef[Any], NodeRef[Any]]:
-    """
-    Recursive helper for graph flatten.
-
-    Parameters
-    ----------
-    path : PathParts
-        The path to the node.
-    ref_index : RefMap[Any, Index]
-        A mapping from nodes to indexes.
-    flatted_state_mapping : Dict[PathParts, StateLeaf]
-        A mapping from paths to state leaves.
-    node : Node
-        The node to flatten.
-    treefy_state : bool, optional
-        Whether to convert states to TreefyState, by default False.
-
-    Returns
-    -------
-    NodeDef or NodeRef
-        A NodeDef or a NodeRef.
-
-    """
+) -> NodeDef[Any] | NodeRef[Any]:
+    """Recursively flatten a graph node into a NodeDef/NodeRef tree."""
     if not _is_node(node):
         raise RuntimeError(f'Unsupported type: {type(node)}, this is a bug.')
 
-    # If the node is already in the cache, return a reference, otherwise
-    # add it to the cache and continue with the flattening process.
-    # This is done to avoid infinite recursion when there is a reference cycle.
     if node in ref_index:
         return NodeRef(type(node), ref_index[node])
 
-    # Get the node implementation for the node type.
-    # There are two types of node implementations: GraphNodeImpl and PyTreeNodeImpl.
-    # - ``GraphNodeImpl`` is used for nodes that have a graph structure.
-    # - ``PyTreeNodeImpl`` is used for nodes that have a tree structure.
     node_impl = _get_node_impl(node)
 
-    # There are two types of nodes: Node and State.
-    # Here we handle the Node case.
     if isinstance(node_impl, GraphNodeImpl):
-        # add the node to the cache
         index = len(ref_index)
         ref_index[node] = index
     else:
         index = -1
 
-    subgraphs: list[tuple[Key, Union[NodeDef[Any], NodeRef[Any]]]] = []
+    subgraphs: list[tuple[Key, NodeDef[Any] | NodeRef[Any]]] = []
     static_fields: list[tuple] = []
-    leaves: list[tuple[Key, Union[NodeRef[Any], None]]] = []
+    leaves: list[tuple[Key, NodeRef[Any] | None]] = []
 
-    # Flatten the node into a sequence of key-value pairs.
     values, metadata = node_impl.flatten(node)
     for key, value in values:
         if _is_node(value):
-            # Recursively flatten the subgraph.
             nodedef = _graph_flatten((*path, key), ref_index, flatted_state_mapping, value, treefy_state)
             subgraphs.append((key, nodedef))
         elif isinstance(value, State):
-            # If the variable is in the cache, add a reference to it.
             if value in ref_index:
                 leaves.append((key, NodeRef(type(value), ref_index[value])))
             else:
-                # If the variable is not in the cache, add it to the cache.
-                # This is done to avoid multiple references to the same variable.
                 flatted_state_mapping[(*path, key)] = (value.to_state_ref() if treefy_state else value)
                 variable_index = ref_index[value] = len(ref_index)
                 leaves.append((key, NodeRef(type(value), variable_index)))
         elif _is_state_leaf(value):
-            # The instance of ``TreefyState`` is a leaf.
             flatted_state_mapping[(*path, key)] = value
             leaves.append((key, None))
         else:
-            # if isinstance(value, (jax.Array, np.ndarray)):
-            #   path_str = '/'.join(map(str, (*path, key)))
-            #   raise ValueError(f'Arrays leaves are not supported, at {path_str!r}: {value}')
-
-            # The value is a static field.
             static_fields.append((key, value))
 
-    nodedef = NodeDef.create(
+    return NodeDef.create(
         type=node_impl.type,
         index=index,
         attributes=tuple(key for key, _ in values),
@@ -559,49 +375,19 @@ def _graph_flatten(
         metadata=metadata,
         index_mapping=None,
     )
-    return nodedef
 
 
 @set_module_as('brainstate.graph')
 def flatten(
     node: Any,
     /,
-    ref_index: Optional[RefMap[Any, Index]] = None,
+    ref_index: RefMap[Any, Index] | None = None,
     treefy_state: bool = True,
-) -> Tuple[GraphDef[Any], NestedDict]:
-    """
-    Flattens a graph node into a (graph_def, state_mapping) pair.
-
-    Parameters
-    ----------
-    node : Node
-        A graph node.
-    ref_index : RefMap[Any, Index], optional
-        A mapping from nodes to indexes, defaults to None. If not provided, a new
-        empty dictionary is created. This argument can be used to flatten a sequence of graph
-        nodes that share references.
-    treefy_state : bool, optional
-        If True, the state mapping will be a NestedDict instead of a flat dictionary.
-        Default is True.
-
-    Returns
-    -------
-    tuple[GraphDef, NestedDict]
-        A tuple containing the graph definition and state mapping.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> node = brainstate.graph.Node()
-        >>> graph_def, state_mapping = brainstate.graph.flatten(node)
-        >>> print(graph_def)
-        >>> print(state_mapping)
-
-    """
+) -> tuple[GraphDef[Any], NestedDict]:
+    """Flatten a graph node into a (graph_def, state_mapping) pair."""
     ref_index = RefMap() if ref_index is None else ref_index
-    assert isinstance(ref_index, RefMap), f"ref_index must be a RefMap. But we got: {ref_index}"
+    if not isinstance(ref_index, RefMap):
+        raise TypeError(f"ref_index must be a RefMap, got: {type(ref_index)}")
     flatted_state_mapping: dict[PathParts, StateLeaf] = {}
     graph_def = _graph_flatten((), ref_index, flatted_state_mapping, node, treefy_state)
     return graph_def, NestedDict.from_flat(flatted_state_mapping)
@@ -611,48 +397,30 @@ def _get_children(
     graph_def: NodeDef[Any],
     state_mapping: Mapping,
     index_ref: dict[Index, Any],
-    index_ref_cache: Optional[dict[Index, Any]],
-) -> dict[Key, Union[StateLeaf, Any]]:
-    children: dict[Key, Union[StateLeaf, Any]] = {}
+    index_ref_cache: dict[Index, Any] | None,
+) -> dict[Key, StateLeaf | Any]:
+    children: dict[Key, StateLeaf | Any] = {}
 
-    # NOTE: we could allow adding new StateLeafs here
-    # All state keys must be present in the graph definition (the object attributes)
     if unknown_keys := set(state_mapping) - set(graph_def.attributes):
         raise ValueError(f'Unknown keys: {unknown_keys}')
 
-    # for every key in attributes there are 6 possible cases:
-    #  - (2) the key can either be present in the state or not
-    #  - (3) the key can be a subgraph, a leaf, or a static attribute
     for key in graph_def.attributes:
-        if key not in state_mapping:  # static field
-            # Support unflattening with missing keys for static fields and subgraphs
-            # This allows partial state restoration and flexible graph reconstruction
+        if key not in state_mapping:
             if key in graph_def.static_fields:
                 children[key] = graph_def.static_fields[key]
 
             elif key in graph_def.subgraphs:
-                # if the key is a subgraph we create an empty node
                 subgraphdef = graph_def.subgraphs[key]
                 if isinstance(subgraphdef, NodeRef):
-                    # subgraph exists, take it from the cache
                     children[key] = index_ref[subgraphdef.index]
-
                 else:
-                    # create a node from an empty state, reasoning:
-                    # * it is a node with no state
-                    # * it is a node with state but only through references of already
-                    #   created nodes
-                    substate = {}
-                    children[key] = _graph_unflatten(subgraphdef, substate, index_ref, index_ref_cache)
+                    children[key] = _graph_unflatten(subgraphdef, {}, index_ref, index_ref_cache)
 
             elif key in graph_def.leaves:
                 noderef = graph_def.leaves[key]
                 if (noderef is not None) and (noderef.index in index_ref):
-                    # variable exists, take it from the cache
                     children[key] = index_ref[noderef.index]
-
                 else:
-                    # key for a variable is missing, raise an error
                     raise ValueError(
                         f'Expected key {key!r} in state while building node of type '
                         f'{graph_def.type.__name__}.'
@@ -661,7 +429,7 @@ def _get_children(
             else:
                 raise RuntimeError(f'Unknown static field: {key!r}')
 
-        else:  # state field
+        else:
             value = state_mapping[key]
             if isinstance(value, PrettyDict):
                 value = dict(value)
@@ -670,13 +438,11 @@ def _get_children(
                 raise ValueError(f'Got state for static field {key!r}, this is not supported.')
 
             if key in graph_def.subgraphs:
-                # if _is_state_leaf(value):
                 if isinstance(value, (TreefyState, State)):
                     raise ValueError(
                         f'Expected value of type {graph_def.subgraphs[key]} '
                         f'for {key!r}, but got {value!r}'
                     )
-
                 if not isinstance(value, dict):
                     raise TypeError(f'Expected a dict for {key!r}, but got {type(value)}.')
 
@@ -687,34 +453,24 @@ def _get_children(
                     children[key] = _graph_unflatten(subgraphdef, value, index_ref, index_ref_cache)
 
             elif key in graph_def.leaves:
-                # if not _is_state_leaf(value):
                 if not isinstance(value, (TreefyState, State)):
                     raise ValueError(f'Expected a leaf for {key!r}, but got {value!r}')
 
                 noderef = graph_def.leaves[key]
                 if noderef is None:
-                    # if the leaf is None, it means that the value was originally
-                    # a non-TreefyState leaf, however we allow providing a
-                    # TreefyState presumbly created by modifying the NestedDict
                     if isinstance(value, TreefyState):
                         value = value.to_state()
-                    elif isinstance(value, State):
-                        value = value
                     children[key] = value
 
                 elif noderef.index in index_ref:
-                    # add an existing variable
                     children[key] = index_ref[noderef.index]
 
                 else:
-                    # it is an unseen variable, create a new one
                     if not isinstance(value, (TreefyState, State)):
                         raise ValueError(
                             f'Expected a State type for {key!r}, but got {type(value)}.'
                         )
 
-                    # when idxmap is present, check if the Varable exists there
-                    # and update existing variables if it does
                     if index_ref_cache is not None and noderef.index in index_ref_cache:
                         variable = index_ref_cache[noderef.index]
                         if not isinstance(variable, State):
@@ -728,7 +484,7 @@ def _get_children(
                                 variable.restore_value(value.value)
                         else:
                             raise ValueError(f'Expected a State type for {key!r}, but got {type(value)}.')
-                    else:  # if it doesn't, create a new variable
+                    else:
                         if isinstance(value, TreefyState):
                             variable = value.to_state()
                         elif isinstance(value, State):
@@ -745,78 +501,43 @@ def _get_children(
 
 
 def _graph_unflatten(
-    graph_def: Union[NodeDef[Any], NodeRef[Any]],
-    state_mapping: Mapping[Key, Union[StateLeaf, Mapping]],
+    graph_def: NodeDef[Any] | NodeRef[Any],
+    state_mapping: Mapping[Key, StateLeaf | Mapping],
     index_ref: dict[Index, Any],
-    index_ref_cache: Optional[dict[Index, Any]],
+    index_ref_cache: dict[Index, Any] | None,
 ) -> Any:
-    """
-    Recursive helper for graph unflatten.
-
-    Args:
-      graph_def: A `GraphDef` instance or an index to a node in the cache.
-      state_mapping: A state mapping from attribute names to variables or subgraphs.
-      index_ref: A mapping from indexes to nodes that have been traversed.
-                 If a node is already in the cache, it won't be traversed again.
-      index_ref_cache: A mapping from indexes to existing nodes that can be reused.
-                        When an reference is reused, ``GraphNodeImpl.clear`` is called to leave the
-                        object in an empty state and then filled by the unflatten process, as a result
-                        existing graph nodes are mutated to have the new content/topology
-                        specified by the nodedef.
-
-    Returns:
-      A node instance.
-    """
-
-    # if the graph_def is a reference, this means that the node has already been created, so
-    # we return the node from the cache
+    """Recursively unflatten a graph_def + state_mapping into a node."""
     if isinstance(graph_def, NodeRef):
         return index_ref[graph_def.index]
-    else:
-        assert isinstance(graph_def, NodeDef), f"graph_def must be a NodeDef. But we got: {graph_def}"
 
-    # graph_def must be a registered node type
+    if not isinstance(graph_def, NodeDef):
+        raise TypeError(f"graph_def must be a NodeDef, got: {type(graph_def)}")
+
     if not _is_node_type(graph_def.type):
         raise RuntimeError(f'Unsupported type: {graph_def.type}, this is a bug.')
 
-    # check if the index is already in the cache
     if graph_def.index in index_ref:
         raise RuntimeError(f'GraphDef index {graph_def.index} already used.')
 
-    # get the node implementation for the node type
     node_impl = get_node_impl_for_type(graph_def.type)
 
     if isinstance(node_impl, GraphNodeImpl):
-        # we create an empty node first and add it to the index
-        # this avoids infinite recursion when there is a reference cycle
-
         if (index_ref_cache is not None) and (graph_def.index in index_ref_cache):
-            # clear the node to leave it in an empty state
             node = index_ref_cache[graph_def.index]
             if type(node) != graph_def.type:
-                raise ValueError(f'Expected a node of type {graph_def.type} for index '
-                                 f'{graph_def.index}, but got a node of type {type(node)}.')
+                raise ValueError(
+                    f'Expected a node of type {graph_def.type} for index '
+                    f'{graph_def.index}, but got a node of type {type(node)}.'
+                )
             node_impl.clear(node)
         else:
-            # create an empty node
             node = node_impl.create_empty(graph_def.metadata)
 
-        # add the node to the cache
         index_ref[graph_def.index] = node
-
-        # get the children (the attributes) of the node
         children = _get_children(graph_def, state_mapping, index_ref, index_ref_cache)
-
-        # initialize the node with the children
         node_impl.init(node, tuple(children.items()))
-
     else:
-        # if the node type does not support the creation of an empty object it means
-        # that it cannot reference itself, so we can create its children first
-
-        # first, we create the children (attributes)
         children = _get_children(graph_def, state_mapping, index_ref, index_ref_cache)
-        # then, we create the node
         node = node_impl.unflatten(tuple(children.items()), graph_def.metadata)
 
     return node
@@ -828,58 +549,19 @@ def unflatten(
     state_mapping: NestedDict,
     /,
     *,
-    index_ref: Optional[dict[Index, Any]] = None,
-    index_ref_cache: Optional[dict[Index, Any]] = None,
+    index_ref: dict[Index, Any] | None = None,
+    index_ref_cache: dict[Index, Any] | None = None,
 ) -> Any:
-    """
-    Unflattens a graphdef into a node with the given state tree mapping.
-
-    Parameters
-    ----------
-    graph_def : GraphDef
-        A GraphDef instance.
-    state_mapping : NestedDict
-        A NestedDict instance containing the state mapping.
-    index_ref : dict[Index, Any], optional
-        A mapping from indexes to nodes references found during the graph
-        traversal. If not provided, a new empty dictionary is created. This argument
-        can be used to unflatten a sequence of (graphdef, state_mapping) pairs that
-        share the same index space.
-    index_ref_cache : dict[Index, Any], optional
-        A mapping from indexes to existing nodes that can be reused. When a reference
-        is reused, ``GraphNodeImpl.clear`` is called to leave the object in an empty
-        state and then filled by the unflatten process. As a result, existing graph
-        nodes are mutated to have the new content/topology specified by the graphdef.
-
-    Returns
-    -------
-    Node
-        The reconstructed node.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> class MyNode(brainstate.graph.Node):
-        ...     def __init__(self):
-        ...         self.a = brainstate.nn.Linear(2, 3)
-        ...         self.b = brainstate.nn.Linear(3, 4)
-        ...
-        >>> # Flatten a node
-        >>> node = MyNode()
-        >>> graphdef, statetree = brainstate.graph.flatten(node)
-        >>>
-        >>> # Unflatten back to node
-        >>> reconstructed_node = brainstate.graph.unflatten(graphdef, statetree)
-        >>> assert isinstance(reconstructed_node, MyNode)
-        >>> assert isinstance(reconstructed_node.a, brainstate.nn.Linear)
-        >>> assert isinstance(reconstructed_node.b, brainstate.nn.Linear)
-    """
+    """Unflatten a graph_def + state_mapping back into a node."""
     index_ref = {} if index_ref is None else index_ref
-    assert isinstance(graph_def, (NodeDef, NodeRef)), f"graph_def must be a NodeDef or NodeRef. But we got: {graph_def}"
-    node = _graph_unflatten(graph_def, state_mapping.to_dict(), index_ref, index_ref_cache)
-    return node
+    if not isinstance(graph_def, (NodeDef, NodeRef)):
+        raise TypeError(f"graph_def must be a NodeDef or NodeRef, got: {type(graph_def)}")
+    return _graph_unflatten(graph_def, state_mapping.to_dict(), index_ref, index_ref_cache)
+
+
+# --------------------------------------------------------
+# State extraction / manipulation
+# --------------------------------------------------------
 
 
 def _graph_pop(
@@ -909,9 +591,7 @@ def _graph_pop(
                 predicates=predicates,
             )
             continue
-        elif not _is_node_leaf(value):
-            continue
-        elif id(value) in id_to_index:
+        elif not _is_node_leaf(value) or id(value) in id_to_index:
             continue
 
         node_path = (*path_parts, name)
@@ -922,87 +602,30 @@ def _graph_pop(
                     raise ValueError(f'Cannot pop key {name!r} from node of type {type(node).__name__}')
                 id_to_index[id(value)] = len(id_to_index)
                 node_impl.pop_key(node, name)
-                # if isinstance(value, State):
-                #   value = value.to_state_ref()
-                state_dicts[node_path] = value  # type: ignore[index] # mypy is wrong here?
+                state_dicts[node_path] = value
                 break
-        else:
-            # NOTE: should we raise an error here?
-            pass
 
 
 @set_module_as('brainstate.graph')
 def pop_states(
     node: Any, *filters: Any
-) -> Union[NestedDict, Tuple[NestedDict, ...]]:
-    """
-    Pop one or more :class:`State` types from the graph node.
-
-    Parameters
-    ----------
-    node : Node
-        A graph node object.
-    *filters
-        One or more :class:`State` objects to filter by.
-
-    Returns
-    -------
-    NestedDict or tuple[NestedDict, ...]
-        The popped :class:`NestedDict` containing the :class:`State`
-        objects that were filtered for.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> import jax.numpy as jnp
-
-        >>> class Model(brainstate.nn.Module):
-        ...     def __init__(self):
-        ...         super().__init__()
-        ...         self.a = brainstate.nn.Linear(2, 3)
-        ...         self.b = brainpy.state.LIF([10, 2])
-
-        >>> model = Model()
-        >>> with brainstate.catch_new_states('new'):
-        ...     brainstate.nn.init_all_states(model)
-
-        >>> assert len(model.states()) == 2
-        >>> model_states = brainstate.graph.pop_states(model, 'new')
-        >>> model_states  # doctest: +SKIP
-        NestedDict({
-          'b': {
-            'V': {
-              'st': ShortTermState(
-                value=Array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
-                       0., 0., 0.], dtype=float32),
-                tag='new'
-              )
-            }
-          }
-        })
-    """
+) -> NestedDict | tuple[NestedDict, ...]:
+    """Pop one or more State types from the graph node, removing them from the node."""
     if len(filters) == 0:
         raise ValueError('Expected at least one filter')
 
     id_to_index: dict[int, Index] = {}
-    path_parts: PathParts = ()
     predicates = tuple(to_predicate(filter) for filter in filters)
     flatted_state_dicts: tuple[FlattedDict[PathParts, StateLeaf], ...] = tuple({} for _ in predicates)
     _graph_pop(
         node=node,
         id_to_index=id_to_index,
-        path_parts=path_parts,
+        path_parts=(),
         flatted_state_dicts=flatted_state_dicts,
         predicates=predicates,
     )
-    states = tuple(NestedDict.from_flat(flat_state) for flat_state in flatted_state_dicts)
-
-    if len(states) == 1:
-        return states[0]
-    else:
-        return states
+    result = tuple(NestedDict.from_flat(flat_state) for flat_state in flatted_state_dicts)
+    return result[0] if len(result) == 1 else result
 
 
 def _split_state(
@@ -1014,53 +637,15 @@ def _split_state(
     states = state.split(*filters)
     if isinstance(states, NestedDict):
         return (states,)
-    assert len(states) > 0
     return states  # type: ignore[return-value]
 
 
 @set_module_as('brainstate.graph')
-def treefy_split(
-    node: A, *filters: Filter
-):
-    """
-    Split a graph node into a :class:`GraphDef` and one or more :class:`NestedDict`s.
+def treefy_split(node: A, *filters: Filter):
+    """Split a graph node into a GraphDef and one or more state NestedDicts.
 
-    NestedDict is a ``Mapping`` from strings or integers to ``Variables``, Arrays or nested States.
-    GraphDef contains all the static information needed to reconstruct a ``Module`` graph, it is
-    analogous to JAX's ``PyTreeDef``. :func:`split` is used in conjunction with :func:`merge` to
-    switch seamlessly between stateful and stateless representations of the graph.
-
-    Parameters
-    ----------
-    node : A
-        Graph node to split.
-    *filters
-        Optional filters to group the state into mutually exclusive substates.
-
-    Returns
-    -------
-    tuple
-        ``GraphDef`` and one or more ``States`` equal to the number of filters passed.
-        If no filters are passed, a single ``NestedDict`` is returned.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> import jax, jax.numpy as jnp
-
-        >>> class Foo(brainstate.graph.Node):
-        ...     def __init__(self):
-        ...         self.a = brainstate.nn.BatchNorm1d([10, 2])
-        ...         self.b = brainstate.nn.Linear(2, 3)
-        ...
-        >>> node = Foo()
-        >>> graphdef, params, others = brainstate.graph.treefy_split(
-        ...     node, brainstate.ParamState, ...
-        ... )
-        >>> # params contains ParamState variables
-        >>> # others contains all other state variables
+    If no filters are given, returns (graphdef, state).
+    With filters, returns (graphdef, state1, state2, ...) split by filter predicates.
     """
     graphdef, state_tree = flatten(node)
     states = tuple(_split_state(state_tree, filters))
@@ -1069,57 +654,20 @@ def treefy_split(
 
 @set_module_as('brainstate.graph')
 def treefy_merge(graphdef: GraphDef[A], *state_mappings) -> A:
-    """
-    The inverse of :func:`split`.
-
-    ``merge`` takes a :class:`GraphDef` and one or more :class:`NestedDict`'s and creates
-    a new node with the same structure as the original node.
-
-    Parameters
-    ----------
-    graphdef : GraphDef[A]
-        A :class:`GraphDef` object.
-    *state_mappings 
-        Additional :class:`NestedDict` objects.
-
-    Returns
-    -------
-    A
-        The merged :class:`Module`.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> import jax, jax.numpy as jnp
-
-        >>> class Foo(brainstate.graph.Node):
-        ...     def __init__(self):
-        ...         self.a = brainstate.nn.BatchNorm1d([10, 2])
-        ...         self.b = brainstate.nn.Linear(2, 3)
-        ...
-        >>> node = Foo()
-        >>> graphdef, params, others = brainstate.graph.treefy_split(
-        ...     node, brainstate.ParamState, ...
-        ... )
-        >>> new_node = brainstate.graph.treefy_merge(graphdef, params, others)
-        >>> assert isinstance(new_node, Foo)
-        >>> assert isinstance(new_node.b, brainstate.nn.BatchNorm1d)
-        >>> assert isinstance(new_node.a, brainstate.nn.Linear)
-    """
+    """Reconstruct a node from its GraphDef and one or more state NestedDicts."""
     state_mapping = GraphStateMapping.merge(*state_mappings)
-    node = unflatten(graphdef, state_mapping)
-    return node
+    return unflatten(graphdef, state_mapping)
 
 
-def _filters_to_predicates(filters: Tuple[Filter, ...]) -> Tuple[Predicate, ...]:
+def _filters_to_predicates(filters: tuple[Filter, ...]) -> tuple[Predicate, ...]:
     for i, filter_ in enumerate(filters):
         if filter_ in (..., True) and i != len(filters) - 1:
             remaining_filters = filters[i + 1:]
             if not all(f in (..., True) for f in remaining_filters):
-                raise ValueError('`...` or `True` can only be used as the last filters, '
-                                 f'got {filter_} it at index {i}.')
+                raise ValueError(
+                    f'`...` or `True` can only be used as the last filters, '
+                    f'got {filter_!r} at index {i}.'
+                )
     return tuple(map(to_predicate, filters))
 
 
@@ -1128,9 +676,6 @@ def _split_flatted(
     filters: tuple[Filter, ...],
 ) -> tuple[list[tuple[PathParts, Any]], ...]:
     predicates = _filters_to_predicates(filters)
-
-    # we have n + 1 states, where n is the number of predicates
-    # the last state is for values that don't match any predicate
     flat_states: tuple[list[tuple[PathParts, Any]], ...] = tuple([] for _ in predicates)
 
     for path, value in flatted:
@@ -1139,35 +684,19 @@ def _split_flatted(
                 flat_states[i].append((path, value))
                 break
         else:
-            raise ValueError('Non-exhaustive filters, got a non-empty remainder: '
-                             f'{path} -> {value}.'
-                             '\nUse `...` to match all remaining elements.')
+            raise ValueError(
+                f'Non-exhaustive filters, got a non-empty remainder: {path} -> {value}.'
+                '\nUse `...` to match all remaining elements.'
+            )
 
     return flat_states
 
 
 @set_module_as('brainstate.graph')
 def nodes(
-    node, *filters: Filter, allowed_hierarchy: Tuple[int, int] = (0, MAX_INT)
-):
-    """
-    Similar to :func:`split` but only returns the :class:`NestedDict`'s indicated by the filters.
-
-    Parameters
-    ----------
-    node : Node
-        The node to get nodes from.
-    *filters
-        Filters to apply to the nodes.
-    allowed_hierarchy : tuple[int, int], optional
-        The allowed hierarchy levels, by default (0, MAX_INT).
-
-    Returns
-    -------
-    FlattedDict or tuple[FlattedDict, ...]
-        The filtered nodes.
-
-    """
+    node, *filters: Filter, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
+) -> FlattedDict | tuple[FlattedDict, ...]:
+    """Return all graph nodes, optionally filtered and limited by hierarchy depth."""
     num_filters = len(filters)
     if num_filters == 0:
         filters = (..., ...)
@@ -1182,7 +711,7 @@ def nodes(
     return node_maps[:num_filters]
 
 
-def _states_generator(node, allowed_hierarchy) -> Iterable[Tuple[PathParts, State]]:
+def _states_generator(node, allowed_hierarchy) -> Iterable[tuple[PathParts, State]]:
     for path, value in iter_leaf(node, allowed_hierarchy=allowed_hierarchy):
         if isinstance(value, State):
             yield path, value
@@ -1190,26 +719,9 @@ def _states_generator(node, allowed_hierarchy) -> Iterable[Tuple[PathParts, Stat
 
 @set_module_as('brainstate.graph')
 def states(
-    node, *filters: Filter, allowed_hierarchy: Tuple[int, int] = (0, MAX_INT)
-) -> Union[FlattedDict, tuple[FlattedDict, ...]]:
-    """
-    Similar to :func:`split` but only returns the :class:`NestedDict`'s indicated by the filters.
-
-    Parameters
-    ----------
-    node : Node
-        The node to get states from.
-    *filters
-        Filters to apply to the states.
-    allowed_hierarchy : tuple[int, int], optional
-        The allowed hierarchy levels, by default (0, MAX_INT).
-
-    Returns
-    -------
-    FlattedDict or tuple[FlattedDict, ...]
-        The filtered states.
-
-    """
+    node, *filters: Filter, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
+) -> FlattedDict | tuple[FlattedDict, ...]:
+    """Return all State objects from a graph node, optionally filtered."""
     num_filters = len(filters)
     if num_filters == 0:
         filters = (..., ...)
@@ -1225,52 +737,12 @@ def states(
 
 
 @set_module_as('brainstate.graph')
-def treefy_states(
-    node, *filters,
-):
-    """
-    Similar to :func:`split` but only returns the :class:`NestedDict`'s indicated by the filters.
-
-    Parameters
-    ----------
-    node : Node
-        A graph node object.
-    *filters
-        One or more :class:`State` objects to filter by.
-
-    Returns
-    -------
-    NestedDict or tuple of NestedDict
-        One or more :class:`NestedDict` mappings.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> class Model(brainstate.nn.Module):
-        ...     def __init__(self):
-        ...         super().__init__()
-        ...         self.l1 = brainstate.nn.Linear(2, 3)
-        ...         self.l2 = brainstate.nn.Linear(3, 4)
-        ...     def __call__(self, x):
-        ...         return self.l2(self.l1(x))
-
-        >>> model = Model()
-        >>> # Get the learnable parameters
-        >>> params = brainstate.graph.treefy_states(model, brainstate.ParamState)
-        >>> # Get them separately
-        >>> params, others = brainstate.graph.treefy_states(
-        ...     model, brainstate.ParamState, brainstate.ShortTermState
-        ... )
-        >>> # Get all states together
-        >>> states = brainstate.graph.treefy_states(model)
-    """
+def treefy_states(node, *filters) -> NestedDict | tuple[NestedDict, ...]:
+    """Return the treefy state mapping of a graph node, optionally filtered."""
     _, state_mapping = flatten(node)
     if len(filters) == 0:
         return state_mapping
-    else:
-        return state_mapping.filter(*filters)
+    return state_mapping.filter(*filters)
 
 
 def _graph_update_dynamic(node: Any, state: Mapping) -> None:
@@ -1280,36 +752,33 @@ def _graph_update_dynamic(node: Any, state: Mapping) -> None:
     node_impl = _get_node_impl(node)
     node_dict = node_impl.node_dict(node)
     for key, value in state.items():
-        # case 1: new state is being added
         if key not in node_dict:
             if isinstance(node_impl, PyTreeNodeImpl):
-                raise ValueError(f'Cannot set key {key!r} on immutable node of '
-                                 f'type {type(node).__name__}')
+                raise ValueError(
+                    f'Cannot set key {key!r} on immutable node of type {type(node).__name__}'
+                )
             if isinstance(value, State):
-                # TODO: here maybe error? we should check if the state already belongs to another node?
-                value = value.to_state_ref()  # Convert to state reference for proper state management
+                value = value.to_state_ref()
             node_impl.set_key(node, key, value)
             continue
 
-        # check values are of the same type
         current_value = node_dict[key]
 
-        # case 2: subgraph is being updated
         if _is_node(current_value):
             if _is_state_leaf(value):
                 raise ValueError(f'Expected a subgraph for {key!r}, but got: {value!r}')
             _graph_update_dynamic(current_value, value)
         elif isinstance(value, TreefyState):
-            # case 3: state leaf is being updated
             if not isinstance(current_value, State):
-                raise ValueError(f'Trying to update a non-State attribute {key!r} with a State: '
-                                 f'{value!r}')
+                raise ValueError(
+                    f'Trying to update a non-State attribute {key!r} with a State: {value!r}'
+                )
             current_value.update_from_ref(value)
         elif _is_state_leaf(value):
-            # case 4: state field is being updated
             if isinstance(node_impl, PyTreeNodeImpl):
-                raise ValueError(f'Cannot set key {key!r} on immutable node of '
-                                 f'type {type(node).__name__}')
+                raise ValueError(
+                    f'Cannot set key {key!r} on immutable node of type {type(node).__name__}'
+                )
             node_impl.set_key(node, key, value)
         else:
             raise ValueError(f'Unsupported update type: {type(value)} for key {key!r}')
@@ -1317,23 +786,11 @@ def _graph_update_dynamic(node: Any, state: Mapping) -> None:
 
 def update_states(
     node: Any,
-    state_dict: Union[NestedDict, FlattedDict],
+    state_dict: NestedDict | FlattedDict,
     /,
-    *state_dicts: Union[NestedDict, FlattedDict]
+    *state_dicts: NestedDict | FlattedDict,
 ) -> None:
-    """
-    Update the given graph node with a new :class:`NestedMapping` in-place.
-
-    Parameters
-    ----------
-    node : Node
-        A graph node to update.
-    state_dict : NestedDict | FlattedDict
-        A :class:`NestedMapping` object.
-    *state_dicts : NestedDict | FlattedDict
-        Additional :class:`NestedMapping` objects.
-
-    """
+    """Update the graph node in-place with the given state dict(s)."""
     if state_dicts:
         state_dict = NestedDict.merge(state_dict, *state_dicts)
     _graph_update_dynamic(node, state_dict.to_dict())
@@ -1341,243 +798,85 @@ def update_states(
 
 @set_module_as('brainstate.graph')
 def graphdef(node: Any) -> GraphDef[Any]:
-    """
-    Get the :class:`GraphDef` of the given graph node.
-
-    Parameters
-    ----------
-    node : Any
-        A graph node object.
-
-    Returns
-    -------
-    GraphDef[Any]
-        The :class:`GraphDef` of the :class:`Module` object.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-
-        >>> model = brainstate.nn.Linear(2, 3)
-        >>> graphdef, _ = brainstate.graph.treefy_split(model)
-        >>> assert graphdef == brainstate.graph.graphdef(model)
-
-    """
-    graphdef, _ = flatten(node)
-    return graphdef
+    """Return the GraphDef of the given graph node."""
+    gdef, _ = flatten(node)
+    return gdef
 
 
 @set_module_as('brainstate.graph')
 def clone(node: A) -> A:
-    """
-    Create a deep copy of the given graph node.
-
-    Parameters
-    ----------
-    node : Node
-        A graph node object.
-
-    Returns
-    -------
-    Node
-        A deep copy of the :class:`Module` object.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> model = brainstate.nn.Linear(2, 3)
-        >>> cloned_model = brainstate.graph.clone(model)
-        >>> model.weight.value['bias'] += 1
-        >>> assert (model.weight.value['bias'] != cloned_model.weight.value['bias']).all()
-
-    """
-    graphdef, state = treefy_split(node)
-    return treefy_merge(graphdef, state)
+    """Create a deep copy of the given graph node."""
+    gdef, state = treefy_split(node)
+    return treefy_merge(gdef, state)
 
 
 @set_module_as('brainstate.graph')
 def iter_leaf(
-    node: Any, allowed_hierarchy: Tuple[int, int] = (0, MAX_INT)
+    node: Any, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
 ) -> Iterator[tuple[PathParts, Any]]:
-    """
-    Iterates over all nested leaves in the given graph node, including the current node.
+    """Iterate over all leaf values in the graph node (non-node values).
 
-    ``iter_graph`` creates a generator that yields path and value pairs, where
-    the path is a tuple of strings or integers representing the path to the value from the
-    root. Repeated nodes are visited only once. Leaves include static values.
-
-    Parameters
-    ----------
-    node : Any
-        The node to iterate over.
-    allowed_hierarchy : tuple[int, int], optional
-        The allowed hierarchy levels, by default (0, MAX_INT).
-
-    Yields
-    ------
-    Iterator[tuple[PathParts, Any]]
-        Path and value pairs.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> import jax.numpy as jnp
-
-        >>> class Linear(brainstate.nn.Module):
-        ...     def __init__(self, din, dout):
-        ...         super().__init__()
-        ...         self.weight = brainstate.ParamState(brainstate.random.randn(din, dout))
-        ...         self.bias = brainstate.ParamState(brainstate.random.randn(dout))
-        ...         self.a = 1
-        ...
-        >>> module = Linear(3, 4)
-        ...
-        >>> for path, value in brainstate.graph.iter_leaf([module, module]):
-        ...     print(path, type(value).__name__)
-        ...
-        (0, 'a') int
-        (0, 'bias') ParamState
-        (0, 'weight') ParamState
-
+    Repeated nodes are visited only once. Yields (path, value) pairs.
     """
 
-    def _iter_graph_leaf(
-        node_: Any,
-        visited_: set[int],
-        path_parts_: PathParts,
-        level_: int,
-    ) -> Iterator[tuple[PathParts, Any]]:
+    def _iter(node_: Any, visited_: set[int], path_: PathParts, level_: int):
         if level_ > allowed_hierarchy[1]:
             return
-
         if _is_node(node_):
             if id(node_) in visited_:
                 return
             visited_.add(id(node_))
             node_dict = _get_node_impl(node_).node_dict(node_)
             for key, value in node_dict.items():
-                yield from _iter_graph_leaf(
-                    value,
-                    visited_,
-                    (*path_parts_, key),
-                    level_ + 1 if _is_graph_node(value) else level_
+                yield from _iter(
+                    value, visited_, (*path_, key),
+                    level_ + 1 if _is_graph_node(value) else level_,
                 )
         else:
             if level_ >= allowed_hierarchy[0]:
-                yield path_parts_, node_
+                yield path_, node_
 
-    visited: set[int] = set()
-    path_parts: PathParts = ()
-    level: int = 0
-    yield from _iter_graph_leaf(node, visited, path_parts, level)
+    yield from _iter(node, set(), (), 0)
 
 
 @set_module_as('brainstate.graph')
 def iter_node(
-    node: Any, allowed_hierarchy: Tuple[int, int] = (0, MAX_INT)
-) -> Iterator[Tuple[PathParts, Any]]:
-    """
-    Iterates over all nested nodes of the given graph node, including the current node.
+    node: Any, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
+) -> Iterator[tuple[PathParts, Any]]:
+    """Iterate over all graph nodes within the given node.
 
-    ``iter_graph`` creates a generator that yields path and value pairs, where
-    the path is a tuple of strings or integers representing the path to the value from the
-    root. Repeated nodes are visited only once. Leaves include static values.
-
-    Parameters
-    ----------
-    node : Any
-        The node to iterate over.
-    allowed_hierarchy : tuple[int, int], optional
-        The allowed hierarchy levels, by default (0, MAX_INT).
-
-    Yields
-    ------
-    Iterator[tuple[PathParts, Any]]
-        Path and node pairs.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> import jax.numpy as jnp
-
-        >>> class Model(brainstate.nn.Module):
-        ...     def __init__(self):
-        ...         super().__init__()
-        ...         self.a = brainstate.nn.Linear(1, 2)
-        ...         self.b = brainstate.nn.Linear(2, 3)
-        ...         self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
-        ...         self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
-        ...         self.b.a = brainpy.state.LIF(2)
-        ...
-        >>> model = Model()
-        ...
-        >>> for path, node in brainstate.graph.iter_node([model, model]):
-        ...     print(path, node.__class__.__name__)
-        ...
-        (0, 'a') Linear
-        (0, 'b', 'a') LIF
-        (0, 'b') Linear
-        (0, 'c', 0) Linear
-        (0, 'c', 1) Linear
-        (0, 'd', 'x') Linear
-        (0, 'd', 'y') Linear
-        (0,) Model
-
+    Repeated nodes are visited only once. Yields (path, node) pairs.
     """
 
-    def _iter_graph_node(
-        node_: Any,
-        visited_: set[int],
-        path_parts_: PathParts,
-        level_: int,
-    ) -> Iterator[tuple[PathParts, Any]]:
+    def _iter(node_: Any, visited_: set[int], path_: PathParts, level_: int):
         if level_ > allowed_hierarchy[1]:
             return
-
         if _is_node(node_):
             if id(node_) in visited_:
                 return
-
             visited_.add(id(node_))
             node_dict = _get_node_impl(node_).node_dict(node_)
             for key, value in node_dict.items():
-                yield from _iter_graph_node(value, visited_, (*path_parts_, key),
-                                            level_ + 1 if _is_graph_node(value) else level_)
-
+                yield from _iter(
+                    value, visited_, (*path_, key),
+                    level_ + 1 if _is_graph_node(value) else level_,
+                )
             if _is_graph_node(node_) and level_ >= allowed_hierarchy[0]:
-                yield path_parts_, node_
+                yield path_, node_
 
-    visited: set[int] = set()
-    path_parts: PathParts = ()
-    level: int = 0
-    yield from _iter_graph_node(node, visited, path_parts, level)
+    yield from _iter(node, set(), (), 0)
 
 
 # --------------------------------------------------------
-# Graph operations: end
+# Static wrapper and Pytree support
 # --------------------------------------------------------
 
 
 @dataclasses.dataclass(frozen=True)
 class Static(Generic[A]):
-    """
-    An empty pytree node that treats its inner value as static.
+    """An empty pytree node that treats its inner value as static.
 
     ``value`` must define ``__eq__`` and ``__hash__``.
-
-    Attributes
-    ----------
-    value : A
-        The static value to wrap.
-
     """
 
     value: A
@@ -1586,10 +885,6 @@ class Static(Generic[A]):
 jax.tree_util.register_static(Static)
 
 
-# ---------------------------------------------------------
-# Pytree
-# ---------------------------------------------------------
-
 class PytreeType:
     ...
 
@@ -1597,9 +892,7 @@ class PytreeType:
 def _key_path_to_key(key: Any) -> Key:
     if isinstance(key, jax.tree_util.SequenceKey):
         return key.idx
-    elif isinstance(
-        key, (jax.tree_util.DictKey, jax.tree_util.FlattenedIndexKey)
-    ):
+    elif isinstance(key, (jax.tree_util.DictKey, jax.tree_util.FlattenedIndexKey)):
         if not isinstance(key.key, Key):
             raise ValueError(
                 f'Invalid key: {key.key}. May be due to its type not being hashable or comparable.'
@@ -1607,11 +900,10 @@ def _key_path_to_key(key: Any) -> Key:
         return key.key
     elif isinstance(key, jax.tree_util.GetAttrKey):
         return key.name
-    else:
-        return str(key)
+    return str(key)
 
 
-def _flatten_pytree(pytree: Any) -> Tuple[Tuple[Tuple, ...], jax.tree_util.PyTreeDef]:
+def _flatten_pytree(pytree: Any) -> tuple[tuple[tuple, ...], jax.tree_util.PyTreeDef]:
     leaves, treedef = jax.tree_util.tree_flatten_with_path(pytree, is_leaf=lambda x: x is not pytree)
     nodes = tuple((_key_path_to_key(path[0]), value) for path, value in leaves)
     return nodes, treedef
@@ -1619,10 +911,9 @@ def _flatten_pytree(pytree: Any) -> Tuple[Tuple[Tuple, ...], jax.tree_util.PyTre
 
 def _unflatten_pytree(
     nodes: tuple[tuple, ...],
-    treedef: jax.tree_util.PyTreeDef
+    treedef: jax.tree_util.PyTreeDef,
 ) -> Any:
-    pytree = treedef.unflatten(value for _, value in nodes)
-    return pytree
+    return treedef.unflatten(value for _, value in nodes)
 
 
 PYTREE_NODE_IMPL = PyTreeNodeImpl(type=PytreeType, flatten=_flatten_pytree, unflatten=_unflatten_pytree)

--- a/brainstate/graph/_operation.py
+++ b/brainstate/graph/_operation.py
@@ -641,7 +641,7 @@ def _split_state(
 
 
 @set_module_as('brainstate.graph')
-def treefy_split(node: A, *filters: Filter):
+def treefy_split(node: A, *filters):
     """Split a graph node into a GraphDef and one or more state NestedDicts.
 
     If no filters are given, returns (graphdef, state).
@@ -694,7 +694,7 @@ def _split_flatted(
 
 @set_module_as('brainstate.graph')
 def nodes(
-    node, *filters: Filter, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
+    node, *filters, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
 ) -> FlattedDict | tuple[FlattedDict, ...]:
     """Return all graph nodes, optionally filtered and limited by hierarchy depth."""
     num_filters = len(filters)
@@ -719,7 +719,7 @@ def _states_generator(node, allowed_hierarchy) -> Iterable[tuple[PathParts, Stat
 
 @set_module_as('brainstate.graph')
 def states(
-    node, *filters: Filter, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
+    node, *filters, allowed_hierarchy: tuple[int, int] = (0, MAX_INT)
 ) -> FlattedDict | tuple[FlattedDict, ...]:
     """Return all State objects from a graph node, optionally filtered."""
     num_filters = len(filters)

--- a/brainstate/graph/_operation_test.py
+++ b/brainstate/graph/_operation_test.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+
+from __future__ import annotations
 
 import unittest
 from collections.abc import Callable
@@ -19,72 +20,16 @@ from threading import Thread
 
 import jax
 import jax.numpy as jnp
+import pytest
 from absl.testing import absltest, parameterized
 
-import pytest
-pytest.skip("skipping tests", allow_module_level=True)
-
 import brainstate
-import braintools
-import brainpy
+import brainstate.util
 
 
-class TestIter(unittest.TestCase):
-    def test1(self):
-        class Model(brainstate.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.a = brainstate.nn.Linear(1, 2)
-                self.b = brainstate.nn.Linear(2, 3)
-                self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
-                self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
-                self.b.a = brainpy.LIF(2)
-
-        for path, node in brainstate.graph.iter_leaf(Model()):
-            print(path, node)
-        for path, node in brainstate.graph.iter_node(Model()):
-            print(path, node)
-        for path, node in brainstate.graph.iter_node(Model(), allowed_hierarchy=(1, 1)):
-            print(path, node)
-        for path, node in brainstate.graph.iter_node(Model(), allowed_hierarchy=(2, 2)):
-            print(path, node)
-
-    def test_iter_leaf_v1(self):
-        class Linear(brainstate.nn.Module):
-            def __init__(self, din, dout):
-                super().__init__()
-                self.weight = brainstate.ParamState(brainstate.random.randn(din, dout))
-                self.bias = brainstate.ParamState(brainstate.random.randn(dout))
-                self.a = 1
-
-        module = Linear(3, 4)
-        graph = [module, module]
-
-        num = 0
-        for path, value in brainstate.graph.iter_leaf(graph):
-            print(path, type(value).__name__)
-            num += 1
-
-        assert num == 3
-
-    def test_iter_node_v1(self):
-        class Model(brainstate.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.a = brainstate.nn.Linear(1, 2)
-                self.b = brainstate.nn.Linear(2, 3)
-                self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
-                self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
-                self.b.a = brainpy.LIF(2)
-
-        model = Model()
-
-        num = 0
-        for path, node in brainstate.graph.iter_node([model, model]):
-            print(path, node.__class__.__name__)
-            num += 1
-        assert num == 8
-
+# ---------------------------------------------------------------------------
+# Module-level helpers used across test classes
+# ---------------------------------------------------------------------------
 
 class List(brainstate.nn.Module):
     def __init__(self, items):
@@ -124,6 +69,88 @@ class StatefulLinear(brainstate.nn.Module):
         self.count.value += 1
         return x @ self.w.value + self.b.value
 
+
+# ---------------------------------------------------------------------------
+# Iteration tests
+# ---------------------------------------------------------------------------
+
+class TestIter(unittest.TestCase):
+    def test_iter_leaf_v1(self):
+        class Linear(brainstate.nn.Module):
+            def __init__(self, din, dout):
+                super().__init__()
+                self.weight = brainstate.ParamState(brainstate.random.randn(din, dout))
+                self.bias = brainstate.ParamState(brainstate.random.randn(dout))
+                self.a = 1
+
+        module = Linear(3, 4)
+        graph = [module, module]
+
+        num = 0
+        for path, value in brainstate.graph.iter_leaf(graph):
+            num += 1
+        assert num == 3
+
+    def test_iter_leaf_nested_modules(self):
+        class SubModule(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((2,)))
+
+        class Model(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = brainstate.nn.Linear(1, 2)
+                self.b = brainstate.nn.Linear(2, 3)
+                self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
+                self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
+                self.b.sub = SubModule()
+
+        model = Model()
+        for path, leaf in brainstate.graph.iter_leaf(model):
+            assert path is not None
+        for path, node in brainstate.graph.iter_node(model):
+            assert path is not None
+
+    def test_iter_node_hierarchy(self):
+        class Model(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = brainstate.nn.Linear(1, 2)
+                self.b = brainstate.nn.Linear(2, 3)
+
+        model = Model()
+        nodes_all = list(brainstate.graph.iter_node(model))
+        nodes_level1 = list(brainstate.graph.iter_node(model, allowed_hierarchy=(1, 1)))
+        assert len(nodes_level1) <= len(nodes_all)
+
+    def test_iter_node_count(self):
+        class SubModule(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((2,)))
+
+        class Model(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = brainstate.nn.Linear(1, 2)
+                self.b = brainstate.nn.Linear(2, 3)
+                self.c = [brainstate.nn.Linear(3, 4), brainstate.nn.Linear(4, 5)]
+                self.d = {'x': brainstate.nn.Linear(5, 6), 'y': brainstate.nn.Linear(6, 7)}
+                self.b.sub = SubModule()
+
+        model = Model()
+        # iter_node on [model, model] should visit each node only once
+        num = 0
+        for path, node in brainstate.graph.iter_node([model, model]):
+            num += 1
+        # Model itself + a, b, b.sub, c[0], c[1], d[x], d[y] = 8
+        assert num == 8
+
+
+# ---------------------------------------------------------------------------
+# Core graph utility tests
+# ---------------------------------------------------------------------------
 
 class TestGraphUtils(absltest.TestCase):
     def test_flatten_treey_state(self):
@@ -207,8 +234,6 @@ class TestGraphUtils(absltest.TestCase):
                 super().__init__()
                 self.bar = brainstate.nn.Linear(2, 2)
                 self.baz = brainstate.nn.Linear(2, 2)
-
-                # tie the weights
                 self.baz.weight = self.bar.weight
 
         node = Foo()
@@ -220,9 +245,11 @@ class TestGraphUtils(absltest.TestCase):
 
         assert node2.bar.weight is node2.baz.weight
 
-    def test_tied_weights_example(self):
+    def test_tied_weights_example_with_braintools(self):
+        braintools = pytest.importorskip('braintools')
+
         class LinearTranspose(brainstate.nn.Module):
-            def __init__(self, dout: int, din: int, ) -> None:
+            def __init__(self, dout: int, din: int) -> None:
                 super().__init__()
                 self.kernel = brainstate.ParamState(braintools.init.LecunNormal()((dout, din)))
 
@@ -230,12 +257,10 @@ class TestGraphUtils(absltest.TestCase):
                 return x @ self.kernel.value.T
 
         class Encoder(brainstate.nn.Module):
-            def __init__(self, ) -> None:
+            def __init__(self) -> None:
                 super().__init__()
                 self.embed = brainstate.nn.Embedding(10, 2)
                 self.linear_out = LinearTranspose(10, 2)
-
-                # tie the weights
                 self.linear_out.kernel = self.embed.weight
 
             def __call__(self, x):
@@ -249,7 +274,6 @@ class TestGraphUtils(absltest.TestCase):
 
         x = jax.random.randint(jax.random.key(0), (2,), 0, 10)
         y = model(x)
-
         assert y.shape == (2, 10)
 
     def test_state_variables_not_shared_with_graph(self):
@@ -329,35 +353,12 @@ class TestGraphUtils(absltest.TestCase):
         assert m2.tree is not m.tree
 
 
-class SimpleModule(brainstate.nn.Module):
-    pass
-
-
-class SimplePyTreeModule(brainstate.nn.Module):
-    pass
-
-
-class TestThreading(parameterized.TestCase):
-
-    @parameterized.parameters(
-        (SimpleModule,),
-        (SimplePyTreeModule,),
-    )
-    def test_threading(self, module_fn: Callable[[], brainstate.nn.Module]):
-        x = module_fn()
-
-        class MyThread(Thread):
-
-            def run(self) -> None:
-                brainstate.graph.treefy_split(x)
-
-        thread = MyThread()
-        thread.start()
-        thread.join()
-
+# ---------------------------------------------------------------------------
+# Graph operation tests
+# ---------------------------------------------------------------------------
 
 class TestGraphOperation(unittest.TestCase):
-    def test1(self):
+    def test_flatten_basic(self):
         class MyNode(brainstate.graph.Node):
             def __init__(self):
                 self.a = brainstate.nn.Linear(2, 3)
@@ -366,9 +367,7 @@ class TestGraphOperation(unittest.TestCase):
                 self.d = {'x': brainstate.nn.Linear(1, 3), 'y': brainstate.nn.Linear(1, 4)}
 
         graphdef, statetree = brainstate.graph.flatten(MyNode())
-        # print(graphdef)
-        print(statetree)
-        # print(brainstate.graph.unflatten(graphdef, statetree))
+        assert statetree is not None
 
     def test_split(self):
         class Foo(brainstate.graph.Node):
@@ -379,10 +378,8 @@ class TestGraphOperation(unittest.TestCase):
         node = Foo()
         graphdef, params, others = brainstate.graph.treefy_split(node, brainstate.ParamState, ...)
 
-        print(params)
-        print(jax.tree.map(jnp.shape, params))
-
-        print(jax.tree.map(jnp.shape, others))
+        assert params is not None
+        assert others is not None
 
     def test_merge(self):
         class Foo(brainstate.graph.Node):
@@ -392,7 +389,6 @@ class TestGraphOperation(unittest.TestCase):
 
         node = Foo()
         graphdef, params, others = brainstate.graph.treefy_split(node, brainstate.ParamState, ...)
-
         new_node = brainstate.graph.treefy_merge(graphdef, params, others)
 
         assert isinstance(new_node, Foo)
@@ -423,18 +419,18 @@ class TestGraphOperation(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.a = brainstate.nn.Linear(2, 3)
-                self.b = brainpy.LIF([10, 2])
 
         model = Model()
+        # Add a dynamically tagged state inside a catch_new_states context
         with brainstate.catch_new_states('new'):
-            brainstate.nn.init_all_states(model)
-        # print(model.states())
-        self.assertTrue(len(model.states()) == 2)
-        model_states = brainstate.graph.pop_states(model, 'new')
-        print(model_states)
-        self.assertTrue(len(model.states()) == 1)
-        assert not hasattr(model.b, 'V')
-        # print(model.states())
+            model.dynamic = brainstate.ShortTermState(jnp.zeros(5))
+
+        before_count = len(model.states())
+        self.assertGreater(before_count, 0)
+
+        popped = brainstate.graph.pop_states(model, 'new')
+        self.assertEqual(len(model.states()), before_count - 1)
+        self.assertFalse(hasattr(model, 'dynamic'))
 
     def test_treefy_split(self):
         class MLP(brainstate.graph.Node):
@@ -444,58 +440,49 @@ class TestGraphOperation(unittest.TestCase):
                 self.output = brainstate.nn.Linear(dmid, dout)
 
             def __call__(self, x):
-                x = brainstate.functional.relu(self.input(x))
+                x = jax.nn.relu(self.input(x))
                 for layer in self.layers:
-                    x = brainstate.functional.relu(layer(x))
+                    x = jax.nn.relu(layer(x))
                 return self.output(x)
 
         model = MLP(2, 1, 3)
         graph_def, treefy_states = brainstate.graph.treefy_split(model)
-
-        print(graph_def)
-        print(treefy_states)
-
-        # states = brainstate.graph.states(model)
-        # print(states)
-        # nest_states = states.to_nest()
-        # print(nest_states)
+        assert graph_def is not None
+        assert treefy_states is not None
 
     def test_states(self):
         class MLP(brainstate.graph.Node):
             def __init__(self, din: int, dmid: int, dout: int, n_layer: int = 3):
                 self.input = brainstate.nn.Linear(din, dmid)
                 self.layers = [brainstate.nn.Linear(dmid, dmid) for _ in range(n_layer)]
-                self.output = brainpy.LIF(dout)
+                self.output = brainstate.nn.Linear(dmid, dout)
 
             def __call__(self, x):
-                x = brainstate.functional.relu(self.input(x))
+                x = jax.nn.relu(self.input(x))
                 for layer in self.layers:
-                    x = brainstate.functional.relu(layer(x))
+                    x = jax.nn.relu(layer(x))
                 return self.output(x)
 
-        model = brainstate.nn.init_all_states(MLP(2, 1, 3))
-        states = brainstate.graph.states(model)
-        print(states)
-        nest_states = states.to_nest()
-        print(nest_states)
+        model = MLP(2, 1, 3)
+        all_states = brainstate.graph.states(model)
+        assert all_states is not None
 
-        params, others = brainstate.graph.states(model, brainstate.ParamState, brainstate.ShortTermState)
-        print(params)
-        print(others)
+        params, others = brainstate.graph.states(model, brainstate.ParamState, ...)
+        assert params is not None
+        assert others is not None
 
+
+# ---------------------------------------------------------------------------
+# RefMap tests
+# ---------------------------------------------------------------------------
 
 class TestRefMap(unittest.TestCase):
-    """Test RefMap class functionality."""
-
     def test_refmap_basic_operations(self):
-        """Test basic RefMap operations."""
         ref_map = brainstate.graph.RefMap()
 
-        # Test empty RefMap
         self.assertEqual(len(ref_map), 0)
         self.assertFalse(object() in ref_map)
 
-        # Test adding items
         obj1 = object()
         obj2 = object()
         ref_map[obj1] = 'value1'
@@ -507,40 +494,32 @@ class TestRefMap(unittest.TestCase):
         self.assertEqual(ref_map[obj1], 'value1')
         self.assertEqual(ref_map[obj2], 'value2')
 
-        # Test iteration
         keys = list(ref_map)
         self.assertIn(obj1, keys)
         self.assertIn(obj2, keys)
 
-        # Test deletion
         del ref_map[obj1]
         self.assertEqual(len(ref_map), 1)
         self.assertFalse(obj1 in ref_map)
         self.assertTrue(obj2 in ref_map)
 
     def test_refmap_initialization_with_mapping(self):
-        """Test RefMap initialization with a mapping."""
         obj1, obj2 = object(), object()
-        mapping = {obj1: 'value1', obj2: 'value2'}
-        ref_map = brainstate.graph.RefMap(mapping)
+        ref_map = brainstate.graph.RefMap({obj1: 'value1', obj2: 'value2'})
 
         self.assertEqual(len(ref_map), 2)
         self.assertEqual(ref_map[obj1], 'value1')
         self.assertEqual(ref_map[obj2], 'value2')
 
     def test_refmap_initialization_with_iterable(self):
-        """Test RefMap initialization with an iterable."""
         obj1, obj2 = object(), object()
-        pairs = [(obj1, 'value1'), (obj2, 'value2')]
-        ref_map = brainstate.graph.RefMap(pairs)
+        ref_map = brainstate.graph.RefMap([(obj1, 'value1'), (obj2, 'value2')])
 
         self.assertEqual(len(ref_map), 2)
         self.assertEqual(ref_map[obj1], 'value1')
         self.assertEqual(ref_map[obj2], 'value2')
 
-    def test_refmap_same_object_different_instances(self):
-        """Test RefMap handles same content objects with different ids."""
-        # Create two lists with same content but different ids
+    def test_refmap_same_content_different_identity(self):
         list1 = [1, 2, 3]
         list2 = [1, 2, 3]
 
@@ -548,245 +527,183 @@ class TestRefMap(unittest.TestCase):
         ref_map[list1] = 'list1'
         ref_map[list2] = 'list2'
 
-        # Should have 2 entries since they have different ids
         self.assertEqual(len(ref_map), 2)
         self.assertEqual(ref_map[list1], 'list1')
         self.assertEqual(ref_map[list2], 'list2')
 
     def test_refmap_update(self):
-        """Test RefMap update method."""
         obj1, obj2, obj3 = object(), object(), object()
         ref_map = brainstate.graph.RefMap()
         ref_map[obj1] = 'value1'
 
-        # Update with mapping
         ref_map.update({obj2: 'value2', obj3: 'value3'})
         self.assertEqual(len(ref_map), 3)
 
-        # Update existing key
         ref_map[obj1] = 'new_value1'
         self.assertEqual(ref_map[obj1], 'new_value1')
 
     def test_refmap_str_repr(self):
-        """Test RefMap string representation."""
         ref_map = brainstate.graph.RefMap()
         obj = object()
         ref_map[obj] = 'value'
 
         str_repr = str(ref_map)
         self.assertIsInstance(str_repr, str)
-        # Check that __str__ calls __repr__
         self.assertEqual(str_repr, repr(ref_map))
 
 
-class TestHelperFunctions(unittest.TestCase):
-    """Test helper functions in the _operation module."""
+# ---------------------------------------------------------------------------
+# Internal helper function tests
+# ---------------------------------------------------------------------------
 
+class TestHelperFunctions(unittest.TestCase):
     def test_is_state_leaf(self):
-        """Test _is_state_leaf function."""
         from brainstate.graph._operation import _is_state_leaf
 
-        # Create TreefyState instance
         state = brainstate.ParamState(1)
         treefy_state = state.to_state_ref()
 
         self.assertTrue(_is_state_leaf(treefy_state))
         self.assertFalse(_is_state_leaf(state))
         self.assertFalse(_is_state_leaf(1))
-        self.assertFalse(_is_state_leaf("string"))
         self.assertFalse(_is_state_leaf(None))
 
     def test_is_node_leaf(self):
-        """Test _is_node_leaf function."""
         from brainstate.graph._operation import _is_node_leaf
 
         state = brainstate.ParamState(1)
 
         self.assertTrue(_is_node_leaf(state))
         self.assertFalse(_is_node_leaf(1))
-        self.assertFalse(_is_node_leaf("string"))
         self.assertFalse(_is_node_leaf(None))
 
     def test_is_node(self):
-        """Test _is_node function."""
         from brainstate.graph._operation import _is_node
 
-        # Test with graph nodes
         node = brainstate.nn.Module()
         self.assertTrue(_is_node(node))
-
-        # Test with pytree nodes
         self.assertTrue(_is_node([1, 2, 3]))
         self.assertTrue(_is_node({'a': 1}))
-
-        # Test with non-nodes
         self.assertFalse(_is_node(1))
         self.assertFalse(_is_node("string"))
 
     def test_is_pytree_node(self):
-        """Test _is_pytree_node function."""
         from brainstate.graph._operation import _is_pytree_node
 
         self.assertTrue(_is_pytree_node([1, 2, 3]))
         self.assertTrue(_is_pytree_node({'a': 1}))
         self.assertTrue(_is_pytree_node((1, 2)))
-
         self.assertFalse(_is_pytree_node(1))
         self.assertFalse(_is_pytree_node("string"))
         self.assertFalse(_is_pytree_node(jnp.array([1, 2])))
 
     def test_is_graph_node(self):
-        """Test _is_graph_node function."""
         from brainstate.graph._operation import _is_graph_node
 
-        # Register a custom type for testing
         class CustomNode:
             pass
 
-        # Graph nodes are those registered with register_graph_node_type
         node = brainstate.nn.Module()
         self.assertTrue(_is_graph_node(node))
-
-        # Non-registered types
         self.assertFalse(_is_graph_node([1, 2, 3]))
         self.assertFalse(_is_graph_node({'a': 1}))
         self.assertFalse(_is_graph_node(CustomNode()))
 
 
-class TestRegisterGraphNodeType(unittest.TestCase):
-    """Test register_graph_node_type functionality."""
+# ---------------------------------------------------------------------------
+# register_graph_node_type tests
+# ---------------------------------------------------------------------------
 
+class TestRegisterGraphNodeType(unittest.TestCase):
     def test_register_custom_node_type(self):
-        """Test registering a custom graph node type."""
         from brainstate.graph._operation import _is_graph_node, _get_node_impl
 
         class CustomNode:
             def __init__(self):
                 self.data = {}
 
-        def flatten_custom(node):
-            return list(node.data.items()), None
-
-        def set_key_custom(node, key, value):
-            node.data[key] = value
-
-        def pop_key_custom(node, key):
-            return node.data.pop(key)
-
-        def create_empty_custom(metadata):
-            return CustomNode()
-
-        def clear_custom(node):
-            node.data.clear()
-
-        # Register the custom node type
         brainstate.graph.register_graph_node_type(
             CustomNode,
-            flatten_custom,
-            set_key_custom,
-            pop_key_custom,
-            create_empty_custom,
-            clear_custom
+            flatten=lambda node: (list(node.data.items()), None),
+            set_key=lambda node, key, value: node.data.__setitem__(key, value),
+            pop_key=lambda node, key: node.data.pop(key),
+            create_empty=lambda metadata: CustomNode(),
+            clear=lambda node: node.data.clear(),
         )
 
-        # Test that the node is recognized
         node = CustomNode()
         self.assertTrue(_is_graph_node(node))
 
-        # Test node operations
         node.data['key1'] = 'value1'
         node_impl = _get_node_impl(node)
 
-        # Test flatten
         items, metadata = node_impl.flatten(node)
         self.assertEqual(list(items), [('key1', 'value1')])
 
-        # Test set_key
         node_impl.set_key(node, 'key2', 'value2')
         self.assertEqual(node.data['key2'], 'value2')
 
-        # Test pop_key
         value = node_impl.pop_key(node, 'key1')
         self.assertEqual(value, 'value1')
         self.assertNotIn('key1', node.data)
 
-        # Test create_empty
         new_node = node_impl.create_empty(None)
         self.assertIsInstance(new_node, CustomNode)
-        self.assertEqual(new_node.data, {})
 
-        # Test clear
         node_impl.clear(node)
         self.assertEqual(node.data, {})
 
 
-class TestHashableMapping(unittest.TestCase):
-    """Test HashableMapping class."""
+# ---------------------------------------------------------------------------
+# HashableMapping tests
+# ---------------------------------------------------------------------------
 
+class TestHashableMapping(unittest.TestCase):
     def test_hashable_mapping_basic(self):
-        """Test basic HashableMapping operations."""
         from brainstate.graph._operation import HashableMapping
 
-        mapping = {'a': 1, 'b': 2}
-        hm = HashableMapping(mapping)
+        hm = HashableMapping({'a': 1, 'b': 2})
 
-        # Test basic operations
         self.assertEqual(len(hm), 2)
         self.assertTrue('a' in hm)
         self.assertFalse('c' in hm)
         self.assertEqual(hm['a'], 1)
-        self.assertEqual(hm['b'], 2)
-
-        # Test iteration
-        keys = list(hm)
-        self.assertEqual(set(keys), {'a', 'b'})
+        self.assertEqual(set(hm), {'a', 'b'})
 
     def test_hashable_mapping_hash(self):
-        """Test HashableMapping hashing."""
         from brainstate.graph._operation import HashableMapping
 
         hm1 = HashableMapping({'a': 1, 'b': 2})
         hm2 = HashableMapping({'a': 1, 'b': 2})
         hm3 = HashableMapping({'a': 1, 'b': 3})
 
-        # Equal mappings should have same hash
         self.assertEqual(hash(hm1), hash(hm2))
         self.assertEqual(hm1, hm2)
-
-        # Different mappings should not be equal
         self.assertNotEqual(hm1, hm3)
-
-        # Can be used in sets
-        s = {hm1, hm2, hm3}
-        self.assertEqual(len(s), 2)  # hm1 and hm2 are the same
+        self.assertEqual(len({hm1, hm2, hm3}), 2)
 
     def test_hashable_mapping_from_iterable(self):
-        """Test HashableMapping creation from iterable."""
         from brainstate.graph._operation import HashableMapping
 
-        pairs = [('a', 1), ('b', 2)]
-        hm = HashableMapping(pairs)
+        hm = HashableMapping([('a', 1), ('b', 2)])
 
         self.assertEqual(len(hm), 2)
         self.assertEqual(hm['a'], 1)
         self.assertEqual(hm['b'], 2)
 
 
-class TestNodeDefAndNodeRef(unittest.TestCase):
-    """Test NodeDef and NodeRef classes."""
+# ---------------------------------------------------------------------------
+# NodeDef / NodeRef tests
+# ---------------------------------------------------------------------------
 
+class TestNodeDefAndNodeRef(unittest.TestCase):
     def test_noderef_creation(self):
-        """Test NodeRef creation and attributes."""
-        node_ref = brainstate.graph.NodeRef(
-            type=brainstate.nn.Module,
-            index=42
-        )
+        node_ref = brainstate.graph.NodeRef(type=brainstate.nn.Module, index=42)
 
         self.assertEqual(node_ref.type, brainstate.nn.Module)
         self.assertEqual(node_ref.index, 42)
 
     def test_nodedef_creation(self):
-        """Test NodeDef creation and attributes."""
         from brainstate.graph._operation import HashableMapping
 
         nodedef = brainstate.graph.NodeDef.create(
@@ -797,7 +714,7 @@ class TestNodeDefAndNodeRef(unittest.TestCase):
             static_fields=[('static', 'value')],
             leaves=[],
             metadata=None,
-            index_mapping=None
+            index_mapping=None,
         )
 
         self.assertEqual(nodedef.type, brainstate.nn.Module)
@@ -810,7 +727,6 @@ class TestNodeDefAndNodeRef(unittest.TestCase):
         self.assertIsNone(nodedef.index_mapping)
 
     def test_nodedef_with_index_mapping(self):
-        """Test NodeDef with index_mapping."""
         nodedef = brainstate.graph.NodeDef.create(
             type=brainstate.nn.Module,
             index=1,
@@ -819,7 +735,7 @@ class TestNodeDefAndNodeRef(unittest.TestCase):
             static_fields=[],
             leaves=[],
             metadata=None,
-            index_mapping={1: 2, 3: 4}
+            index_mapping={1: 2, 3: 4},
         )
 
         self.assertIsNotNone(nodedef.index_mapping)
@@ -827,67 +743,55 @@ class TestNodeDefAndNodeRef(unittest.TestCase):
         self.assertEqual(nodedef.index_mapping[3], 4)
 
 
+# ---------------------------------------------------------------------------
+# graphdef / clone tests
+# ---------------------------------------------------------------------------
+
 class TestGraphDefAndClone(unittest.TestCase):
-    """Test graphdef and clone functions."""
-
     def test_graphdef_function(self):
-        """Test graphdef function returns correct GraphDef."""
         model = brainstate.nn.Linear(2, 3)
-        graphdef = brainstate.graph.graphdef(model)
+        gdef = brainstate.graph.graphdef(model)
 
-        self.assertIsInstance(graphdef, brainstate.graph.NodeDef)
-        self.assertEqual(graphdef.type, brainstate.nn.Linear)
+        self.assertIsInstance(gdef, brainstate.graph.NodeDef)
+        self.assertEqual(gdef.type, brainstate.nn.Linear)
 
-        # Compare with flatten result
-        graphdef2, _ = brainstate.graph.flatten(model)
-        self.assertEqual(graphdef, graphdef2)
+        gdef2, _ = brainstate.graph.flatten(model)
+        self.assertEqual(gdef, gdef2)
 
     def test_clone_function(self):
-        """Test clone creates a deep copy."""
         model = brainstate.nn.Linear(2, 3)
         cloned = brainstate.graph.clone(model)
 
-        # Check types
         self.assertIsInstance(cloned, brainstate.nn.Linear)
         self.assertIsNot(model, cloned)
-
-        # Check that states are not shared
         self.assertIsNot(model.weight, cloned.weight)
 
-        # Modify original and check clone is unaffected
         original_weight = cloned.weight.value['weight'].copy()
         model.weight.value = jax.tree.map(lambda x: x + 1, model.weight.value)
-
-        # Clone should be unchanged
         self.assertTrue(jnp.allclose(cloned.weight.value['weight'], original_weight))
 
-    def test_clone_with_shared_variables(self):
-        """Test cloning preserves shared variable structure."""
-
+    def test_clone_preserves_shared_variables(self):
         class SharedModel(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.shared_weight = brainstate.ParamState(jnp.ones((2, 2)))
                 self.layer1 = brainstate.nn.Linear(2, 2)
                 self.layer2 = brainstate.nn.Linear(2, 2)
-                # Share weights
                 self.layer2.weight = self.layer1.weight
 
         model = SharedModel()
         cloned = brainstate.graph.clone(model)
 
-        # Check that sharing is preserved
         self.assertIs(cloned.layer1.weight, cloned.layer2.weight)
-        # But not shared with original
         self.assertIsNot(cloned.layer1.weight, model.layer1.weight)
 
 
+# ---------------------------------------------------------------------------
+# nodes() function tests
+# ---------------------------------------------------------------------------
+
 class TestNodesFunction(unittest.TestCase):
-    """Test nodes function for filtering graph nodes."""
-
     def test_nodes_without_filters(self):
-        """Test nodes function without filters."""
-
         class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -897,18 +801,13 @@ class TestNodesFunction(unittest.TestCase):
         model = Model()
         all_nodes = brainstate.graph.nodes(model)
 
-        # Should return all nodes as FlattedDict
         self.assertIsInstance(all_nodes, brainstate.util.FlattedDict)
-
-        # Check that nodes are present
         paths = [path for path, _ in all_nodes.items()]
         self.assertIn(('a',), paths)
         self.assertIn(('b',), paths)
-        self.assertIn((), paths)  # The model itself
+        self.assertIn((), paths)
 
     def test_nodes_with_filter(self):
-        """Test nodes function with a single filter."""
-
         class CustomModule(brainstate.nn.Module):
             pass
 
@@ -919,22 +818,17 @@ class TestNodesFunction(unittest.TestCase):
                 self.custom = CustomModule()
 
         model = Model()
-
-        # Filter for Linear modules
         linear_nodes = brainstate.graph.nodes(
             model,
-            lambda path, node: isinstance(node, brainstate.nn.Linear)
+            lambda path, node: isinstance(node, brainstate.nn.Linear),
         )
 
         self.assertIsInstance(linear_nodes, brainstate.util.FlattedDict)
-        # Should only contain the Linear module
         nodes_list = list(linear_nodes.values())
         self.assertEqual(len(nodes_list), 1)
         self.assertIsInstance(nodes_list[0], brainstate.nn.Linear)
 
     def test_nodes_with_hierarchy(self):
-        """Test nodes function with hierarchy limits."""
-
         class Model(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -942,21 +836,19 @@ class TestNodesFunction(unittest.TestCase):
                 self.layer1.sublayer = brainstate.nn.Linear(3, 3)
 
         model = Model()
-
-        # Get only level 1 nodes
         level1_nodes = brainstate.graph.nodes(model, allowed_hierarchy=(1, 1))
         paths = [path for path, _ in level1_nodes.items()]
 
         self.assertIn(('layer1',), paths)
-        # Sublayer should not be included at level 1
         self.assertNotIn(('layer1', 'sublayer'), paths)
 
 
-class TestStatic(unittest.TestCase):
-    """Test Static class functionality."""
+# ---------------------------------------------------------------------------
+# Static tests
+# ---------------------------------------------------------------------------
 
+class TestStatic(unittest.TestCase):
     def test_static_basic(self):
-        """Test basic Static wrapper."""
         from brainstate.graph._operation import Static
 
         value = {'key': 'value'}
@@ -966,120 +858,95 @@ class TestStatic(unittest.TestCase):
         self.assertIs(static.value, value)
 
     def test_static_is_pytree_leaf(self):
-        """Test that Static is treated as a pytree leaf."""
         from brainstate.graph._operation import Static
 
         static = Static({'key': 'value'})
+        leaves, _ = jax.tree_util.tree_flatten(static)
+        self.assertEqual(len(leaves), 0)
 
-        # Should be treated as a leaf in pytree operations
-        leaves, treedef = jax.tree_util.tree_flatten(static)
-        self.assertEqual(len(leaves), 0)  # Static has no leaves
-
-        # Test in a structure
         tree = {'a': 1, 'b': static, 'c': [2, 3]}
-        leaves, treedef = jax.tree_util.tree_flatten(tree)
-
-        # static should not be in leaves since it's registered as static
+        leaves, _ = jax.tree_util.tree_flatten(tree)
         self.assertNotIn(static, leaves)
 
     def test_static_equality_and_hash(self):
-        """Test Static equality and hashing."""
         from brainstate.graph._operation import Static
 
         static1 = Static(42)
         static2 = Static(42)
         static3 = Static(43)
 
-        # Dataclass frozen=True provides equality
         self.assertEqual(static1, static2)
         self.assertNotEqual(static1, static3)
-
-        # Can be hashed due to frozen=True
         self.assertEqual(hash(static1), hash(static2))
         self.assertNotEqual(hash(static1), hash(static3))
 
 
-class TestErrorHandling(unittest.TestCase):
-    """Test error handling and edge cases."""
+# ---------------------------------------------------------------------------
+# Error handling tests
+# ---------------------------------------------------------------------------
 
+class TestErrorHandling(unittest.TestCase):
     def test_flatten_with_invalid_ref_index(self):
-        """Test flatten with invalid ref_index."""
         model = brainstate.nn.Linear(2, 3)
 
-        # Should raise assertion error with non-RefMap
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             brainstate.graph.flatten(model, ref_index={})
 
     def test_unflatten_with_invalid_graphdef(self):
-        """Test unflatten with invalid graphdef."""
         state = brainstate.util.NestedDict({})
 
-        # Should raise assertion error with non-GraphDef
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             brainstate.graph.unflatten("not_a_graphdef", state)
 
     def test_pop_states_without_filters(self):
-        """Test pop_states raises error without filters."""
         model = brainstate.nn.Linear(2, 3)
 
         with self.assertRaises(ValueError) as context:
             brainstate.graph.pop_states(model)
-
         self.assertIn('Expected at least one filter', str(context.exception))
 
     def test_update_states_immutable_node(self):
-        """Test update_states on immutable pytree node."""
-        # Create a pytree node (tuple is immutable)
         node = (1, 2, brainstate.ParamState(3))
         state = brainstate.util.NestedDict({0: brainstate.TreefyState(int, 10)})
 
-        # Should raise ValueError when trying to update immutable node
         with self.assertRaises(ValueError):
             brainstate.graph.update_states(node, state)
 
     def test_get_node_impl_with_state(self):
-        """Test _get_node_impl raises error for State objects."""
         from brainstate.graph._operation import _get_node_impl
 
         state = brainstate.ParamState(1)
 
         with self.assertRaises(ValueError) as context:
             _get_node_impl(state)
-
         self.assertIn('State is not a node', str(context.exception))
 
     def test_split_with_non_exhaustive_filters(self):
-        """Test split with non-exhaustive filters."""
         from brainstate.graph._operation import _split_flatted
 
         flatted = [(('a',), 1), (('b',), 2)]
-        filters = (lambda path, value: value == 1,)  # Only matches first item
+        filters = (lambda path, value: value == 1,)
 
-        # Should raise ValueError for non-exhaustive filters
         with self.assertRaises(ValueError) as context:
             _split_flatted(flatted, filters)
-
         self.assertIn('Non-exhaustive filters', str(context.exception))
 
     def test_invalid_filter_order(self):
-        """Test filters with ... not at the end."""
         from brainstate.graph._operation import _filters_to_predicates
 
-        # ... must be the last filter
         filters = (..., lambda p, v: True)
 
         with self.assertRaises(ValueError) as context:
             _filters_to_predicates(filters)
-
         self.assertIn('can only be used as the last filters', str(context.exception))
 
 
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
 class TestIntegration(unittest.TestCase):
-    """Integration tests for complex scenarios."""
-
     def test_complex_graph_operations(self):
-        """Test complex graph with multiple levels and shared references."""
-
         class SubModule(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1091,56 +958,66 @@ class TestIntegration(unittest.TestCase):
                 self.shared = SubModule()
                 self.layer1 = brainstate.nn.Linear(2, 3)
                 self.layer2 = brainstate.nn.Linear(3, 4)
-                self.layer2.shared_ref = self.shared  # Create a reference
+                self.layer2.shared_ref = self.shared
                 self.nested = {
                     'a': brainstate.nn.Linear(4, 5),
-                    'b': [brainstate.nn.Linear(5, 6), self.shared]  # Another reference
+                    'b': [brainstate.nn.Linear(5, 6), self.shared],
                 }
 
         model = ComplexModel()
-
-        # Test flatten/unflatten preserves structure
         graphdef, state = brainstate.graph.treefy_split(model)
         reconstructed = brainstate.graph.treefy_merge(graphdef, state)
 
-        # Check shared references are preserved
         self.assertIs(reconstructed.shared, reconstructed.layer2.shared_ref)
         self.assertIs(reconstructed.shared, reconstructed.nested['b'][1])
 
-        # Test state updates
         new_state = jax.tree.map(lambda x: x * 2, state)
         brainstate.graph.update_states(model, new_state)
 
-        # Verify updates applied
         self.assertTrue(jnp.allclose(
             model.shared.weight.value,
-            jnp.ones((2, 2)) * 2
+            jnp.ones((2, 2)) * 2,
         ))
 
     def test_recursive_structure(self):
-        """Test handling of recursive/circular references."""
-
         class RecursiveModule(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.weight = brainstate.ParamState(1)
                 self.child = None
 
-        # Create circular reference
         parent = RecursiveModule()
         child = RecursiveModule()
         parent.child = child
-        child.child = parent  # Circular reference
+        child.child = parent
 
-        # Should handle circular references without infinite recursion
         graphdef, state = brainstate.graph.treefy_split(parent)
-
-        # Should be able to reconstruct
         reconstructed = brainstate.graph.treefy_merge(graphdef, state)
 
-        # Check structure is preserved
         self.assertIsNotNone(reconstructed.child)
         self.assertIs(reconstructed.child.child, reconstructed)
+
+
+# ---------------------------------------------------------------------------
+# Threading tests
+# ---------------------------------------------------------------------------
+
+class SimpleModule(brainstate.nn.Module):
+    pass
+
+
+class TestThreading(parameterized.TestCase):
+    @parameterized.parameters((SimpleModule,),)
+    def test_threading(self, module_fn: Callable[[], brainstate.nn.Module]):
+        x = module_fn()
+
+        class MyThread(Thread):
+            def run(self) -> None:
+                brainstate.graph.treefy_split(x)
+
+        thread = MyThread()
+        thread.start()
+        thread.join()
 
 
 if __name__ == '__main__':

--- a/brainstate/transform/_error_if.py
+++ b/brainstate/transform/_error_if.py
@@ -28,7 +28,7 @@ __all__ = [
 
 
 def _err_jit_true_branch(err_fun, args, kwargs):
-    jax.debug.callback(err_fun, *args, **kwargs)
+    jax.debug.callback(err_fun, *args, **kwargs, ordered=True)
 
 
 def _err_jit_false_branch(args, kwargs):

--- a/brainstate/transform/_ir_visualize.py
+++ b/brainstate/transform/_ir_visualize.py
@@ -20,7 +20,9 @@ from typing import Tuple, Union, List
 
 import jax
 
-from brainstate._compatible_import import Var
+from brainstate._compatible_import import (
+    Var, ClosedJaxpr, Jaxpr, JaxprEqn, Literal, DropVar
+)
 
 pydot_is_installed = importlib.util.find_spec("pydot") is not None
 
@@ -167,7 +169,7 @@ if pydot_is_installed:
 
 
     def draw_dot_graph(
-        fn: jax.core.ClosedJaxpr, collapse_primitives: bool, show_avals: bool
+        fn: ClosedJaxpr, collapse_primitives: bool, show_avals: bool
     ) -> pydot.Graph:
         """
         Generate a pydot representation of an XLA graph
@@ -201,7 +203,7 @@ if pydot_is_installed:
 
 
     def get_conditional(
-        conditional: jax.core.Jaxpr,
+        conditional: Jaxpr,
         parent_id: str,
         n: int,
         collapse_primitives: bool,
@@ -212,7 +214,7 @@ if pydot_is_installed:
 
         Parameters
         ----------
-        conditional: jax.core.Jaxpr
+        conditional: Jaxpr
             Jaxpr of the conditional function
         parent_id: str
             ID of the parent subgraph of the conditional node
@@ -262,7 +264,7 @@ if pydot_is_installed:
 
         cond_var = conditional.invars[0]
         cond_var_id = f"{parent_id}_{cond_var}"
-        if isinstance(cond_var, jax.core.Literal):
+        if isinstance(cond_var, Literal):
             new_nodes.append(
                 get_arg_node(cond_var_id, cond_var, show_avals, True)
             )
@@ -270,7 +272,7 @@ if pydot_is_installed:
 
         for arg in conditional.invars[1:]:
             arg_id = f"{cond_graph_id}_{arg}"
-            is_literal = isinstance(arg, jax.core.Literal)
+            is_literal = isinstance(arg, Literal)
             cond_arguments.add_node(
                 get_arg_node(arg_id, arg, show_avals, is_literal)
             )
@@ -328,7 +330,7 @@ if pydot_is_installed:
                         eqn.params["name"] if "name" in eqn.params else eqn.primitive.name
                     )
                     no_literal_inputs = any(
-                        [isinstance(a, jax.core.Literal) for a in branch.jaxpr.invars]
+                        [isinstance(a, Literal) for a in branch.jaxpr.invars]
                     )
                     collapse_branch = no_literal_inputs or collapse_primitives
                     if collapse_branch:
@@ -442,7 +444,7 @@ if pydot_is_installed:
 
 
     def _get_node(
-        eqn: jax.core.JaxprEqn,
+        eqn: JaxprEqn,
         graph_id: str,
         show_avals: bool,
         n: int,
@@ -454,7 +456,7 @@ if pydot_is_installed:
 
         Parameters
         ----------
-        eqn: jax.core.JaxprEqn
+        eqn: JaxprEqn
             JaxprEqn of the function
         graph_id: str
             Id of the computation graph containing this node
@@ -499,7 +501,7 @@ if pydot_is_installed:
         out_edges = list()
 
         for var in eqn.invars:
-            if isinstance(var, jax.core.Literal):
+            if isinstance(var, Literal):
                 new_nodes.append(
                     get_arg_node(f"{graph_id}_{var}", var, show_avals, True)
                 )
@@ -514,7 +516,7 @@ if pydot_is_installed:
 
 
     def expand_non_primitive(
-        eqn: jax.core.JaxprEqn,
+        eqn: JaxprEqn,
         parent_id: str,
         n: int,
         collapse_primitives: bool,
@@ -525,7 +527,7 @@ if pydot_is_installed:
 
         Parameters
         ----------
-        eqn: jax.core.JaxprEqn
+        eqn: JaxprEqn
             JaxprEqn of the function
         parent_id: str
             ID of the parent graph to this eqn
@@ -611,7 +613,7 @@ if pydot_is_installed:
 
 
     def expand_pjit_primitive(
-        jaxpr: jax.core.Jaxpr,
+        jaxpr: Jaxpr,
         parent_id: str,
         n: int,
         collapse_primitives: bool,
@@ -623,7 +625,7 @@ if pydot_is_installed:
 
         Parameters
         ----------
-        jaxpr: jax.core.Jaxpr
+        jaxpr: Jaxpr
             JaxprEqn of the function
         parent_id: str
             ID of the parent graph to this eqn
@@ -708,7 +710,7 @@ if pydot_is_installed:
 
 
     def get_scan(
-        eqn: jax.core.JaxprEqn,
+        eqn: JaxprEqn,
         parent_id: str,
         n: int,
         collapse_primitives: bool,
@@ -810,7 +812,7 @@ if pydot_is_installed:
 
 
     def get_while_branch(
-        jaxpr: jax.core.Jaxpr,
+        jaxpr: Jaxpr,
         parent_id: str,
         parent_args: List[Var],
         parent_outvars: List[Var],
@@ -838,12 +840,12 @@ if pydot_is_installed:
                 # TODO: What does the underscore mean?
                 if str(var)[-1] == "_":
                     continue
-                is_literal = isinstance(var, jax.core.Literal)
+                is_literal = isinstance(var, Literal)
                 if not is_literal:
                     arg_edges.append(pydot.Edge(f"{parent_id}_{p_var}", graph_id))
 
             for (var, p_var) in zip(jaxpr.outvars, parent_outvars):
-                if isinstance(var, jax.core.DropVar):
+                if isinstance(var, DropVar):
                     continue
                 out_edges.append(pydot.Edge(graph_id, f"{parent_id}_{p_var}"))
 
@@ -895,7 +897,7 @@ if pydot_is_installed:
 
 
     def get_while(
-        eqn: jax.core.JaxprEqn,
+        eqn: JaxprEqn,
         parent_id: str,
         n: int,
         collapse_primitives: bool,
@@ -916,7 +918,7 @@ if pydot_is_installed:
 
         for var in eqn.invars:
             arg_id = f"{while_graph_id}_{var}"
-            is_literal = isinstance(var, jax.core.Literal)
+            is_literal = isinstance(var, Literal)
             while_graph.add_node(
                 get_arg_node(arg_id, var, show_avals, is_literal)
             )
@@ -963,14 +965,14 @@ if pydot_is_installed:
         for var in eqn.outvars:
             arg_id = f"{while_graph_id}_{var}"
             while_graph.add_node(get_out_node(arg_id, var, show_avals))
-            if not isinstance(var, jax.core.DropVar):
+            if not isinstance(var, DropVar):
                 out_edges.append(pydot.Edge(arg_id, f"{parent_id}_{var}"))
 
         return while_graph, arg_edges, [], out_edges, n
 
 
     def get_sub_graph(
-        eqn: jax.core.JaxprEqn,
+        eqn: JaxprEqn,
         parent_id: str,
         n: int,
         collapse_primitives: bool,
@@ -985,7 +987,7 @@ if pydot_is_installed:
 
         Parameters
         ----------
-        eqn: jax.core.JaxprEqn
+        eqn: JaxprEqn
             JaxprEqn of the function
         parent_id: str
             ID of the
@@ -1073,7 +1075,7 @@ if pydot_is_installed:
 
     def get_arg_node(
         arg_id: str,
-        var: Union[Var, jax.core.Literal],
+        var: Union[Var, Literal],
         show_avals: bool,
         is_literal: bool,
     ) -> pydot.Node:
@@ -1106,7 +1108,7 @@ if pydot_is_installed:
 
     def get_const_node(
         arg_id: str,
-        var: Union[Var, jax.core.Literal],
+        var: Union[Var, Literal],
         show_avals: bool,
     ) -> pydot.Node:
         """
@@ -1251,7 +1253,7 @@ if pydot_is_installed:
             if str(var)[-1] == "_":
                 continue
             arg_id = f"{graph_id}_{var}"
-            is_literal = isinstance(var, jax.core.Literal)
+            is_literal = isinstance(var, Literal)
             argument_nodes.add_node(get_arg_node(arg_id, var, show_avals, is_literal))
             if not is_literal:
                 argument_edges.append(pydot.Edge(f"{parent_id}_{p_var}", arg_id))
@@ -1316,8 +1318,8 @@ if pydot_is_installed:
                 continue
             arg_id = f"{graph_id}_{var}"
 
-            var_is_literal = isinstance(var, jax.core.Literal)
-            parent_is_literal = isinstance(p_var, jax.core.Literal)
+            var_is_literal = isinstance(var, Literal)
+            parent_is_literal = isinstance(p_var, Literal)
             is_literal = var_is_literal or parent_is_literal
 
             if parent_is_literal:
@@ -1499,7 +1501,7 @@ if pydot_is_installed:
 
 
     def get_node_label(
-        v: Union[Var, jax.core.Literal],
+        v: Union[Var, Literal],
         show_avals: bool
     ) -> str:
         """
@@ -1523,7 +1525,7 @@ if pydot_is_installed:
             return str(v)
 
 
-    def is_not_primitive(x: jax.core.JaxprEqn) -> bool:
+    def is_not_primitive(x: JaxprEqn) -> bool:
         """
         Test if a JaxprEqn is a primitive.
 
@@ -1539,7 +1541,7 @@ if pydot_is_installed:
         return x.primitive.name == "pjit"
 
 
-    def contains_non_primitives(eqns: List[jax.core.JaxprEqn]) -> bool:
+    def contains_non_primitives(eqns: List[JaxprEqn]) -> bool:
         """
         Check it the sub-functions of a JaxPR contains only JAX primitives
 

--- a/brainstate/transform/_jit.py
+++ b/brainstate/transform/_jit.py
@@ -15,7 +15,7 @@
 
 import functools
 from collections.abc import Iterable, Sequence
-from typing import (Any, Callable, Union)
+from typing import Callable, Union
 
 import jax
 from jax._src import sharding_impls

--- a/brainstate/transform/_loop_collect_return.py
+++ b/brainstate/transform/_loop_collect_return.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, TypeVar, Tuple, Any
 import jax
 import jax.numpy as jnp
 
+from brainstate._compatible_import import get_aval
 from brainstate._utils import set_module_as
 from ._make_jaxpr import StatefulFunction
 from ._progress_bar import ProgressBar
@@ -242,7 +243,7 @@ def scan(
 
     # evaluate jaxpr, get all states #
     # ------------------------------ #
-    xs_avals = [jax.core.get_aval(x) for x in xs_flat]
+    xs_avals = [get_aval(x) for x in xs_flat]
     x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
     args = [init, xs_tree.unflatten(x_avals)]
     stateful_fun = StatefulFunction(f, name='scan').make_jaxpr(*args)
@@ -381,7 +382,7 @@ def checkpointed_scan(
         pbar_runner = None
 
     # evaluate jaxpr
-    xs_avals = [jax.core.get_aval(x) for x in xs_flat]
+    xs_avals = [get_aval(x) for x in xs_flat]
     x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
     args = (init, xs_tree.unflatten(x_avals))
     stateful_fun = StatefulFunction(f, name='checkpoint_scan').make_jaxpr(*args)

--- a/brainstate/transform/_loop_collect_return.py
+++ b/brainstate/transform/_loop_collect_return.py
@@ -20,7 +20,7 @@ from typing import Callable, Optional, TypeVar, Tuple, Any
 import jax
 import jax.numpy as jnp
 
-from brainstate._compatible_import import get_aval
+from brainstate._compatible_import import get_aval, mapped_aval
 from brainstate._utils import set_module_as
 from ._make_jaxpr import StatefulFunction
 from ._progress_bar import ProgressBar
@@ -244,7 +244,7 @@ def scan(
     # evaluate jaxpr, get all states #
     # ------------------------------ #
     xs_avals = [get_aval(x) for x in xs_flat]
-    x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
+    x_avals = [mapped_aval(length, 0, aval) for aval in xs_avals]
     args = [init, xs_tree.unflatten(x_avals)]
     stateful_fun = StatefulFunction(f, name='scan').make_jaxpr(*args)
     state_trace = stateful_fun.get_state_trace(*args)
@@ -383,7 +383,7 @@ def checkpointed_scan(
 
     # evaluate jaxpr
     xs_avals = [get_aval(x) for x in xs_flat]
-    x_avals = [jax.core.mapped_aval(length, 0, aval) for aval in xs_avals]
+    x_avals = [mapped_aval(length, 0, aval) for aval in xs_avals]
     args = (init, xs_tree.unflatten(x_avals))
     stateful_fun = StatefulFunction(f, name='checkpoint_scan').make_jaxpr(*args)
     state_trace = stateful_fun.get_state_trace(*args)

--- a/brainstate/transform/_make_jaxpr.py
+++ b/brainstate/transform/_make_jaxpr.py
@@ -834,7 +834,7 @@ class StatefulFunction(PrettyObject):
                 dyn_args = tuple(args[i] for i in range(len(args)) if i not in self.static_argnums)
 
                 # jaxpr
-                if jax.__version_info__ >= (0, 8, 2):
+                if jax.__version_info__ >= (0, 8, 0):
                     jaxpr, (out_shapes, state_shapes) = jax.make_jaxpr(
                         functools.partial(
                             self._wrapped_fun_to_eval,

--- a/brainstate/transform/_make_jaxpr.py
+++ b/brainstate/transform/_make_jaxpr.py
@@ -52,29 +52,23 @@ function.
 """
 
 import functools
-import inspect
 import operator
 import threading
 from collections.abc import Hashable, Iterable, Sequence
-from contextlib import ExitStack
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 from jax._src import source_info_util
 from jax.api_util import shaped_abstractify
-from jax.extend.linear_util import transformation_with_aux
 from jax.interpreters import partial_eval as pe
 
-from brainstate._compatible_import import (
-    ClosedJaxpr, extend_axis_env_nd, safe_map, safe_zip, unzip2, wraps, wrap_init,
-)
+from brainstate._compatible_import import ClosedJaxpr, safe_map, wraps
 from brainstate._state import State, StateTraceStack
 from brainstate._utils import set_module_as
 from brainstate.typing import PyTree
 from brainstate.util import PrettyObject
 from brainstate.util._cache import BoundedCache
-from ._ir_optim import optimize_jaxpr
 
 __all__ = [
     "StatefulFunction",
@@ -834,29 +828,16 @@ class StatefulFunction(PrettyObject):
                 dyn_args = tuple(args[i] for i in range(len(args)) if i not in self.static_argnums)
 
                 # jaxpr
-                if jax.__version_info__ >= (0, 8, 0):
-                    jaxpr, (out_shapes, state_shapes) = jax.make_jaxpr(
-                        functools.partial(
-                            self._wrapped_fun_to_eval,
-                            cache_key,
-                            static_kwargs,
-                        ),
-                        static_argnums=self.static_argnums,
-                        axis_env=self.axis_env,
-                        return_shape=True,
-                    )(*args, **dyn_kwargs)
-                else:
-                    jaxpr, (out_shapes, state_shapes) = _make_jaxpr(
-                        functools.partial(
-                            self._wrapped_fun_to_eval,
-                            cache_key,
-                            static_kwargs,
-                        ),
-                        static_argnums=self.static_argnums,
-                        axis_env=self.axis_env,
-                        return_shape=True,
-                        ir_optimizations=self.ir_optimizations,
-                    )(*args, **dyn_kwargs)
+                jaxpr, (out_shapes, state_shapes) = jax.make_jaxpr(
+                    functools.partial(
+                        self._wrapped_fun_to_eval,
+                        cache_key,
+                        static_kwargs,
+                    ),
+                    static_argnums=self.static_argnums,
+                    axis_env=self.axis_env,
+                    return_shape=True,
+                )(*args, **dyn_kwargs)
 
                 self._cached_jaxpr_out_tree.set(cache_key, jax.tree.structure((out_shapes, state_shapes)))
                 self._cached_out_shapes.set(cache_key, (out_shapes, state_shapes))
@@ -1205,147 +1186,6 @@ def make_jaxpr(
             )
 
     # wrapped jaxpr builder function
-    make_jaxpr_f.__module__ = "brainstate.transform"
-    if hasattr(fun, "__qualname__"):
-        make_jaxpr_f.__qualname__ = f"make_jaxpr({fun.__qualname__})"
-    if hasattr(fun, "__name__"):
-        make_jaxpr_f.__name__ = f"make_jaxpr({fun.__name__})"
-    return make_jaxpr_f
-
-
-def _check_callable(fun):
-    # In Python 3.10+, the only thing stopping us from supporting static methods
-    # is that we can't take weak references to them, which the C++ JIT requires.
-    if isinstance(fun, staticmethod):
-        raise TypeError(f"staticmethod arguments are not supported, got {fun}")
-    if not callable(fun):
-        raise TypeError(f"Expected a callable value, got {fun}")
-    if inspect.isgeneratorfunction(fun):
-        raise TypeError(f"Expected a function, got a generator function: {fun}")
-
-
-@transformation_with_aux
-def _flatten_fun(in_tree, *args_flat):
-    py_args, py_kwargs = jax.tree.unflatten(in_tree, args_flat)
-    ans = yield py_args, py_kwargs
-    yield jax.tree.flatten(ans)
-
-
-def _make_jaxpr(
-    fun: Callable,
-    static_argnums: int | Iterable[int] = (),
-    axis_env: Sequence[tuple[AxisName, int]] | None = None,
-    return_shape: bool = False,
-    ir_optimizations: Union[str, Sequence[str]] = None,
-) -> Callable[..., (ClosedJaxpr | tuple[ClosedJaxpr, Any])]:
-    """
-    Create a function that produces its jaxpr given example args (internal implementation).
-
-    This is an internal implementation function. Users should use the public
-    ``make_jaxpr`` function instead.
-
-    Parameters
-    ----------
-    fun : Callable
-        The function whose ``jaxpr`` is to be computed. Its positional
-        arguments and return value should be arrays, scalars, or standard Python
-        containers (tuple/list/dict) thereof.
-    static_argnums : int or iterable of int, optional
-        See the :py:func:`jax.jit` docstring.
-    axis_env : sequence of tuple, optional
-        A sequence of pairs where the first element is an axis
-        name and the second element is a positive integer representing the size of
-        the mapped axis with that name. This parameter is useful when lowering
-        functions that involve parallel communication collectives, and it
-        specifies the axis name/size environment that would be set up by
-        applications of :py:func:`jax.pmap`.
-    return_shape : bool, default False
-        If ``True``, the wrapped function returns a pair where the first element
-        is the ``ClosedJaxpr`` representation of ``fun`` and the second element
-        is a pytree with the same structure as the output of ``fun`` and where
-        the leaves are objects with ``shape``, ``dtype``, and ``named_shape``
-        attributes representing the corresponding types of the output leaves.
-    ir_optimizations: str or sequence of str, optional
-        A string or sequence of strings specifying IR optimizations to apply
-        during jaxpr tracing. If None, no optimizations are applied.
-
-    Returns
-    -------
-    Callable
-        A wrapped version of ``fun`` that when applied to example arguments returns
-        a ``ClosedJaxpr`` representation of ``fun`` on those arguments. If the
-        argument ``return_shape`` is ``True``, then the returned function instead
-        returns a pair where the first element is the ``ClosedJaxpr``
-        representation of ``fun`` and the second element is a pytree representing
-        the structure, shape, dtypes, and named shapes of the output of ``fun``.
-
-    Notes
-    -----
-    A ``jaxpr`` is JAX's intermediate representation for program traces. The
-    ``jaxpr`` language is based on the simply-typed first-order lambda calculus
-    with let-bindings. This function adapts a function to return its
-    ``jaxpr``, which we can inspect to understand what JAX is doing internally.
-    The ``jaxpr`` returned is a trace of ``fun`` abstracted to
-    :py:class:`ShapedArray` level. Other levels of abstraction exist internally.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import jax
-        >>>
-        >>> def f(x): return jax.numpy.sin(jax.numpy.cos(x))
-        >>> print(f(3.0))
-        -0.83602
-        >>> _make_jaxpr(f)(3.0)
-        { lambda ; a:f32[]. let b:f32[] = cos a; c:f32[] = sin b in (c,) }
-        >>> _make_jaxpr(jax.grad(f))(3.0)
-        { lambda ; a:f32[]. let
-            b:f32[] = cos a
-            c:f32[] = sin a
-            _:f32[] = sin b
-            d:f32[] = cos b
-            e:f32[] = mul 1.0 d
-            f:f32[] = neg e
-            g:f32[] = mul f c
-          in (g,) }
-    """
-    from jax._src.traceback_util import api_boundary
-    from jax._src.linear_util import annotate
-
-    _check_callable(fun)
-    static_argnums = _ensure_index_tuple(static_argnums)
-
-    def _abstractify(args, kwargs):
-        flat_args, in_tree = jax.tree.flatten((args, kwargs))
-        return map(shaped_abstractify, flat_args), in_tree, [True] * len(flat_args)
-
-    @wraps(fun)
-    @api_boundary
-    def make_jaxpr_f(*args, **kwargs):
-        f = wrap_init(fun, (), {}, 'brainstate.transform.make_jaxpr')
-        if static_argnums:
-            dyn_argnums = [i for i in range(len(args)) if i not in static_argnums]
-            f, args = jax.api_util.argnums_partial(f, dyn_argnums, args)
-        in_avals, in_tree, keep_inputs = _abstractify(args, kwargs)
-        in_type = tuple(safe_zip(in_avals, keep_inputs))
-        f, out_tree = _flatten_fun(f, in_tree)
-        f = annotate(f, in_type)
-        with ExitStack() as stack:
-            if axis_env is not None:
-                stack.enter_context(extend_axis_env_nd(axis_env))
-            jaxpr, out_type, consts = pe.trace_to_jaxpr_dynamic2(f)
-        closed_jaxpr = ClosedJaxpr(jaxpr, consts)
-        if ir_optimizations is not None:
-            closed_jaxpr = closed_jaxpr.replace(
-                jaxpr=optimize_jaxpr(closed_jaxpr.jaxpr, optimizations=ir_optimizations)
-            )
-        if return_shape:
-            out_avals, _ = unzip2(out_type)
-            out_shapes_flat = [jax.ShapeDtypeStruct(a.shape, a.dtype) for a in out_avals]
-            return closed_jaxpr, jax.tree.unflatten(out_tree(), out_shapes_flat)
-        return closed_jaxpr
-
     make_jaxpr_f.__module__ = "brainstate.transform"
     if hasattr(fun, "__qualname__"):
         make_jaxpr_f.__qualname__ = f"make_jaxpr({fun.__qualname__})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ exclude = [
 name = "brainstate"
 description = "A State-based Transformation System for Brain Modeling."
 readme = 'README.md'
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 authors = [{ name = 'BrainState Developers', email = 'chao.brain@qq.com' }]
 classifiers = [
     'Natural Language :: English',
@@ -31,7 +31,6 @@ classifiers = [
     'Intended Audience :: Developers',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,29 +73,29 @@ repository = 'https://github.com/chaobrain/brainstate'
 
 [project.optional-dependencies]
 cpu = [
-    'jax[cpu]',
+    'jax[cpu]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 cuda12 = [
-    'jax[cuda12]',
+    'jax[cuda12]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 cuda13 = [
-    'jax[cuda13]',
+    'jax[cuda13]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 tpu = [
-    'jax[tpu]',
+    'jax[tpu]>=0.6.0',
     'brainunit',
     'brainevent',
 ]
 testing = [
     'absl-py',
     'pytest',
-    'jax',
+    'jax>=0.6.0',
     'brainunit',
     'brainevent',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-jax
+jax>=0.6.0
 jaxlib
 brainunit>=0.1.0
 brainevent


### PR DESCRIPTION
## Summary by Sourcery

Refine the graph operation and transformation infrastructure, modernize typing and JAX version handling, improve error messages and docstrings, and significantly expand and stabilize the associated tests.

Bug Fixes:
- Fix misuse of internal RefMap storage by accessing its items via the public mapping interface when scanning for states.
- Ensure debug callbacks used in error_if are ordered to avoid non‑deterministic behavior.
- Correct filter validation and error paths in graph splitting utilities to provide more precise exceptions.

Enhancements:
- Simplify and clarify graph operation internals with stricter type hints, reduced duplication, and more focused docstrings across graph utilities and node helpers.
- Modernize JAX integration by consolidating make_jaxpr handling, updating compatible imports (including mapped_aval), and refining IR visualization type usage.
- Tighten graph context management for split/merge operations using thread‑local stacks and clearer context helpers, and adjust graph/tree conversion helpers for safer RefMap usage and alias checking.

Build:
- Raise the minimum supported Python version to 3.11 and require JAX >= 0.6.0 across core, extras, and documentation tooling.
- Update ReadTheDocs configuration to build documentation with Python 3.13.

Documentation:
- Streamline and update docstrings throughout graph operations, node helpers, conversion utilities, and compatibility helpers to better explain behavior while removing obsolete or overly verbose sections.

Tests:
- Unskip and substantially rewrite graph operation tests to rely on assertions instead of prints, cover iteration, graph manipulation, helper utilities, threading, and complex aliasing scenarios.
- Adjust compatibility and module‑structure tests to match the updated compatible import surface (e.g., removal of extend_axis_env_nd).