### PR TITLE
Rebuild NaN/Inf debugging on jax.experimental.checkify

### DIFF
--- a/brainstate/transform/_debug.py
+++ b/brainstate/transform/_debug.py
@@ -13,16 +13,58 @@
 # limitations under the License.
 # ==============================================================================
 
-import threading
+"""
+NaN / Inf debugging utilities, built on :mod:`jax.experimental.checkify`.
+
+Why checkify
+------------
+An earlier version of this module re-implemented a jaxpr interpreter that
+replayed every primitive and recursed by hand into ``jit`` / ``cond`` /
+``while`` / ``scan``.  That approach was fragile: it broke on the modern
+``Primitive.get_bind_params`` contract, mishandled ``while`` loop constants,
+and silently failed on higher-order primitives such as ``custom_jvp_call``,
+``custom_vjp_call`` and ``remat`` — exactly the primitives produced by
+gradients, ``vmap`` and neural-network activations.
+
+``checkify`` is a JAX transform, so it composes *natively* with ``grad``,
+``vmap``, ``jit``, ``scan``, ``while_loop``, ``cond`` and custom-derivative
+primitives.  Re-basing the detector on it removes the entire hand-written
+interpreter and the whole class of bugs that came with it.
+
+Two-layer detection
+--------------------
+``checkify`` finds *where* a NaN (or division-by-zero) is produced.  But a
+per-primitive checker also flags NaN that is computed inside a branch / lane
+that is subsequently *masked away* (``jnp.where`` "safe" patterns, a
+``vmap``-ed ``cond`` lowered to ``select_n``).  Those NaN never reach the
+result and should not be reported.
+
+To avoid such false positives we add an **output-contamination gate**: after
+running the function we only surface an error when NaN/Inf actually reaches
+the function's observable outputs (its return value *and* any updated state).
+``checkify`` supplies the source primitive and location; the gate decides
+whether to raise.
+
+Inf localization
+----------------
+``checkify`` localizes NaN and division-by-zero to the producing primitive
+with an IDE-clickable source line.  It does **not** localize other Infs
+(e.g. ``exp`` overflow or ``log(0) == -inf``).  Such Infs are still *detected*
+by the output gate and reported with per-output diagnostics, but without a
+primitive-level source.
+"""
+
+import functools
 import traceback as tb_module
-from typing import Callable, Dict, List
+from typing import Any, Callable, List, Tuple
 
 import jax
 import jax.numpy as jnp
 from jax._src import traceback_util as _traceback_util
+from jax.experimental import checkify
 from jax.extend import source_info_util
 
-from brainstate._compatible_import import DropVar, Literal, ClosedJaxpr, Tracer, is_jit_primitive
+from brainstate._compatible_import import Tracer
 from ._conditions import cond
 from ._make_jaxpr import StatefulFunction
 from ._unvmap import unvmap
@@ -33,494 +75,201 @@ __all__ = [
     'debug_nan_if',
 ]
 
-# ---------------------------------------------------------------------------
-# Thread-local NaN detection store
-#
-# Callbacks must NOT raise inside jax.debug.callback because JAX wraps any
-# exception in JaxRuntimeError("INTERNAL: CpuCallback error …"), burying the
-# user-facing message.  Instead the callback stores (message, raw_source_info)
-# here; _interpret_jaxpr_with_nan_check checks after every run and raises via
-# source_info_util.user_context — the same mechanism used by
-# State.raise_error_with_source_info — so the exception traceback points
-# directly at the user code that introduced NaN.
-# ---------------------------------------------------------------------------
-
-_nan_store = threading.local()
-
-
-def _nan_store_get() -> List[tuple]:
-    """Each entry is (formatted_message: str, raw_source_info | None)."""
-    if not hasattr(_nan_store, 'records'):
-        _nan_store.records = []
-    return _nan_store.records
+# checkify error categories used for detection: NaN generation and
+# division-by-zero (which is the most common source of Inf).
+_FLOAT_CHECKS = checkify.float_checks
 
 
 # ---------------------------------------------------------------------------
-# Source info: IDE-clickable location strings
+# Output-gate helpers: does an array (or list of arrays) carry NaN / Inf?
 # ---------------------------------------------------------------------------
 
-def _extract_user_source(source_info) -> str:
-    """
-    Extract a human-readable, IDE-clickable source location from a jaxpr
-    equation's source_info.
-
-    Uses JAX's ``filter_traceback`` (which respects ``register_exclusion``
-    registrations from brainstate and other libraries) then further strips
-    any remaining ``site-packages`` frames so that only genuine user frames
-    are shown.  Returns the innermost user frame in standard Python traceback
-    format ``File "path", line N, in func_name`` which VSCode / PyCharm
-    recognise as a hyperlink.
-    """
-    if source_info is None:
-        return "<unknown source>"
-    tb = getattr(source_info, 'traceback', None)
-    if tb is None:
-        return "<unknown source>"
-    try:
-        py_tb = tb.as_python_traceback()
-        # Step 1: use JAX's filter which honours register_exclusion
-        # (this removes brainstate + JAX core frames)
-        filtered_tb = _traceback_util.filter_traceback(py_tb)
-        if filtered_tb:
-            lines = tb_module.format_tb(filtered_tb)
-            # Step 2: further strip any remaining site-packages frames
-            # (e.g. jax.numpy helpers not in JAX's exclude list)
-            lines = [l for l in lines if '/site-packages/' not in l and '\\site-packages\\' not in l]
-            if lines:
-                return lines[-1].strip()
-            # Fallback: return the innermost filtered frame
-            if lines:
-                return lines[-1].strip()
-    except Exception:
-        pass
-    # Fallback to JAX's own summarise helper
-    try:
-        return source_info_util.summarize(source_info)
-    except Exception:
-        return "<unknown source>"
+def _is_inexact_array(x) -> bool:
+    """Return True for floating *and* complex arrays (``jnp.inexact``)."""
+    return hasattr(x, 'dtype') and jnp.issubdtype(x.dtype, jnp.inexact)
 
 
-# ---------------------------------------------------------------------------
-# Jaxpr variable formatting (shared helpers)
-# ---------------------------------------------------------------------------
-
-def _build_var_names(jaxpr) -> Dict[int, str]:
-    var_names: Dict[int, str] = {}
-    counter = 0
-    for var in jaxpr.invars:
-        var_names[id(var)] = f"v{counter}"
-        counter += 1
-    for eqn in jaxpr.eqns:
-        for var in eqn.outvars:
-            if not isinstance(var, DropVar):
-                var_names[id(var)] = f"v{counter}"
-                counter += 1
-    return var_names
-
-
-def _format_var(var, var_names: Dict[int, str]) -> str:
-    if isinstance(var, Literal):
-        val = var.val
-        if hasattr(val, 'item') and val.ndim == 0:
-            val = val.item()
-        return str(val)
-    name = var_names.get(id(var))
-    if name is None:
-        return f"const:{var.aval.str_short()}"
-    return f"{name}:{var.aval.str_short()}"
-
-
-def _format_eqn(eqn, var_names: Dict[int, str]) -> str:
-    outvars = ' '.join(_format_var(v, var_names) for v in eqn.outvars)
-    invars = ' '.join(_format_var(v, var_names) for v in eqn.invars)
-    return f"{outvars} = {eqn.primitive.name} {invars}"
-
-
-# ---------------------------------------------------------------------------
-# On-device NaN / Inf detection helpers (run inside JIT on the device)
-# ---------------------------------------------------------------------------
-
-def _is_float_array(x) -> bool:
-    return hasattr(x, 'dtype') and jnp.issubdtype(x.dtype, jnp.floating)
+def _bad_elements(x) -> jax.Array:
+    """Elementwise boolean mask of NaN-or-Inf entries (works for complex)."""
+    return jnp.isnan(x) | jnp.isinf(x)
 
 
 def _has_nan_flag(vals) -> jax.Array:
-    """Return a scalar bool JAX array: True iff any float value has NaN or Inf."""
-    flags = [
-        jnp.any(jnp.isnan(v) | jnp.isinf(v))
-        for v in vals if _is_float_array(v)
-    ]
+    """
+    Return a scalar boolean JAX array: True iff any inexact value is NaN or Inf.
+
+    Integer / boolean arrays are ignored.  Complex arrays are scanned on both
+    their real and imaginary parts (``jnp.isnan`` / ``jnp.isinf`` already do
+    this elementwise).
+    """
+    flags = [jnp.any(_bad_elements(v)) for v in vals if _is_inexact_array(v)]
     if not flags:
         return jnp.array(False)
     return jnp.any(jnp.stack(flags))
 
 
 # ---------------------------------------------------------------------------
-# NaN callback factory
+# Source info: IDE-clickable location strings
 # ---------------------------------------------------------------------------
 
-def _format_nan_message(
-    eqn_idx: int, total_eqns: int, prim_name: str,
-    eqn_str: str, source_loc: str, phase: str,
-    float_vals
-) -> str:
+def _extract_user_source(obj) -> str:
+    """
+    Extract a human-readable, IDE-clickable source location.
+
+    Accepts either a jaxpr equation's ``source_info`` (which carries a
+    ``traceback`` attribute) or a raw ``jaxlib`` ``Traceback`` object (such as
+    the one attached to a :mod:`checkify` error).
+
+    Uses JAX's ``filter_traceback`` — which respects ``register_exclusion``
+    registrations from brainstate and other libraries — then further strips any
+    remaining ``site-packages`` frames so only genuine user frames are shown.
+    Returns the innermost user frame in standard Python traceback format
+    ``File "path", line N, in func_name`` which VSCode / PyCharm hyperlink.
+    """
+    if obj is None:
+        return "<unknown source>"
+    # A source_info exposes ``.traceback``; a raw Traceback exposes
+    # ``.as_python_traceback`` directly.
+    tb = getattr(obj, 'traceback', None)
+    if tb is None and hasattr(obj, 'as_python_traceback'):
+        tb = obj
+    if tb is None:
+        return "<unknown source>"
+
+    def _innermost_user_frame(py_tb) -> str:
+        """Return the innermost frame string that is not a ``site-packages`` frame."""
+        if py_tb is None:
+            return ""
+        lines = tb_module.format_tb(py_tb)
+        lines = [l for l in lines if '/site-packages/' not in l and '\\site-packages\\' not in l]
+        return lines[-1].strip() if lines else ""
+
+    try:
+        py_tb = tb.as_python_traceback()
+    except Exception:
+        py_tb = None
+
+    if py_tb is not None:
+        # 1. JAX-aware filtering: respects ``register_exclusion`` registrations
+        #    (brainstate registers its whole package), so this hides library
+        #    internals and surfaces genuine user code.
+        try:
+            filtered_tb = _traceback_util.filter_traceback(py_tb)
+        except Exception:
+            filtered_tb = None
+        src = _innermost_user_frame(filtered_tb)
+        if src:
+            return src
+        # 2. Fallback: every frame was excluded (e.g. the NaN was produced
+        #    entirely inside registered/library code).  Surface the innermost
+        #    non-``site-packages`` frame so the report still points somewhere
+        #    instead of giving up.
+        src = _innermost_user_frame(py_tb)
+        if src:
+            return src
+
+    try:
+        return source_info_util.summarize(obj)
+    except Exception:
+        return "<unknown source>"
+
+
+# ---------------------------------------------------------------------------
+# checkify error introspection + message formatting
+# ---------------------------------------------------------------------------
+
+def _error_info(err) -> Tuple[Any, Any, Any]:
+    """
+    Return ``(primitive_name, traceback, detail)`` from a checkify ``Error``.
+
+    Any element may be ``None``:
+
+    * ``primitive_name`` is set for :class:`NaNError` (e.g. ``'log'``) and
+      ``None`` for :class:`DivisionByZeroError` and Inf-only contamination.
+    * ``traceback`` is the raw JAX ``Traceback`` recorded at the failing
+      primitive (present for NaN and division errors).
+    * ``detail`` is checkify's own human message (e.g.
+      ``'nan generated by primitive: log.'``).
+    """
+    try:
+        exc = err.get_exception()
+    except Exception:
+        exc = None
+    if exc is None:
+        return None, None, None
+    prim = getattr(exc, 'prim', None)
+    tb = getattr(exc, 'traceback_info', None)
+    try:
+        detail = err.get()
+    except Exception:
+        detail = None
+    return prim, tb, detail
+
+
+def _diagnose(out_leaves) -> List[str]:
+    """Per-output diagnostics for every leaf that carries NaN / Inf."""
+    lines: List[str] = []
+    for i, v in enumerate(out_leaves):
+        if not _is_inexact_array(v):
+            continue
+        try:
+            n_nan = int(jnp.sum(jnp.isnan(v)))
+            n_inf = int(jnp.sum(jnp.isinf(v)))
+        except Exception:
+            continue
+        if n_nan == 0 and n_inf == 0:
+            continue
+        desc = (
+            f"    output[{i}]: shape={tuple(jnp.shape(v))} dtype={v.dtype} "
+            f"NaNs={n_nan} Infs={n_inf}"
+        )
+        if jnp.issubdtype(v.dtype, jnp.floating):
+            try:
+                desc += f" min={float(jnp.nanmin(v)):.4g} max={float(jnp.nanmax(v)):.4g}"
+            except Exception:
+                pass
+        lines.append(desc)
+    return lines
+
+
+def _build_message(err, out_leaves, phase: str) -> Tuple[str, Any]:
+    """Build the user-facing error message and return ``(message, traceback)``."""
+    prim, tb, detail = _error_info(err)
     phase_tag = f" [{phase}]" if phase else ""
-    lines = [
-        f"NaN/Inf detected{phase_tag}!",
-        f"  Introduced by primitive : `{prim_name}`",
-        f"  Source location         :",
-        f"    {source_loc}",
-        f"  Equation [{eqn_idx + 1}/{total_eqns}]: {eqn_str}",
-    ]
-    if float_vals:
-        lines.append("  Float input values:")
-        for i, v in enumerate(float_vals):
-            if hasattr(v, 'size') and v.size <= 8:
-                lines.append(f"    input[{i}] = {v}")
-            elif hasattr(v, 'shape'):
-                nan_cnt = int(jnp.sum(jnp.isnan(v)))
-                inf_cnt = int(jnp.sum(jnp.isinf(v)))
-                lines.append(
-                    f"    input[{i}]: shape={v.shape}  "
-                    f"min={float(jnp.min(v)):.4g}  max={float(jnp.max(v)):.4g}  "
-                    f"NaNs={nan_cnt}  Infs={inf_cnt}"
-                )
-    return '\n'.join(lines)
+    lines = [f"NaN/Inf detected{phase_tag} in the output of the checked function!"]
+    if prim is not None:
+        lines.append(f"  Introduced by primitive : `{prim}`")
+    lines.append("  Source location         :")
+    lines.append(f"    {_extract_user_source(tb)}")
+    if detail:
+        lines.append(f"  Checkify report         : {detail}")
+    diag = _diagnose(out_leaves)
+    if diag:
+        lines.append("  Contaminated outputs    :")
+        lines.extend(diag)
+    if prim is None and not diag:
+        lines.append("  (NaN/Inf reached the output but could not be localized.)")
+    return '\n'.join(lines), tb
 
 
-def _make_nan_callback(eqn_idx: int, total_eqns: int, prim_name: str,
-                       eqn_str: str, source_loc: str, raw_source_info,
-                       phase: str, raise_in_callback: bool = False):
-    """
-    Return a host callback that reports a NaN detection.
-
-    Two modes:
-    - ``raise_in_callback=False`` (default, used outside JIT):
-      Stores ``(message, raw_source_info)`` in thread-local storage.
-      ``_raise_if_nan_detected`` then raises a **clean** ``RuntimeError``
-      via ``source_info_util.user_context``, pointing the traceback at the
-      user code — same mechanism as ``State.raise_error_with_source_info``.
-
-    - ``raise_in_callback=True`` (used inside JIT / ``jax.lax.cond`` with
-      traced predicate):
-      Raises ``RuntimeError`` directly so JAX can propagate it.  The error
-      will be wrapped in ``JaxRuntimeError`` but the full message (with source
-      info) is still visible in ``str(exc)``.
-    """
-
-    def _report(*float_vals):
-        msg = _format_nan_message(
-            eqn_idx, total_eqns, prim_name, eqn_str, source_loc, phase, float_vals
-        )
-        if raise_in_callback:
-            raise RuntimeError(msg)
-        else:
-            _nan_store_get().append((msg, raw_source_info))
-
-    return _report
-
-
-# ---------------------------------------------------------------------------
-# Core: instrumented jaxpr interpreter (all ops stay on device)
-# ---------------------------------------------------------------------------
-
-def _get_invals(eqn, env):
-    return [env[v] if not isinstance(v, Literal) else v.val for v in eqn.invars]
-
-
-def _store_outvals(eqn, outvals, env):
-    for var, val in zip(eqn.outvars, outvals):
-        if not isinstance(var, DropVar):
-            env[var] = val
-
-
-def _raise_if_nan_detected(store_snapshot: int) -> None:
-    """
-    After an instrumented run, check the thread-local store for new NaN records.
-
-    Uses ``source_info_util.user_context`` — the same mechanism as
-    ``State.raise_error_with_source_info`` — so that JAX's traceback filtering
-    shows the *user code* that introduced the NaN rather than library internals.
-    """
-    records = _nan_store_get()
-    new = records[store_snapshot:]
-    if not new:
-        return
-    msg, raw_src = new[0]
-    if raw_src is not None:
-        tb = getattr(raw_src, 'traceback', None)
-        name_stack = (
-            source_info_util.current_name_stack()
-            + getattr(raw_src, 'name_stack', source_info_util.NameStack())
-        )
-        with source_info_util.user_context(tb, name_stack=name_stack):
-            raise RuntimeError(msg)
+def _raise_report(err, out_leaves, phase: str) -> None:
+    """Raise a clean ``RuntimeError`` (eager) pointing the traceback at user code."""
+    msg, tb = _build_message(err, out_leaves, phase)
+    if tb is not None:
+        try:
+            ctx = source_info_util.user_context(tb)
+        except Exception:
+            ctx = None
+        if ctx is not None:
+            with ctx:
+                raise RuntimeError(msg)
     raise RuntimeError(msg)
 
 
-def _interpret_jaxpr_with_nan_check(
-    jaxpr, consts, *flat_args, phase: str = '', raise_in_callback: bool = False
-) -> list:
-    """
-    Replay *jaxpr* equation-by-equation using real JAX primitives (JIT-compatible).
-
-    After each equation an on-device NaN flag is computed.  When a primitive
-    *introduces* NaN (output has NaN but input did not), ``jax.debug.callback``
-    appends a report to thread-local storage.  After the full run,
-    ``_raise_if_nan_detected`` checks for new reports and raises a clean
-    ``RuntimeError`` via ``source_info_util.user_context``, so the traceback
-    points to the user's code — not to library internals.
-    """
-    var_names = _build_var_names(jaxpr)
-    total_eqns = len(jaxpr.eqns)
-
-    # Build per-equation static metadata at Python / compile time
-    eqn_meta: List[dict] = []
-    for i, eqn in enumerate(jaxpr.eqns):
-        raw_src = getattr(eqn, 'source_info', None)
-        eqn_meta.append({
-            'idx': i,
-            'total': total_eqns,
-            'prim': eqn.primitive.name,
-            'eqn_str': _format_eqn(eqn, var_names),
-            'source_loc': _extract_user_source(raw_src),
-            'raw_src': raw_src,
-        })
-
-    # Set up environment
-    env: dict = {}
-    for var, val in zip(jaxpr.constvars, consts):
-        env[var] = val
-    for var, val in zip(jaxpr.invars, flat_args):
-        env[var] = val
-
-    for eqn, meta in zip(jaxpr.eqns, eqn_meta):
-        invals = _get_invals(eqn, env)
-
-        # On-device: does the input already carry NaN?
-        input_has_nan = _has_nan_flag(invals)
-
-        # Execute the primitive (with recursive instrumentation for nested ones)
-        outvals = _execute_eqn(eqn, invals, phase, raise_in_callback)
-
-        # On-device: did this op introduce new NaN?
-        output_has_nan = _has_nan_flag(outvals)
-        nan_introduced = output_has_nan & ~input_has_nan
-
-        # Collect float inputs to pass to the callback
-        float_invals = [v for v in invals if _is_float_array(v)]
-
-        # Build callback closed over static metadata
-        cb = _make_nan_callback(
-            meta['idx'], meta['total'], meta['prim'],
-            meta['eqn_str'], meta['source_loc'], meta['raw_src'], phase,
-            raise_in_callback=raise_in_callback,
-        )
-
-        # Conditionally fire the callback (both branches return None)
-        if float_invals:
-            captured = tuple(float_invals)
-
-            def _do_report(vals=captured, fn=cb):
-                jax.debug.callback(fn, *vals, ordered=True)
-
-            jax.lax.cond(nan_introduced, _do_report, lambda: None)
-        else:
-            jax.lax.cond(
-                nan_introduced,
-                lambda fn=cb: jax.debug.callback(fn, ordered=True),
-                lambda: None,
-            )
-
-        _store_outvals(eqn, outvals, env)
-
-    return [env[v] if not isinstance(v, Literal) else v.val for v in jaxpr.outvars]
-
-
-# ---------------------------------------------------------------------------
-# Primitive dispatch helpers
-# ---------------------------------------------------------------------------
-
-def _execute_eqn(eqn, invals, phase: str, raise_in_callback: bool = False) -> list:
-    """Dispatch to specialised handlers for nested high-level primitives."""
-    if is_jit_primitive(eqn):
-        return _execute_jit_eqn(eqn, invals, phase, raise_in_callback)
-    name = eqn.primitive.name
-    if name == 'cond':
-        return _execute_cond_eqn(eqn, invals, phase, raise_in_callback)
-    if name == 'while':
-        return _execute_while_eqn(eqn, invals, phase, raise_in_callback)
-    if name == 'scan':
-        return _execute_scan_eqn(eqn, invals, phase, raise_in_callback)
-    # Plain primitive: execute normally
-    try:
-        subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
-    except ValueError:
-        bind_params = eqn.primitive.get_bind_params(eqn.params)
-        subfuns = bind_params.pop('subfuns', ())
-    outvals = eqn.primitive.bind(*subfuns, *invals, **bind_params)
-    if not eqn.primitive.multiple_results:
-        outvals = [outvals]
-    return outvals
-
-
-def _extract_closed_jaxpr(obj):
-    """Return (inner_jaxpr, inner_consts) from a ClosedJaxpr or bare Jaxpr."""
-    if isinstance(obj, ClosedJaxpr):
-        return obj.jaxpr, obj.consts
-    return obj, ()
-
-
-def _execute_jit_eqn(eqn, invals, phase: str, raise_in_callback: bool = False) -> list:
-    """Replace a pjit/jit call with its recursively-instrumented inner jaxpr."""
-    call_jaxpr = eqn.params.get('jaxpr') or eqn.params.get('call_jaxpr')
-    if call_jaxpr is None:
-        subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
-        outvals = eqn.primitive.bind(*subfuns, *invals, **bind_params)
-        return [outvals] if not eqn.primitive.multiple_results else outvals
-    inner_jaxpr, inner_consts = _extract_closed_jaxpr(call_jaxpr)
-    return _interpret_jaxpr_with_nan_check(
-        inner_jaxpr, inner_consts, *invals, phase=phase, raise_in_callback=raise_in_callback
-    )
-
-
-def _execute_cond_eqn(eqn, invals, phase: str, raise_in_callback: bool = False) -> list:
-    """
-    Replace a ``cond`` call with instrumented branches.
-
-    JAX's cond jaxpr stores a sequence of ``ClosedJaxpr`` branches in
-    ``eqn.params['branches']``.  The first inval is the integer index and
-    the rest are the shared operands passed to every branch.
-    """
-    branches = eqn.params.get('branches')
-    if branches is None:
-        subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
-        outvals = eqn.primitive.bind(*subfuns, *invals, **bind_params)
-        return [outvals] if not eqn.primitive.multiple_results else outvals
-
-    index = invals[0]
-    operands = tuple(invals[1:])
-
-    def make_branch_fn(closed_jaxpr):
-        b_jaxpr, b_consts = _extract_closed_jaxpr(closed_jaxpr)
-
-        def branch_fn(*ops):
-            result = _interpret_jaxpr_with_nan_check(
-                b_jaxpr, b_consts, *ops, phase=phase, raise_in_callback=raise_in_callback
-            )
-            return tuple(result)
-
-        return branch_fn
-
-    branch_fns = [make_branch_fn(b) for b in branches]
-    result = jax.lax.switch(index, branch_fns, *operands)
-    return list(result) if isinstance(result, tuple) else [result]
-
-
-def _execute_while_eqn(eqn, invals, phase: str, raise_in_callback: bool = False) -> list:
-    """
-    Replace a ``while`` call with an instrumented while loop.
-
-    The body and condition jaxprs are instrumented so NaN checking occurs on
-    every iteration without any CPU fallback.
-    """
-    cond_jaxpr_param = eqn.params.get('cond_jaxpr')
-    body_jaxpr_param = eqn.params.get('body_jaxpr')
-    if cond_jaxpr_param is None or body_jaxpr_param is None:
-        subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
-        outvals = eqn.primitive.bind(*subfuns, *invals, **bind_params)
-        return [outvals] if not eqn.primitive.multiple_results else outvals
-
-    cond_jaxpr, cond_consts = _extract_closed_jaxpr(cond_jaxpr_param)
-    body_jaxpr, body_consts = _extract_closed_jaxpr(body_jaxpr_param)
-
-    def cond_fn(carry):
-        result = _interpret_jaxpr_with_nan_check(
-            cond_jaxpr, cond_consts, *carry, phase=phase, raise_in_callback=raise_in_callback
-        )
-        return result[0]  # single bool output
-
-    def body_fn(carry):
-        result = _interpret_jaxpr_with_nan_check(
-            body_jaxpr, body_consts, *carry, phase=phase, raise_in_callback=raise_in_callback
-        )
-        return tuple(result)
-
-    init_carry = tuple(invals)
-    final_carry = jax.lax.while_loop(cond_fn, body_fn, init_carry)
-    return list(final_carry) if isinstance(final_carry, tuple) else [final_carry]
-
-
-def _execute_scan_eqn(eqn, invals, phase: str, raise_in_callback: bool = False) -> list:
-    """
-    Replace a ``scan`` call with an instrumented scan.
-
-    The scan body jaxpr is instrumented so each iteration's NaN introduction
-    is detected on the device.  The overall scan still runs natively via
-    ``jax.lax.scan`` — no manual Python-level unrolling needed.
-    """
-    scan_jaxpr_param = eqn.params.get('jaxpr')
-    if scan_jaxpr_param is None:
-        subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
-        outvals = eqn.primitive.bind(*subfuns, *invals, **bind_params)
-        return [outvals] if not eqn.primitive.multiple_results else outvals
-
-    num_consts = eqn.params.get('num_consts', 0)
-    num_carry = eqn.params.get('num_carry', 0)
-    length = eqn.params.get('length')
-    reverse = eqn.params.get('reverse', False)
-    unroll = eqn.params.get('unroll', 1)
-
-    inner_jaxpr, inner_consts_param = _extract_closed_jaxpr(scan_jaxpr_param)
-
-    # Split outer invals: consts_from_outer | carry | xs
-    outer_consts = tuple(invals[:num_consts])
-    carry_init = tuple(invals[num_consts:num_consts + num_carry])
-    xs_list = invals[num_consts + num_carry:]
-
-    def scan_body(carry, x):
-        # Reconstruct full argument list for the inner jaxpr:
-        # inner_consts_param (closed) + outer_consts + carry + x_slices
-        if len(xs_list) == 0:
-            x_slices = ()
-        elif len(xs_list) == 1:
-            x_slices = (x,)
-        else:
-            x_slices = tuple(x)  # JAX passes a tuple when multiple xs
-
-        all_inputs = list(outer_consts) + list(carry) + list(x_slices)
-        outputs = _interpret_jaxpr_with_nan_check(
-            inner_jaxpr, inner_consts_param, *all_inputs,
-            phase=phase, raise_in_callback=raise_in_callback
-        )
-        new_carry = tuple(outputs[:num_carry])
-        ys = tuple(outputs[num_carry:])
-        return new_carry, ys
-
-    if len(xs_list) == 0:
-        xs_arg = None
-    elif len(xs_list) == 1:
-        xs_arg = xs_list[0]
-    else:
-        xs_arg = tuple(xs_list)
-
-    final_carry, stacked_ys = jax.lax.scan(
-        scan_body, carry_init, xs_arg,
-        length=length, reverse=reverse, unroll=unroll,
-    )
-
-    carry_out = list(final_carry) if isinstance(final_carry, tuple) else [final_carry]
-
-    num_ys = len(inner_jaxpr.outvars) - num_carry
-    if num_ys == 0:
-        ys_out = []
-    else:
-        if isinstance(stacked_ys, tuple):
-            ys_out = list(stacked_ys)
-        else:
-            ys_out = [stacked_ys]
-
-    return carry_out + ys_out
+def _raise_report_cb(err, out_tree, phase: str) -> None:
+    """Host callback used inside JIT: raise (JAX wraps it in JaxRuntimeError)."""
+    msg, _ = _build_message(err, jax.tree.leaves(out_tree), phase)
+    raise RuntimeError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -531,48 +280,62 @@ class DebugNan:
     """
     JIT-compatible NaN / Inf debugging utility.
 
-    Instead of moving computation to the CPU when NaN is detected, this class
-    instruments the function's jaxpr so that NaN checks run **on the device**
-    (inside JIT) alongside the regular computation.  A lightweight
-    ``jax.debug.callback`` fires only when NaN is actually introduced,
-    reporting:
-
-    * The primitive that introduced the NaN.
-    * The **IDE-clickable** source location (``File "...", line N``).
-    * The equation string from the jaxpr.
-    * The float input values (or their statistics for large arrays).
+    The (possibly stateful) target function is functionalised through
+    :class:`StatefulFunction` and run under :func:`jax.experimental.checkify`.
+    An error is raised only when NaN/Inf reaches the function's observable
+    outputs (return value or updated state), so NaN that is computed but then
+    masked away (e.g. ``jnp.where`` guards, ``vmap``-ed ``cond``) does not
+    trigger a false alarm.
 
     Parameters
     ----------
     fn : Callable
-        The stateful function to debug.
+        The function to debug.  May read and write :class:`~brainstate.State`
+        objects.
     *args
-        Example arguments used to trace the jaxpr (shapes / dtypes matter;
-        values are used for the actual debug run).
+        Example arguments used to trace the function.  Shapes and dtypes matter;
+        the values are used for the actual debug run.
     phase : str, optional
         Label prepended to the error message (e.g. ``"forward"``).
+
+    See Also
+    --------
+    debug_nan : Functional wrapper that runs the check unconditionally.
+    debug_nan_if : Functional wrapper that runs the check conditionally.
+
+    Notes
+    -----
+    ``checkify`` localizes NaN and division-by-zero to the producing primitive
+    with an IDE-clickable source location.  Other Infs (overflow, ``log(0)``)
+    are detected at the output and reported with diagnostics but without a
+    primitive-level source.
+
+    The function is executed once for tracing and once for the instrumented
+    run, so functions with side effects (including global RNG that is not
+    routed through :mod:`brainstate.random`) may behave differently from a
+    single plain call.
     """
 
     def __init__(self, fn: Callable, *args, phase: str = ''):
         self.fn = fn
         self.phase = phase
+        self._args = args
 
         self._stateful_fn = StatefulFunction(fn)
-        # Compile once to get the jaxpr and the list of State objects accessed.
-        cache_key = self._stateful_fn.get_arg_cache_key(*args, compile_if_miss=True)
-        closed_jaxpr: ClosedJaxpr = self._stateful_fn.get_jaxpr_by_cache(cache_key)
-        self._jaxpr = closed_jaxpr.jaxpr
-        self._consts = closed_jaxpr.consts
-        # User-provided args flattened (no state values yet)
-        self._flat_user_args: list = jax.tree.leaves(args)
-        # Keep the State objects so we can read their *current* values at call
-        # time — state may have been updated between __init__ and check().
-        self._states = self._stateful_fn.get_states_by_cache(cache_key)
+        # Compile once to capture the jaxpr and the accessed State objects.
+        self._cache_key = self._stateful_fn.get_arg_cache_key(*args, compile_if_miss=True)
+        self._states = self._stateful_fn.get_states_by_cache(self._cache_key)
+        # checkify the functional form once; reused by check() / check_if().
+        self._checked = checkify.checkify(self._pure, errors=_FLOAT_CHECKS)
 
-    def _build_flat_args(self) -> list:
-        """Concatenate flat user args with current state values."""
-        flat_state_vals: list = jax.tree.leaves([s.value for s in self._states])
-        return self._flat_user_args + flat_state_vals
+    def _pure(self, state_vals, *args):
+        """Pure ``(state_vals, *args) -> (out, new_state_vals)`` form of ``fn``."""
+        new_state_vals, out = self._stateful_fn.jaxpr_call(state_vals, *args)
+        return out, new_state_vals
+
+    def _state_vals(self) -> list:
+        """Current values of the accessed states (re-read fresh each call)."""
+        return [s.value for s in self._states]
 
     # ------------------------------------------------------------------
     # Public API
@@ -580,20 +343,21 @@ class DebugNan:
 
     def check(self):
         """
-        Unconditionally run the instrumented function (JIT-compatible).
+        Run the instrumented function and raise if NaN/Inf reaches an output.
 
-        All NaN checks execute on the device; the host callback fires only
-        when NaN is detected, and the RuntimeError is raised cleanly after the
-        instrumented run completes (no JAX INTERNAL wrapping).
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        RuntimeError
+            If NaN or Inf contaminates the function's outputs or updated state.
         """
-        flat_args = self._build_flat_args()
-        store_snapshot = len(_nan_store_get())
-        _interpret_jaxpr_with_nan_check(
-            self._jaxpr, self._consts, *flat_args, phase=self.phase
-        )
-        # Callbacks are synchronous in eager mode; raise in Python space so
-        # the user sees a clean RuntimeError, not "INTERNAL: CpuCallback …".
-        _raise_if_nan_detected(store_snapshot)
+        err, out_tree = self._checked(self._state_vals(), *self._args)
+        out_leaves = jax.tree.leaves(out_tree)
+        if bool(_has_nan_flag(out_leaves)):
+            _raise_report(err, out_leaves, self.phase)
         return None
 
     def check_if(self, has_nan):
@@ -603,41 +367,42 @@ class DebugNan:
         Parameters
         ----------
         has_nan : bool or jax.Array
-            Scalar boolean condition.  Supports vmapped / batched arrays via
-            ``unvmap(..., op='any')``.
+            Scalar boolean condition.  Batched / vmapped arrays are collapsed
+            with ``unvmap(..., op='any')``.
+
+        Returns
+        -------
+        None
 
         Notes
         -----
-        Two modes based on whether we are inside a JIT-compiled function:
-
-        * **Eager mode** (pred is concrete): uses the clean store-based raise
-          so the RuntimeError points directly at user code.
-        * **JIT-traced mode** (pred is a JAX Tracer): uses ``jax.lax.cond``
-          with ``raise_in_callback=True`` so the callback raises inside XLA;
-          the error surfaces as a JaxRuntimeError wrapping our message.
+        * **Eager mode** (concrete predicate): runs the clean store-free raise
+          so the ``RuntimeError`` points directly at user code.
+        * **JIT-traced mode** (predicate is a :class:`Tracer`): uses
+          ``jax.lax.cond`` and raises inside an ordered ``jax.debug.callback``;
+          the error surfaces as a ``JaxRuntimeError`` wrapping the message.
         """
-        flat_args = self._build_flat_args()
         pred = unvmap(has_nan, op='any')
 
         if isinstance(pred, Tracer):
-            # Inside JIT: Python code won't re-run at execution time, so we
-            # must raise inside the device callback.
             def _do_check():
-                _interpret_jaxpr_with_nan_check(
-                    self._jaxpr, self._consts, *flat_args,
-                    phase=self.phase, raise_in_callback=True,
+                err, out_tree = self._checked(self._state_vals(), *self._args)
+                outputs_bad = _has_nan_flag(jax.tree.leaves(out_tree))
+                jax.lax.cond(
+                    outputs_bad,
+                    lambda: jax.debug.callback(
+                        functools.partial(_raise_report_cb, phase=self.phase),
+                        err, out_tree, ordered=True,
+                    ),
+                    lambda: None,
                 )
                 return None
 
             jax.lax.cond(pred, _do_check, lambda: None)
         else:
-            # Eager mode: cleaner error — raise after callbacks complete.
             if bool(pred):
-                store_snapshot = len(_nan_store_get())
-                _interpret_jaxpr_with_nan_check(
-                    self._jaxpr, self._consts, *flat_args, phase=self.phase
-                )
-                _raise_if_nan_detected(store_snapshot)
+                self.check()
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -646,7 +411,10 @@ class DebugNan:
 
 def debug_nan(fn: Callable, *args, phase: str = ''):
     """
-    Run *fn* with on-device NaN / Inf detection (JIT-compatible).
+    Run *fn* with NaN / Inf detection (JIT-compatible).
+
+    An error is raised only when NaN/Inf reaches *fn*'s observable outputs, so
+    NaN that is computed but masked away does not trigger a false alarm.
 
     Parameters
     ----------
@@ -657,17 +425,36 @@ def debug_nan(fn: Callable, *args, phase: str = ''):
     phase : str, optional
         Label prepended to the error message.
 
-    Notes
-    -----
-    This function is fully JIT-compatible.  All NaN checks run on the device;
-    no data is moved to the CPU unless NaN is actually detected.
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        If NaN or Inf contaminates *fn*'s outputs or updated state.
+
+    See Also
+    --------
+    debug_nan_if : Conditional variant.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> import brainstate
+        >>> brainstate.transform.debug_nan(lambda x: jnp.log(x), jnp.array([-1.0, 1.0]))
+        Traceback (most recent call last):
+            ...
+        RuntimeError: NaN/Inf detected ...
     """
     DebugNan(fn, *args, phase=phase).check()
 
 
 def debug_nan_if(has_nan, fn: Callable, *args, phase: str = ''):
     """
-    Conditionally run *fn* with on-device NaN / Inf detection.
+    Conditionally run *fn* with NaN / Inf detection.
 
     Equivalent to::
 
@@ -679,13 +466,22 @@ def debug_nan_if(has_nan, fn: Callable, *args, phase: str = ''):
     Parameters
     ----------
     has_nan : bool or jax.Array
-        Condition to trigger debugging.
+        Condition to trigger debugging.  Batched arrays are collapsed with
+        ``unvmap(..., op='any')``.
     fn : Callable
         The function to debug.
     *args
         Arguments to pass to the function.
     phase : str, optional
         Label prepended to the error message.
+
+    Returns
+    -------
+    None
+
+    See Also
+    --------
+    debug_nan : Unconditional variant.
     """
     DebugNan(fn, *args, phase=phase).check_if(has_nan)
 

--- a/brainstate/transform/_debug_test.py
+++ b/brainstate/transform/_debug_test.py
@@ -18,59 +18,50 @@ import unittest
 import jax
 import jax.numpy as jnp
 
+import brainstate
+import brainstate as bst
 from brainstate.transform._debug import (
     debug_nan,
     debug_nan_if,
     DebugNan,
     _has_nan_flag,
     _extract_user_source,
-    _interpret_jaxpr_with_nan_check,
 )
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _run_nan_check(fn, *args, phase=''):
-    """Run the instrumented interpreter directly on fn's jaxpr."""
-    closed = jax.make_jaxpr(fn)(*args)
-    return _interpret_jaxpr_with_nan_check(closed.jaxpr, closed.consts, *args, phase=phase)
-
-
-# ---------------------------------------------------------------------------
-# _has_nan_flag
+# _has_nan_flag (output-gate helper: True iff any inexact value is NaN or Inf)
 # ---------------------------------------------------------------------------
 
 class TestHasNanFlag(unittest.TestCase):
 
     def test_no_nan(self):
-        flag = _has_nan_flag([jnp.array([1.0, 2.0, 3.0])])
-        self.assertFalse(bool(flag))
+        self.assertFalse(bool(_has_nan_flag([jnp.array([1.0, 2.0, 3.0])])))
 
     def test_nan(self):
-        flag = _has_nan_flag([jnp.array([1.0, jnp.nan, 3.0])])
-        self.assertTrue(bool(flag))
+        self.assertTrue(bool(_has_nan_flag([jnp.array([1.0, jnp.nan, 3.0])])))
 
     def test_inf(self):
-        flag = _has_nan_flag([jnp.array([1.0, jnp.inf])])
-        self.assertTrue(bool(flag))
+        self.assertTrue(bool(_has_nan_flag([jnp.array([1.0, jnp.inf])])))
 
     def test_neg_inf(self):
-        flag = _has_nan_flag([jnp.array([-jnp.inf])])
-        self.assertTrue(bool(flag))
+        self.assertTrue(bool(_has_nan_flag([jnp.array([-jnp.inf])])))
 
     def test_integer_array_ignored(self):
-        flag = _has_nan_flag([jnp.array([1, 2, 3])])
-        self.assertFalse(bool(flag))
+        self.assertFalse(bool(_has_nan_flag([jnp.array([1, 2, 3])])))
 
     def test_empty_list(self):
-        flag = _has_nan_flag([])
-        self.assertFalse(bool(flag))
+        self.assertFalse(bool(_has_nan_flag([])))
 
     def test_mixed_clean_and_nan(self):
-        flag = _has_nan_flag([jnp.array([1.0]), jnp.array([jnp.nan])])
-        self.assertTrue(bool(flag))
+        self.assertTrue(bool(_has_nan_flag([jnp.array([1.0]), jnp.array([jnp.nan])])))
+
+    def test_complex_nan_detected(self):
+        # complex dtypes must be scanned too (jnp.floating would exclude them)
+        self.assertTrue(bool(_has_nan_flag([jnp.array([jnp.nan + 0.0j], dtype=jnp.complex64)])))
+
+    def test_complex_clean(self):
+        self.assertFalse(bool(_has_nan_flag([jnp.array([1.0 + 2.0j], dtype=jnp.complex64)])))
 
 
 # ---------------------------------------------------------------------------
@@ -80,22 +71,9 @@ class TestHasNanFlag(unittest.TestCase):
 class TestExtractUserSource(unittest.TestCase):
 
     def test_none_returns_unknown(self):
-        result = _extract_user_source(None)
-        self.assertIn("unknown", result)
+        self.assertIn("unknown", _extract_user_source(None))
 
-    def test_real_eqn_has_source(self):
-        def fn(x):
-            return jnp.log(x)
-
-        closed = jax.make_jaxpr(fn)(jnp.array([1.0]))
-        for eqn in closed.jaxpr.eqns:
-            src = _extract_user_source(getattr(eqn, 'source_info', None))
-            # Should not be unknown for a real traced function
-            self.assertIsInstance(src, str)
-
-    def test_source_excludes_brainstate_internals(self):
-        """Source location should not include brainstate tracing infrastructure."""
-        import brainstate as bst
+    def test_excludes_brainstate_internals(self):
         from brainstate.transform._make_jaxpr import StatefulFunction
 
         class Model(bst.graph.Node):
@@ -105,108 +83,310 @@ class TestExtractUserSource(unittest.TestCase):
             def __call__(self, x):
                 return jnp.log(self.w.value) + x
 
-        model = Model()
-        sf = StatefulFunction(model)
+        sf = StatefulFunction(Model())
         cache_key = sf.get_arg_cache_key(jnp.array([1.0]), compile_if_miss=True)
         closed = sf.get_jaxpr_by_cache(cache_key)
-
         for eqn in closed.jaxpr.eqns:
             src = _extract_user_source(getattr(eqn, 'source_info', None))
-            # Should NOT contain brainstate tracing infrastructure paths
             self.assertNotIn('_make_jaxpr.py', src)
-            # Should return something useful, not <unknown source>
-            self.assertNotEqual(src, '<unknown source>')
 
 
 # ---------------------------------------------------------------------------
-# debug_nan – basic detection
+# Basic detection (NaN, Inf, clean) — output-reaching contamination
 # ---------------------------------------------------------------------------
 
-class TestDebugNan(unittest.TestCase):
+class TestBasic(unittest.TestCase):
 
-    def test_raises_for_nan(self):
+    def test_nan_raises_with_primitive_and_source(self):
         def fn(x):
-            return jnp.log(x)
+            return jnp.log(x)   # log(-1) -> NaN reaches output
 
         with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([0.0, 1.0, 2.0]))
-        self.assertIn("NaN", str(ctx.exception))
+            debug_nan(fn, jnp.array([-1.0, 1.0]))
+        msg = str(ctx.exception)
+        self.assertIn("NaN", msg)
+        self.assertIn("log", msg)
+        self.assertIn("Source location", msg)
+        self.assertTrue('File' in msg or '.py' in msg)
+        self.assertNotIn('_make_jaxpr.py', msg)
 
-    def test_raises_for_inf(self):
+    def test_div_by_zero_inf_raises(self):
         def fn(x):
-            return 1.0 / x
+            return 1.0 / x      # 1/0 -> inf reaches output
 
         with self.assertRaises(RuntimeError) as ctx:
             debug_nan(fn, jnp.array([0.0, 1.0]))
         self.assertIn("NaN", str(ctx.exception))
 
-    def test_no_raise_for_clean(self):
-        def fn(x):
-            return x * 2.0 + 1.0
+    def test_clean_no_raise(self):
+        debug_nan(lambda x: x * 2.0 + 1.0, jnp.array([1.0, 2.0, 3.0]))
 
-        # Should not raise
-        debug_nan(fn, jnp.array([1.0, 2.0, 3.0]))
-
-    def test_error_contains_primitive_name(self):
-        def fn(x):
-            return jnp.log(x)
-
+    def test_phase_in_message(self):
         with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([0.0]))
-        self.assertIn("log", str(ctx.exception))
-
-    def test_error_contains_source_location(self):
-        def fn(x):
-            return jnp.log(x)
-
-        with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([0.0]))
-        msg = str(ctx.exception)
-        # Should contain a file path reference
-        self.assertTrue('File' in msg or '.py' in msg or '<' in msg)
-
-    def test_error_contains_phase(self):
-        def fn(x):
-            return jnp.log(x)
-
-        with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([0.0]), phase='forward')
+            debug_nan(lambda x: jnp.log(x), jnp.array([-1.0]), phase='forward')
         self.assertIn("forward", str(ctx.exception))
 
-    def test_reports_first_nan_source(self):
-        """Propagated NaN should not be re-reported; only the source is flagged."""
+    def test_propagated_nan_attributed_to_source(self):
         def fn(x):
-            y = jnp.log(x)   # introduces NaN
-            z = y * 2.0      # propagates
-            return z + 1.0   # propagates
+            y = jnp.log(x)   # source
+            z = y * 2.0
+            return z + 1.0
 
         with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([0.0]))
-        # The callback raises on 'log', not on later ops
+            debug_nan(fn, jnp.array([-1.0]))
         self.assertIn("log", str(ctx.exception))
 
-    def test_error_source_info_in_message(self):
-        """Error message should contain the source location of the NaN-producing equation."""
-        import brainstate as bst
 
-        class Model(bst.graph.Node):
+# ---------------------------------------------------------------------------
+# Reductions / common primitives must not crash (bug: get_bind_params)
+# ---------------------------------------------------------------------------
+
+class TestReductions(unittest.TestCase):
+
+    def test_sum_clean_no_crash(self):
+        debug_nan(lambda x: jnp.sum(x), jnp.array([1.0, 2.0, 3.0]))
+
+    def test_mean_clean_no_crash(self):
+        debug_nan(lambda x: jnp.mean(x), jnp.array([1.0, 2.0, 3.0]))
+
+    def test_sum_axis_clean_no_crash(self):
+        debug_nan(lambda x: jnp.sum(x, axis=0), jnp.ones((3, 2)))
+
+    def test_cumsum_clean_no_crash(self):
+        debug_nan(lambda x: jnp.cumsum(x), jnp.array([1.0, 2.0, 3.0]))
+
+    def test_exp_overflow_inf_detected(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            debug_nan(lambda x: jnp.exp(x), jnp.array([1e30]))
+        self.assertIn("Inf", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Autodiff / gradients (bug: crashed on reduce_sum in grad jaxpr)
+# ---------------------------------------------------------------------------
+
+class TestGrad(unittest.TestCase):
+
+    def test_grad_clean_no_crash(self):
+        debug_nan(jax.grad(lambda x: (x * 2.0).sum()), jnp.array([1.0, 2.0]))
+
+    def test_grad_backward_nan_detected(self):
+        # backward of sqrt at 0 -> inf/division
+        with self.assertRaises(RuntimeError):
+            debug_nan(jax.grad(lambda x: jnp.sqrt(x).sum()), jnp.array([0.0, 4.0]))
+
+    def test_value_and_grad_clean_no_crash(self):
+        debug_nan(jax.value_and_grad(lambda x: (x ** 2).sum()), jnp.array([1.0, 2.0]))
+
+    def test_vmap_of_grad_clean_no_crash(self):
+        g = jax.grad(lambda x: jnp.sum(jnp.log(x)))
+        debug_nan(jax.vmap(g), jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+
+
+# ---------------------------------------------------------------------------
+# vmap / batching
+# ---------------------------------------------------------------------------
+
+class TestVmap(unittest.TestCase):
+
+    def test_vmap_some_lane_nan_detected(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            debug_nan(jax.vmap(lambda x: jnp.log(x)), jnp.array([-1.0, 1.0, 2.0]))
+        self.assertIn("log", str(ctx.exception))
+
+    def test_vmap_of_cond_masked_nan_is_silent(self):
+        # vmapped cond lowers to select_n; the un-taken branch computes log(-1)=NaN
+        # but it is masked away and the real output is clean -> must NOT raise.
+        def f(x):
+            return jax.lax.cond(x > 0.0, lambda y: jnp.log(y), lambda y: y * 2.0, x)
+
+        xs = jnp.array([1.0, -1.0, 2.0])
+        # sanity: real result is finite
+        assert bool(jnp.all(jnp.isfinite(jax.vmap(f)(xs))))
+        debug_nan(jax.vmap(f), xs)   # must be silent
+
+
+# ---------------------------------------------------------------------------
+# Masked-NaN semantics: only output-reaching NaN is reported
+# ---------------------------------------------------------------------------
+
+class TestMaskedNanSilent(unittest.TestCase):
+
+    def test_where_guarded_log_is_silent(self):
+        # jnp.where computes log on all lanes but discards the bad ones.
+        def f(x):
+            return jnp.where(x > 0, jnp.log(x), 0.0)
+
+        xs = jnp.array([0.0, -1.0, 1.0])
+        assert bool(jnp.all(jnp.isfinite(f(xs))))
+        debug_nan(f, xs)   # must be silent
+
+    def test_output_reaching_nan_still_raises(self):
+        def f(x):
+            return jnp.where(x > 0, 0.0, jnp.log(x))  # selects the NaN lane
+
+        with self.assertRaises(RuntimeError):
+            debug_nan(f, jnp.array([-1.0, 1.0]))
+
+
+# ---------------------------------------------------------------------------
+# custom_jvp / custom_vjp primitives (relu/softmax/logsumexp)
+# ---------------------------------------------------------------------------
+
+class TestCustomJVP(unittest.TestCase):
+
+    def test_relu_clean_no_crash(self):
+        debug_nan(lambda x: jax.nn.relu(x), jnp.array([-1.0, 2.0, 3.0]))
+
+    def test_softmax_clean_no_crash(self):
+        debug_nan(lambda x: jax.nn.softmax(x), jnp.array([1.0, 2.0, 3.0]))
+
+    def test_logsumexp_clean_no_crash(self):
+        debug_nan(lambda x: jax.scipy.special.logsumexp(x), jnp.array([1.0, 2.0, 3.0]))
+
+    def test_custom_jvp_inner_nan_detected_and_attributed(self):
+        @jax.custom_jvp
+        def f(x):
+            return jnp.log(x)   # inner source
+
+        @f.defjvp
+        def _f_jvp(primals, tangents):
+            (x,), (xd,) = primals, tangents
+            return f(x), xd / x
+
+        with self.assertRaises(RuntimeError) as ctx:
+            debug_nan(lambda x: f(x), jnp.array([-1.0, 1.0]))
+        self.assertIn("log", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# remat / checkpoint (bug: misattributed to remat2 + inner NaN hidden)
+# ---------------------------------------------------------------------------
+
+class TestRemat(unittest.TestCase):
+
+    def test_remat_clean_no_raise(self):
+        @jax.checkpoint
+        def block(x):
+            return x * 2.0
+
+        debug_nan(lambda x: block(x), jnp.array([1.0, 2.0]))
+
+    def test_remat_nan_attributed_to_inner_primitive(self):
+        @jax.checkpoint
+        def block(x):
+            return jnp.log(x)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            debug_nan(lambda x: block(x), jnp.array([-1.0, 1.0]))
+        msg = str(ctx.exception)
+        self.assertIn("log", msg)
+        self.assertNotIn("remat", msg)
+
+
+# ---------------------------------------------------------------------------
+# Neural-network model integration (relu + matmul + reductions)
+# ---------------------------------------------------------------------------
+
+class TestNNModel(unittest.TestCase):
+
+    def test_mlp_forward_clean_no_crash(self):
+        class MLP(bst.nn.Module):
             def __init__(self):
-                self.w = bst.State(jnp.array([1.0, 0.0]))
+                super().__init__()
+                self.l1 = bst.nn.Linear(4, 8)
+                self.l2 = bst.nn.Linear(8, 2)
 
             def __call__(self, x):
-                return jnp.log(self.w.value) + x
+                return jax.nn.softmax(self.l2(jax.nn.relu(self.l1(x))))
 
-        model = Model()
+        model = MLP()
+        debug_nan(model, brainstate.random.rand(3, 4))
+
+
+# ---------------------------------------------------------------------------
+# Control flow
+# ---------------------------------------------------------------------------
+
+class TestControlFlow(unittest.TestCase):
+
+    def test_cond_true_branch_nan(self):
+        def fn(x):
+            return jax.lax.cond(x[0] > 0.0, lambda y: jnp.log(y), lambda y: y * 2.0, x)
+
         with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(model, jnp.array([1.0, 2.0]))
+            debug_nan(fn, jnp.array([1.0, -1.0]))   # true branch -> log(-1)=NaN reaches output
+        self.assertIn("log", str(ctx.exception))
 
-        msg = str(ctx.exception)
-        # Message should contain source location pointing to user code
-        self.assertIn('Source location', msg)
-        # Should reference the primitive that introduced NaN
-        self.assertIn('log', msg)
-        # Should NOT reference brainstate tracing infrastructure
-        self.assertNotIn('_make_jaxpr.py', msg)
+    def test_cond_false_branch_clean(self):
+        def fn(x):
+            return jax.lax.cond(x[0] > 0.0, lambda y: jnp.log(y), lambda y: y * 2.0, x)
+
+        debug_nan(fn, jnp.array([-1.0, 1.0, 2.0]))   # false branch taken, clean
+
+    def test_switch_more_than_two_branches(self):
+        def fn(i, x):
+            return jax.lax.switch(i, [lambda y: y * 2.0, lambda y: jnp.log(y), lambda y: y + 1.0], x)
+
+        with self.assertRaises(RuntimeError):
+            debug_nan(fn, jnp.array(1), jnp.array([-1.0, 1.0]))
+
+    def test_while_with_closure_clean(self):
+        # body closes over `step` -> while primitive has body_nconsts=1 (old code crashed)
+        def fn(x, step):
+            return jax.lax.while_loop(lambda v: v < 5.0, lambda v: v + step, x)
+
+        debug_nan(fn, jnp.array(0.0), jnp.array(1.0))
+
+    def test_while_mixed_carry_clean(self):
+        def fn(x):
+            def cond_fn(carry):
+                i, acc = carry
+                return i < 5
+
+            def body_fn(carry):
+                i, acc = carry
+                return i + 1, acc + x
+
+            return jax.lax.while_loop(cond_fn, body_fn, (jnp.array(0, jnp.int32), jnp.array(0.0)))
+
+        debug_nan(fn, jnp.array(2.0))
+
+    def test_scan_body_nan(self):
+        def fn(xs):
+            return jax.lax.scan(lambda c, x: (c + jnp.log(x), c), 0.0, xs)[0]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            debug_nan(fn, jnp.array([-1.0, 1.0, 2.0]))
+        self.assertIn("log", str(ctx.exception))
+
+    def test_scan_clean(self):
+        def fn(xs):
+            return jax.lax.scan(lambda c, x: (c + x, x * 2.0), 0.0, xs)[0]
+
+        debug_nan(fn, jnp.array([1.0, 2.0, 3.0]))
+
+
+# ---------------------------------------------------------------------------
+# Inf / complex detection
+# ---------------------------------------------------------------------------
+
+class TestInfComplex(unittest.TestCase):
+
+    def test_inf_times_zero_nan_detected(self):
+        # inf*0 -> nan; old code masked this (input already had inf)
+        with self.assertRaises(RuntimeError):
+            debug_nan(lambda x: x * 0.0, jnp.array([jnp.inf]))
+
+    def test_complex_nan_detected(self):
+        with self.assertRaises(RuntimeError):
+            debug_nan(lambda x: x / x, jnp.array([0.0 + 0.0j], dtype=jnp.complex64))
+
+    def test_nan_input_reaches_output_flagged(self):
+        # If the input already carries NaN and it reaches the output, flag it
+        # (output is contaminated).
+        with self.assertRaises(RuntimeError):
+            debug_nan(lambda x: x * 2.0, jnp.array([1.0, jnp.nan, 3.0]))
 
 
 # ---------------------------------------------------------------------------
@@ -216,238 +396,111 @@ class TestDebugNan(unittest.TestCase):
 class TestDebugNanIf(unittest.TestCase):
 
     def test_false_predicate_no_raise(self):
-        def fn(x):
-            return jnp.log(x)
-
-        # False → should not trigger debug, so no error
-        debug_nan_if(False, fn, jnp.array([0.0, 1.0]))
+        debug_nan_if(False, lambda x: jnp.log(x), jnp.array([-1.0, 1.0]))
 
     def test_true_predicate_raises(self):
-        def fn(x):
-            return jnp.log(x)
-
         with self.assertRaises(RuntimeError):
-            debug_nan_if(True, fn, jnp.array([0.0, 1.0]))
+            debug_nan_if(True, lambda x: jnp.log(x), jnp.array([-1.0, 1.0]))
 
     def test_jax_array_false_no_raise(self):
-        def fn(x):
-            return jnp.log(x)
-
-        debug_nan_if(jnp.array(False), fn, jnp.array([0.0, 1.0]))
+        debug_nan_if(jnp.array(False), lambda x: jnp.log(x), jnp.array([-1.0, 1.0]))
 
     def test_jax_array_true_raises(self):
-        def fn(x):
-            return jnp.log(x)
-
         with self.assertRaises(RuntimeError):
-            debug_nan_if(jnp.array(True), fn, jnp.array([0.0, 1.0]))
+            debug_nan_if(jnp.array(True), lambda x: jnp.log(x), jnp.array([-1.0, 1.0]))
 
-    def test_jit_compatible_no_nan(self):
+    def test_jit_clean_no_raise(self):
         @jax.jit
         def f(x, trigger):
             debug_nan_if(trigger, lambda y: jnp.log(y), x)
             return x
 
-        result = f(jnp.array([1.0, 2.0]), jnp.array(False))
-        self.assertEqual(result.shape, (2,))
+        out = f(jnp.array([1.0, 2.0]), jnp.array(False))
+        self.assertEqual(out.shape, (2,))
 
-    def test_jit_compatible_with_nan(self):
+    def test_jit_with_nan_raises(self):
         @jax.jit
         def f(x, trigger):
             debug_nan_if(trigger, lambda y: jnp.log(y), x)
             return x
 
-        with self.assertRaises(RuntimeError):
-            f(jnp.array([0.0, 1.0]), jnp.array(True))
+        with self.assertRaises(Exception):
+            jax.block_until_ready(f(jnp.array([-1.0, 1.0]), jnp.array(True)))
 
-
-# ---------------------------------------------------------------------------
-# Nested JIT (pjit)
-# ---------------------------------------------------------------------------
-
-class TestNestedJit(unittest.TestCase):
-
-    def test_nan_inside_inner_jit(self):
+    def test_jit_nan_present_but_trigger_false_is_silent(self):
+        # NaN-prone data, but the trigger is False -> must stay silent.
         @jax.jit
-        def inner(x):
-            return jnp.log(x)
+        def f(x, trigger):
+            debug_nan_if(trigger, lambda y: jnp.log(y), x)
+            return x
 
-        @jax.jit
-        def outer(x):
-            return inner(x) * 2.0
+        out = jax.block_until_ready(f(jnp.array([-1.0, 1.0]), jnp.array(False)))
+        self.assertEqual(out.shape, (2,))
 
-        with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(outer, jnp.array([0.0, 1.0]))
-        self.assertIn("log", str(ctx.exception))
+    def test_vmapped_predicate(self):
+        # unvmap(..., 'any') collapses lanes; any True lane triggers.
+        def f(x, trig):
+            debug_nan_if(trig, lambda y: jnp.log(y), x)
+            return x
 
-    def test_deeply_nested_jit(self):
-        @jax.jit
-        def level3(x):
-            return jnp.log(x)
-
-        @jax.jit
-        def level2(x):
-            return level3(x) + 1.0
-
-        @jax.jit
-        def level1(x):
-            return level2(x) * 2.0
-
-        with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(level1, jnp.array([0.0, 1.0]))
-        self.assertIn("log", str(ctx.exception))
-
-    def test_clean_nested_jit_no_raise(self):
-        @jax.jit
-        def inner(x):
-            return x * 2.0
-
-        @jax.jit
-        def outer(x):
-            return inner(x) + 1.0
-
-        debug_nan(outer, jnp.array([1.0, 2.0, 3.0]))
-
-
-# ---------------------------------------------------------------------------
-# Cond primitive
-# ---------------------------------------------------------------------------
-
-class TestCondPrimitive(unittest.TestCase):
-
-    def test_true_branch_nan_detected(self):
-        def fn(x):
-            return jax.lax.cond(
-                x[0] > 0.0,
-                lambda y: jnp.log(y),   # NaN branch
-                lambda y: y * 2.0,
-                x,
+        with self.assertRaises(Exception):
+            jax.block_until_ready(
+                jax.vmap(f)(jnp.array([-1.0, 1.0]), jnp.array([True, False]))
             )
 
-        with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([1.0, 0.0]))  # x[0]>0 → log branch → NaN
-        self.assertIn("log", str(ctx.exception))
-
-    def test_false_branch_no_nan(self):
-        def fn(x):
-            return jax.lax.cond(
-                x[0] > 0.0,
-                lambda y: jnp.log(y),   # not taken
-                lambda y: y * 2.0,      # taken, clean
-                x,
-            )
-
-        # x[0] = -1 → false branch taken → no NaN
-        debug_nan(fn, jnp.array([-1.0, 1.0, 2.0]))
-
 
 # ---------------------------------------------------------------------------
-# While primitive
+# Stateful models
 # ---------------------------------------------------------------------------
 
-class TestWhilePrimitive(unittest.TestCase):
+class TestStateIntegration(unittest.TestCase):
 
-    def test_nan_in_body(self):
-        def fn(x):
-            def cond_fn(val):
-                return val[0] < 10.0
+    def test_state_value_nan_detected_and_attributed(self):
+        class Model(bst.graph.Node):
+            def __init__(self):
+                self.w = bst.State(jnp.array([1.0, -1.0]))
 
-            def body_fn(val):
-                return jnp.log(val)  # NaN when val has non-positive elements
-
-            return jax.lax.while_loop(cond_fn, body_fn, x)
+            def __call__(self, x):
+                return jnp.log(self.w.value) + x   # log(-1)=NaN from the state
 
         with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([0.5]))  # log(0.5) OK, but jnp.log produces -inf then NaN
-        # We mainly care that NaN was caught somewhere
-        self.assertIn("NaN", str(ctx.exception))
+            debug_nan(Model(), jnp.array([1.0, 2.0]))
+        msg = str(ctx.exception)
+        self.assertIn("log", msg)
+        self.assertNotIn('_make_jaxpr.py', msg)
 
-    def test_clean_while_no_raise(self):
-        def fn(x):
-            def cond_fn(val):
-                return val[0] < 5.0
+    def test_clean_stateful_no_raise(self):
+        class Model(bst.graph.Node):
+            def __init__(self):
+                self.w = bst.State(jnp.array([1.0, 2.0]))
 
-            def body_fn(val):
-                return val + 1.0
+            def __call__(self, x):
+                return self.w.value * x
 
-            return jax.lax.while_loop(cond_fn, body_fn, x)
+        debug_nan(Model(), jnp.array([1.0, 2.0]))
 
-        debug_nan(fn, jnp.array([0.0]))
+    def test_state_write_nan_detected(self):
+        class Model(bst.graph.Node):
+            def __init__(self):
+                self.s = bst.State(jnp.array([1.0]))
 
-
-# ---------------------------------------------------------------------------
-# Scan primitive
-# ---------------------------------------------------------------------------
-
-class TestScanPrimitive(unittest.TestCase):
-
-    def test_nan_in_scan_body(self):
-        def fn(xs):
-            def body(carry, x):
-                return carry + jnp.log(x), carry
-
-            return jax.lax.scan(body, 0.0, xs)
-
-        with self.assertRaises(RuntimeError) as ctx:
-            debug_nan(fn, jnp.array([0.0, 1.0, 2.0]))
-        self.assertIn("log", str(ctx.exception))
-
-    def test_nan_in_later_iteration(self):
-        def fn(xs):
-            def body(carry, x):
-                return carry + jnp.log(x), x * 2.0
-
-            return jax.lax.scan(body, 0.0, xs)
+            def __call__(self, x):
+                self.s.value = jnp.log(x)   # writes NaN to state
+                return self.s.value.sum()
 
         with self.assertRaises(RuntimeError):
-            debug_nan(fn, jnp.array([1.0, 0.0, 2.0]))  # second element causes NaN
+            debug_nan(Model(), jnp.array([-1.0]))
 
-    def test_clean_scan_no_raise(self):
-        def fn(xs):
-            def body(carry, x):
-                return carry + x, x * 2.0
+    def test_multiple_states_clean(self):
+        class Model(bst.graph.Node):
+            def __init__(self):
+                self.a = bst.State(jnp.array([1.0]))
+                self.b = bst.State(jnp.array([2.0]))
 
-            return jax.lax.scan(body, 0.0, xs)
+            def __call__(self, x):
+                return self.a.value * self.b.value + x
 
-        debug_nan(fn, jnp.array([1.0, 2.0, 3.0]))
-
-    def test_scan_with_multiple_carry(self):
-        def fn(xs):
-            def body(carry, x):
-                c1, c2 = carry
-                return (c1 + jnp.log(x), c2 * x), c1
-
-            return jax.lax.scan(body, (0.0, 1.0), xs)
-
-        with self.assertRaises(RuntimeError):
-            debug_nan(fn, jnp.array([0.0, 1.0]))
-
-
-# ---------------------------------------------------------------------------
-# NaN propagation vs introduction
-# ---------------------------------------------------------------------------
-
-class TestNanPropagation(unittest.TestCase):
-
-    def test_nan_input_not_reported(self):
-        """If input already has NaN, no equation 'introduces' it."""
-        def fn(x):
-            return x * 2.0  # just propagates
-
-        # No equation introduces NaN, so no error should be raised
-        # (NaN was already in the input; _interpret finds no new NaN source)
-        _run_nan_check(fn, jnp.array([1.0, jnp.nan, 3.0]))
-
-    def test_multiple_independent_nan_sources(self):
-        """When there are two independent NaN sources, the first is reported."""
-        def fn(x, y):
-            a = jnp.log(x)    # introduces NaN
-            b = 1.0 / y       # also introduces NaN
-            return a + b
-
-        # Both introduce NaN; at least one RuntimeError is raised
-        with self.assertRaises(RuntimeError):
-            debug_nan(fn, jnp.array([0.0]), jnp.array([0.0]))
+        debug_nan(Model(), jnp.array([1.0]))
 
 
 # ---------------------------------------------------------------------------
@@ -457,28 +510,74 @@ class TestNanPropagation(unittest.TestCase):
 class TestDebugNanClass(unittest.TestCase):
 
     def test_check_raises(self):
-        def fn(x):
-            return jnp.log(x)
-
-        d = DebugNan(fn, jnp.array([0.0]), phase='test')
+        d = DebugNan(lambda x: jnp.log(x), jnp.array([-1.0]), phase='test')
         with self.assertRaises(RuntimeError) as ctx:
             d.check()
         self.assertIn("test", str(ctx.exception))
 
-    def test_check_if_false_no_raise(self):
-        def fn(x):
-            return jnp.log(x)
+    def test_check_clean_no_raise(self):
+        DebugNan(lambda x: x * 2.0, jnp.array([1.0])).check()
 
-        d = DebugNan(fn, jnp.array([0.0]))
-        d.check_if(jnp.array(False))  # should not raise
+    def test_check_if_false_no_raise(self):
+        DebugNan(lambda x: jnp.log(x), jnp.array([-1.0])).check_if(jnp.array(False))
 
     def test_check_if_true_raises(self):
-        def fn(x):
-            return jnp.log(x)
-
-        d = DebugNan(fn, jnp.array([0.0]))
         with self.assertRaises(RuntimeError):
-            d.check_if(jnp.array(True))
+            DebugNan(lambda x: jnp.log(x), jnp.array([-1.0])).check_if(jnp.array(True))
+
+
+# ---------------------------------------------------------------------------
+# GradientTransform integration (consumer of debug_nan_if via debug_nan=True)
+# ---------------------------------------------------------------------------
+
+class TestGradTransformIntegration(unittest.TestCase):
+
+    def test_grad_debug_nan_clean_no_raise(self):
+        w = bst.State(jnp.array([1.0, 2.0]))
+
+        def loss(x):
+            return jnp.sum((x * w.value) ** 2)
+
+        g = bst.transform.grad(loss, grad_states=w, debug_nan=True)
+        out = g(jnp.array([1.0, 2.0]))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(out))))
+
+    def test_grad_debug_nan_backward_raises(self):
+        w = bst.State(jnp.array([0.0, 4.0]))
+
+        def loss(x):
+            return jnp.sum(jnp.sqrt(w.value) * x)   # d/dw sqrt(0) -> inf
+
+        g = bst.transform.grad(loss, grad_states=w, debug_nan=True)
+        with self.assertRaises(Exception) as ctx:
+            jax.block_until_ready(g(jnp.array([1.0, 1.0])))
+        self.assertIn("NaN/Inf", str(ctx.exception))
+
+    def test_grad_debug_nan_under_jit_clean_no_raise(self):
+        w = bst.State(jnp.array([1.0, 2.0]))
+
+        def loss(x):
+            return jnp.sum((x * w.value) ** 2)
+
+        @bst.transform.jit
+        def step(x):
+            return bst.transform.grad(loss, grad_states=w, debug_nan=True)(x)
+
+        out = jax.block_until_ready(step(jnp.array([1.0, 2.0])))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(out))))
+
+    def test_grad_debug_nan_under_jit_raises(self):
+        w = bst.State(jnp.array([0.0, 4.0]))
+
+        def loss(x):
+            return jnp.sum(jnp.sqrt(w.value) * x)
+
+        @bst.transform.jit
+        def step(x):
+            return bst.transform.grad(loss, grad_states=w, debug_nan=True)(x)
+
+        with self.assertRaises(Exception):
+            jax.block_until_ready(step(jnp.array([1.0, 1.0])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replace the hand-written jaxpr interpreter in transform/_debug.py with a
checkify-based engine plus an output-contamination gate.

The old interpreter broke on the modern get_bind_params contract, mishandled
while-loop constants, and silently failed on higher-order primitives
(custom_jvp/vjp, remat) produced by grad, vmap and NN activations. checkify is
a JAX transform, so it composes natively with grad/vmap/jit/scan/while/cond and
custom-derivative primitives, removing that entire class of bugs.

An output-contamination gate only surfaces NaN/Inf that actually reaches the
function's observable outputs (return value + updated state), so NaN computed
in a masked-away branch/lane (where-guards, vmapped cond) no longer triggers
false positives. Error messages keep the primitive name, an IDE-clickable
source location (with a fallback when all frames are library-excluded),
checkify's report, and per-output diagnostics. Public API (debug_nan,
debug_nan_if, DebugNan, breakpoint_if) is unchanged.

Tests: 66 in _debug_test.py (incl. grad/vmap/custom_jvp/remat/control-flow/
state/complex + GradientTransform integration); full transform suite 343 passed.

## Summary by Sourcery

Rebuild NaN/Inf debugging on `jax.experimental.checkify`, replacing the custom jaxpr interpreter with a checkify-based engine plus an output-contamination gate while keeping the public debugging API unchanged.

Enhancements:
- Replace the hand-written jaxpr interpreter with a `checkify`-based NaN/Inf detection pipeline that composes correctly with JAX transforms and higher-order primitives.
- Introduce an output-contamination gate so only NaN/Inf that reaches function outputs or updated state is reported, reducing false positives from masked branches or lanes.
- Improve error reporting with IDE-clickable source locations, primitive attribution, and per-output diagnostics including complex dtypes.
- Refine NaN/Inf detection helpers to treat inexact (float and complex) arrays consistently and to better handle Inf-only cases.

Tests:
- Rewrite and expand the NaN/Inf debugging test suite to cover complex dtypes, control flow, vmap/grad/custom_jvp/remat, stateful models, and GradientTransform integration, ensuring compatibility under jit and batched conditions.