### PR TITLE
test(transform): repoint _mapping1_test helper imports to _mapping_core

### DIFF
--- a/brainstate/transform/_mapping1_test.py
+++ b/brainstate/transform/_mapping1_test.py
@@ -49,6 +49,8 @@ import brainstate as bst
 from brainstate.transform._mapping1 import (
     vmap,
     vmap_new_states,
+)
+from brainstate.transform._mapping_core import (
     _flatten_in_out_states,
     _remove_axis,
     _get_batch_size,


### PR DESCRIPTION
The vmap2/pmap2 unification moved _flatten_in_out_states, _remove_axis,
_get_batch_size, and _format_state_axes into _mapping_core, but
_mapping1_test.py still imported them from _mapping1, breaking collection
of the entire test suite. Import the relocated helpers from _mapping_core
(vmap/vmap_new_states still come from _mapping1).

## Summary by Sourcery

Tests:
- Fix _mapping1_test helper imports to reference relocated vmap/pmap helper functions in _mapping_core to restore full test suite collection.