### PR TITLE
test: shared test infrastructure (Phase 0)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,16 @@ jobs:
           python -m pip install . || exit 1
       - name: Test with pytest
         run: |
-          pytest brainstate/
+          # Use the coverage CLI rather than the pytest-cov plugin: the plugin's
+          # tracer-start timing aborts (SIGABRT) under JAX/XLA, while `coverage
+          # run` starts cleanly. Config lives in [tool.coverage.*] in pyproject.
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            coverage run -m pytest brainstate/ --run-slow
+          else
+            coverage run -m pytest brainstate/
+          fi
+          coverage report -m
+          coverage xml
 
   type_check:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,3 +105,48 @@ Open `docs/_build/html/index.html` in your browser to review the result.
 
 ## Need Help?
 If you have questions or want early feedback on substantial changes, open a draft pull request or start a discussion on the issue tracker. We are happy to help you land your contribution.
+
+## Testing conventions
+
+All tests live next to the source as `<module>_test.py` and run via `pytest brainstate/`.
+
+### Framework
+- Use `unittest.TestCase`, with `absl.testing.parameterized` for parametric cases.
+- Every test class/method has a one-line NumPy-doc summary describing the scenario.
+- Naming: `class Test<Thing>`, `def test_<behavior>`.
+
+### Shared helpers (`brainstate/_testing.py`)
+- `assert_allclose(actual, expected, *, rtol, atol, check_dtype)` — unit-aware (brainunit) value+shape check.
+- `assert_jit_equal(fn, *args)` — `jit(fn)` matches eager.
+- `assert_grad_finite(fn, *args, argnums=0)` — gradients of a scalar fn are finite.
+- `assert_vmap_equal(fn, *batched_args)` — `vmap(fn)` over axis 0 matches a Python loop.
+- `assert_transform_compatible(fn, *args, transforms=("jit","grad","vmap"))` — umbrella.
+- `assert_pytree_roundtrip(obj)` — flatten/unflatten roundtrip.
+- Size constants `SMALL_BATCH=4`, `SMALL_DIM=16`, `SMALL_SEQ=5`.
+- `seeded(seed)` — context manager (`with seeded(0): ...`) that seeds and restores RNG.
+
+### Random numbers
+- Always use `brainstate.random` (e.g. `brainstate.random.rand`, `.randn`, `.seed`).
+- **Never** import or call `jax.random` directly in tests.
+
+### Performance
+- Keep inputs tiny: batch ≤ 4, dims ≤ 16 (use the `SMALL_*` constants).
+- Reuse compiled functions / built modules across cases; do not re-`jit` per case.
+- Mark expensive tests `@pytest.mark.slow` (skipped by default; run with `pytest --run-slow`).
+
+### The per-API checklist
+Each public API should be tested for: (1) happy path; (2) shapes/dtypes/units;
+(3) argument variations; (4) edge cases (empty/zero/single/large, boundary, NaN/inf);
+(5) failure paths (assert exception type AND message); (6) JAX-transform compatibility
+(jit/grad/vmap/scan); (7) State semantics (read/write, no leaks, pytree roundtrip);
+(8) determinism under seeded RNG; (9) serialization (treefy/state_dict) where applicable.
+
+### Coverage bar
+Each subpackage targets **≥90% line coverage** (branch coverage measured/reported). Measure
+with the coverage CLI (the `pytest-cov` plugin aborts under JAX/XLA on some platforms; the CLI
+starts the tracer cleanly):
+```bash
+coverage run -m pytest brainstate/<subpackage>/
+coverage report -m
+```
+Coverage settings (source, branch, omit) live in `[tool.coverage.*]` in `pyproject.toml`.

--- a/brainstate/_conftest_test.py
+++ b/brainstate/_conftest_test.py
@@ -1,0 +1,38 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for conftest behavior: deterministic seeding and the slow marker."""
+
+import unittest
+
+import jax.numpy as jnp
+
+import brainstate
+
+
+class TestDeterministicSeed(unittest.TestCase):
+    """The autouse fixture seeds brainstate.random before each test."""
+
+    def test_rng_is_seeded(self):
+        """random draws are reproducible across identical re-seeds."""
+        brainstate.random.seed(0)
+        a = brainstate.random.rand(5)
+        brainstate.random.seed(0)
+        b = brainstate.random.rand(5)
+        self.assertTrue(bool(jnp.allclose(a, b)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/brainstate/_testing.py
+++ b/brainstate/_testing.py
@@ -1,0 +1,174 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared, importable test helpers for the brainstate test suite.
+
+This module is private (underscore-prefixed) and excluded from coverage.  It is
+importable by the co-located ``*_test.py`` files, which are ``unittest.TestCase``
+subclasses and therefore cannot consume pytest fixtures.
+
+See ``CONTRIBUTING.md`` (Testing conventions) for usage guidance.
+"""
+
+from __future__ import annotations
+
+import brainunit as u
+import jax
+import jax.numpy as jnp
+
+import brainstate
+
+__all__ = [
+    "SMALL_BATCH",
+    "SMALL_DIM",
+    "SMALL_SEQ",
+    "DEFAULT_RTOL",
+    "DEFAULT_ATOL",
+    "assert_allclose",
+    "assert_jit_equal",
+    "assert_grad_finite",
+    "assert_vmap_equal",
+    "assert_transform_compatible",
+    "assert_pytree_roundtrip",
+    "seeded",
+]
+
+# Keep test fixtures tiny (see CONTRIBUTING.md > Testing conventions > Performance).
+SMALL_BATCH = 4
+SMALL_DIM = 16
+SMALL_SEQ = 5
+
+DEFAULT_RTOL = 1e-5
+DEFAULT_ATOL = 1e-6
+
+# Re-export brainstate's seed context manager under a discoverable name.
+# Usage: ``with seeded(0): ...`` — temporarily seeds and restores RNG state.
+seeded = brainstate.random.seed_context
+
+
+def assert_allclose(actual, expected, *, rtol=DEFAULT_RTOL, atol=DEFAULT_ATOL, check_dtype=False):
+    """Assert two (possibly unit-carrying) arrays match in shape and value.
+
+    Parameters
+    ----------
+    actual, expected : array_like or brainunit.Quantity
+        Values to compare.  Units are compared via ``brainunit``.
+    rtol, atol : float
+        Relative and absolute tolerances.
+    check_dtype : bool
+        When ``True``, also assert the underlying magnitudes share a dtype.
+    """
+    actual_shape = u.math.shape(actual)
+    expected_shape = u.math.shape(expected)
+    assert actual_shape == expected_shape, (
+        f"shape mismatch: {actual_shape} != {expected_shape}"
+    )
+    # Dimensions must match (mV vs V is fine — same dimension; mV vs mA is not).
+    actual_dim = u.get_dim(actual)
+    expected_dim = u.get_dim(expected)
+    assert actual_dim == expected_dim, (
+        f"unit mismatch: {u.get_unit(actual)} vs {u.get_unit(expected)}"
+    )
+    if check_dtype:
+        a_dtype = u.get_magnitude(actual).dtype
+        e_dtype = u.get_magnitude(expected).dtype
+        assert a_dtype == e_dtype, f"dtype mismatch: {a_dtype} != {e_dtype}"
+    # Express both magnitudes in expected's unit so the dimensionless rtol/atol
+    # apply to plain numbers (saiunit rejects a dimensionless atol compared
+    # against a unit-carrying quantity).
+    ref_unit = u.get_unit(expected)
+    actual_mag = u.Quantity(actual).to_decimal(ref_unit)
+    expected_mag = u.Quantity(expected).to_decimal(ref_unit)
+    assert bool(jnp.allclose(actual_mag, expected_mag, rtol=rtol, atol=atol)), (
+        f"value mismatch beyond rtol={rtol}, atol={atol}"
+    )
+
+
+def _assert_tree_allclose(tree_a, tree_b, *, rtol, atol):
+    """Leaf-wise ``assert_allclose`` over two matching pytrees."""
+    jax.tree.map(
+        lambda a, b: assert_allclose(a, b, rtol=rtol, atol=atol),
+        tree_a,
+        tree_b,
+    )
+
+
+def assert_jit_equal(fn, *args, rtol=DEFAULT_RTOL, atol=DEFAULT_ATOL, **kwargs):
+    """Assert ``brainstate.transform.jit(fn)`` matches eager ``fn`` leaf-wise."""
+    eager = fn(*args, **kwargs)
+    jitted = brainstate.transform.jit(fn)(*args, **kwargs)
+    _assert_tree_allclose(eager, jitted, rtol=rtol, atol=atol)
+    return jitted
+
+
+def assert_grad_finite(fn, *args, argnums=0, **kwargs):
+    """Assert ``brainstate.transform.grad(fn)`` yields all-finite gradients.
+
+    ``fn`` must return a scalar.
+    """
+    grads = brainstate.transform.grad(fn, argnums=argnums)(*args, **kwargs)
+    leaves = jax.tree.leaves(grads)
+    assert leaves, "no gradient leaves were produced"
+    for g in leaves:
+        assert bool(jnp.all(jnp.isfinite(u.get_magnitude(g)))), "non-finite gradient leaf"
+    return grads
+
+
+def assert_vmap_equal(fn, *batched_args, rtol=DEFAULT_RTOL, atol=DEFAULT_ATOL):
+    """Assert ``vmap(fn)`` over axis 0 matches an explicit Python loop.
+
+    Every positional argument is mapped over its leading axis (``in_axes=0``).
+    """
+    vmapped = brainstate.transform.vmap(fn, in_axes=0)(*batched_args)
+    n = u.math.shape(batched_args[0])[0]
+    looped = [fn(*[jnp.take(a, i, axis=0) for a in batched_args]) for i in range(n)]
+    stacked = jax.tree.map(lambda *xs: jnp.stack(xs), *looped)
+    _assert_tree_allclose(vmapped, stacked, rtol=rtol, atol=atol)
+    return vmapped
+
+
+def assert_transform_compatible(
+    fn,
+    *args,
+    transforms=("jit",),
+    grad_argnums=0,
+    rtol=DEFAULT_RTOL,
+    atol=DEFAULT_ATOL,
+    **kwargs,
+):
+    """Run ``fn`` under each requested JAX transform and assert agreement.
+
+    Parameters
+    ----------
+    transforms : sequence of {"jit", "grad", "vmap"}
+        Which transforms to check.  ``"jit"`` only by default.  ``"grad"``
+        requires ``fn`` to return a scalar; ``"vmap"`` maps every arg over axis 0.
+    """
+    if "jit" in transforms:
+        assert_jit_equal(fn, *args, rtol=rtol, atol=atol, **kwargs)
+    if "grad" in transforms:
+        assert_grad_finite(fn, *args, argnums=grad_argnums, **kwargs)
+    if "vmap" in transforms:
+        assert_vmap_equal(fn, *args, rtol=rtol, atol=atol)
+    return True
+
+
+def assert_pytree_roundtrip(obj, *, rtol=DEFAULT_RTOL, atol=DEFAULT_ATOL):
+    """Assert ``obj`` survives a flatten/unflatten roundtrip structurally and by value."""
+    leaves, treedef = jax.tree.flatten(obj)
+    rebuilt = jax.tree.unflatten(treedef, leaves)
+    assert jax.tree.structure(obj) == jax.tree.structure(rebuilt), "pytree structure changed"
+    _assert_tree_allclose(obj, rebuilt, rtol=rtol, atol=atol)
+    return rebuilt

--- a/brainstate/_testing_test.py
+++ b/brainstate/_testing_test.py
@@ -1,0 +1,98 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the shared test-helper module."""
+
+import unittest
+
+import brainunit as u
+import jax.numpy as jnp
+
+from brainstate import _testing
+
+
+class TestAssertAllclose(unittest.TestCase):
+    """Validate the unit-aware closeness assertion."""
+
+    def test_equal_arrays_pass(self):
+        """Identical arrays pass."""
+        _testing.assert_allclose(jnp.ones((2, 3)), jnp.ones((2, 3)))
+
+    def test_shape_mismatch_raises(self):
+        """Different shapes raise AssertionError."""
+        with self.assertRaises(AssertionError):
+            _testing.assert_allclose(jnp.ones((2, 3)), jnp.ones((2, 4)))
+
+    def test_value_mismatch_raises(self):
+        """Different values raise AssertionError."""
+        with self.assertRaises(AssertionError):
+            _testing.assert_allclose(jnp.zeros((2,)), jnp.ones((2,)))
+
+    def test_unit_aware(self):
+        """Quantities with equal magnitude+unit pass."""
+        a = u.Quantity(jnp.ones((3,)), unit=u.mV)
+        _testing.assert_allclose(a, a)
+
+    def test_dtype_check(self):
+        """check_dtype=True catches dtype mismatch."""
+        with self.assertRaises(AssertionError):
+            _testing.assert_allclose(
+                jnp.ones((2,), dtype=jnp.float32),
+                jnp.ones((2,), dtype=jnp.int32),
+                check_dtype=True,
+            )
+
+
+class TestTransformHelpers(unittest.TestCase):
+    """Validate jit/grad/vmap helpers."""
+
+    def test_jit_equal(self):
+        """jit(fn) matches eager fn."""
+        _testing.assert_jit_equal(lambda x: x * 2.0, jnp.ones((4, 8)))
+
+    def test_grad_finite(self):
+        """grad of a scalar fn is finite."""
+        _testing.assert_grad_finite(lambda z: jnp.sum(z ** 2), jnp.ones((4, 8)))
+
+    def test_vmap_equal(self):
+        """vmap(fn) over axis 0 matches a Python loop."""
+        _testing.assert_vmap_equal(lambda r: r.sum(), jnp.arange(12.0).reshape(4, 3))
+
+    def test_transform_compatible_default_jit(self):
+        """Umbrella helper runs jit by default."""
+        _testing.assert_transform_compatible(lambda x: x + 1.0, jnp.ones((4, 8)))
+
+
+class TestPytreeRoundtrip(unittest.TestCase):
+    """Validate pytree flatten/unflatten roundtrip helper."""
+
+    def test_dict_roundtrip(self):
+        """A nested dict roundtrips structurally and by value."""
+        obj = {"a": jnp.ones((2,)), "b": {"c": jnp.zeros((3,))}}
+        _testing.assert_pytree_roundtrip(obj)
+
+
+class TestConstants(unittest.TestCase):
+    """Size constants exist and are small."""
+
+    def test_sizes_small(self):
+        """Constants stay tiny per the performance convention."""
+        self.assertLessEqual(_testing.SMALL_BATCH, 8)
+        self.assertLessEqual(_testing.SMALL_DIM, 32)
+        self.assertLessEqual(_testing.SMALL_SEQ, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/brainstate/conftest.py
+++ b/brainstate/conftest.py
@@ -1,0 +1,55 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Pytest configuration shared across the brainstate test suite.
+
+Provides:
+
+* a ``--run-slow`` command-line flag; tests marked ``@pytest.mark.slow`` are
+  skipped unless it is supplied (keeps the default CI run fast),
+* an autouse fixture that seeds ``brainstate.random`` before every test so
+  randomized tests are deterministic and isolated from one another.
+"""
+
+import pytest
+
+import brainstate
+
+
+def pytest_addoption(parser):
+    """Register the ``--run-slow`` flag."""
+    parser.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="run tests marked @pytest.mark.slow",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip ``slow``-marked tests unless ``--run-slow`` is given."""
+    if config.getoption("--run-slow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_rng():
+    """Seed brainstate.random before each test for reproducibility."""
+    brainstate.random.seed(0)
+    yield

--- a/brainstate/transform/_mapping1_test.py
+++ b/brainstate/transform/_mapping1_test.py
@@ -49,6 +49,10 @@ import brainstate as bst
 from brainstate.transform._mapping1 import (
     vmap,
     vmap_new_states,
+)
+# These private helpers moved to the shared engine module when vmap/vmap2 were
+# unified (#156); import them from their current home so collection succeeds.
+from brainstate.transform._mapping_core import (
     _flatten_in_out_states,
     _remove_axis,
     _get_batch_size,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ tpu = [
 testing = [
     'absl-py',
     'pytest',
+    'coverage',
     'jax>=0.6.0',
     'brainunit',
     'brainevent',
@@ -143,3 +144,26 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 warn_return_any = true
 warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+testpaths = ["brainstate"]
+addopts = "-ra"
+markers = [
+    "slow: marks tests as slow (deselected by default; run with --run-slow)",
+]
+
+[tool.coverage.run]
+source = ["brainstate"]
+branch = true
+omit = [
+    "*/*_test.py",
+    "*/test_*.py",
+    "brainstate/_version.py",
+    "brainstate/conftest.py",
+    "brainstate/_testing.py",
+    "brainstate/experimental/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ brainpy-state
 
 # test requirements
 pytest
+coverage
 absl-py
 
 # type checking


### PR DESCRIPTION
Phase 0 of the comprehensive API test-audit — the shared infrastructure every per-subpackage test cycle depends on.

## What this adds
- **Coverage tooling** — `[tool.coverage.run]` (branch coverage; omit test/infra files) + `[tool.pytest.ini_options]` registering a `slow` marker, in `pyproject.toml`. `coverage` added to `requirements-dev.txt` and the `testing` extra.
- **`brainstate/_testing.py`** — importable assertion helpers (`assert_allclose` unit-aware, `assert_jit_equal`, `assert_grad_finite`, `assert_vmap_equal`, `assert_transform_compatible`, `assert_pytree_roundtrip`, `seeded`, and `SMALL_*` size constants). Plain functions, since the existing `unittest.TestCase` classes cannot consume pytest fixtures.
- **`brainstate/conftest.py`** — a `--run-slow` flag (slow tests skipped by default) and an autouse fixture seeding `brainstate.random` before every test for determinism.
- **CONTRIBUTING.md** — a testing-conventions section (framework, helpers, RNG rule, performance, the 9-point per-API checklist, coverage bar).
- **CI.yml** — measures coverage via the **coverage CLI** rather than the `pytest-cov` plugin (the plugin aborts with SIGABRT under JAX/XLA); slow tests run on the nightly `schedule` event.

## Bug fix (unblocks suite collection)
`brainstate/transform/_mapping1_test.py` imported private helpers (`_flatten_in_out_states`, `_remove_axis`, `_get_batch_size`, `_format_state_axes`) from `_mapping1`, but #156 relocated them to `_mapping_core`. This `ImportError` aborted collection of the **entire** suite. Fixed by importing from the new location.

## Validation
- Full suite: **2870 passed, 1 skipped, 0 failed** (~5m47s, JAX 0.10.1).
- `--run-slow` gate verified in both directions; `_testing.py`/`conftest.py` confirmed omitted from coverage.
- Baseline coverage captured: TOTAL 81% (transform 80.6% … util 91%); per-subpackage plans drive each to >=90%.

Coverage is **reported, not gated** at this stage (per the design's report-first approach); the hard >=90% gate lands per subpackage in later PRs.

## Summary by Sourcery

Introduce shared testing infrastructure, coverage configuration, and CI wiring for the brainstate test suite while fixing a blocking transform test import.

New Features:
- Add a shared brainstate._testing module with reusable assertion helpers, size constants, and RNG seeding utilities for tests.
- Add a project-wide pytest configuration and conftest that defines slow-test handling and deterministic seeding for brainstate.random.
- Document testing conventions, helper usage, and coverage expectations in CONTRIBUTING.md.

Bug Fixes:
- Fix transform mapping tests by updating imports to the new helper location, restoring full test suite collection.

Enhancements:
- Configure coverage.py in pyproject.toml to measure branch coverage while omitting test and infrastructure files, and add coverage as a testing dependency.
- Update CI to run tests under the coverage CLI, report coverage (including XML), and run slow tests only on scheduled workflows.
- Add unit tests for the new testing helpers and pytest configuration to ensure they behave as intended.