### PR TITLE
feat(transform): add parallel-in-time associative_scan and linear_recurrence

### DIFF
--- a/brainstate/transform/__init__.py
+++ b/brainstate/transform/__init__.py
@@ -71,6 +71,9 @@ from ._loop_no_collection import (
 from ._loop_collect_return import (
     scan, checkpointed_scan, for_loop, checkpointed_for_loop,
 )
+from ._associative_scan import (
+    associative_scan, linear_recurrence,
+)
 
 # Utilities
 from ._error_if import (
@@ -155,6 +158,8 @@ __all__ = [
     'checkpointed_scan',
     'for_loop',
     'checkpointed_for_loop',
+    'associative_scan',
+    'linear_recurrence',
 
     # Utilities
     'jit_error_if',

--- a/brainstate/transform/_associative_scan.py
+++ b/brainstate/transform/_associative_scan.py
@@ -1,0 +1,135 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import Any, Callable
+
+import jax
+
+from brainstate._utils import set_module_as
+
+__all__ = ['associative_scan', 'linear_recurrence']
+
+
+@set_module_as("brainstate.transform")
+def associative_scan(fn: Callable, elems: Any, reverse: bool = False, axis: int = 0):
+    """Perform a parallel-prefix (associative) scan along an axis.
+
+    A thin, unit- and pytree-aware surface over :func:`jax.lax.associative_scan`.
+    The scan runs in ``O(log n)`` parallel depth (versus ``O(n)`` for a
+    sequential :func:`~brainstate.transform.scan`), provided ``fn`` is
+    associative. brainunit :class:`~brainunit.Quantity` leaves pass through
+    transparently and retain their units.
+
+    Parameters
+    ----------
+    fn : callable
+        A binary associative combine function ``fn(a, b)`` where ``a`` and ``b``
+        are pytrees matching the structure of one slice of ``elems`` along
+        ``axis``. Must be associative for the result to be well-defined.
+    elems : PyTree
+        The input array(s) to scan. May be a single array, a pytree of arrays,
+        or contain ``Quantity`` leaves. All leaves are scanned along ``axis``.
+    reverse : bool, default False
+        If ``True``, perform the scan from the end of ``axis`` to the start.
+    axis : int, default 0
+        The axis along which to scan.
+
+    Returns
+    -------
+    PyTree
+        The scanned result, with the same structure and leading shape as
+        ``elems``.
+
+    See Also
+    --------
+    linear_recurrence, scan
+
+    Notes
+    -----
+    ``fn`` must be associative — ``fn(a, fn(b, c)) == fn(fn(a, b), c)`` — but
+    need not be commutative. Addition, multiplication, and ``max`` are common
+    choices.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax.numpy as jnp
+        >>> xs = jnp.arange(1.0, 6.0)
+        >>> brainstate.transform.associative_scan(lambda a, b: a + b, xs)
+        Array([ 1.,  3.,  6., 10., 15.], dtype=float32)
+    """
+    return jax.lax.associative_scan(fn, elems, reverse=reverse, axis=axis)
+
+
+@set_module_as("brainstate.transform")
+def linear_recurrence(decay: Any, drive: Any, *, reverse: bool = False, axis: int = 0):
+    """Solve a first-order linear recurrence in parallel (log-depth).
+
+    Computes ``h_t = decay_t * h_{t-1} + drive_t`` with ``h_0 = 0`` for every
+    ``t`` along ``axis`` using an associative scan, giving ``O(log n)`` parallel
+    depth instead of the ``O(n)`` of a sequential loop. This is the parallel
+    engine behind linear state-space models (S4/Mamba-style), linear RNNs, and
+    the linear/subthreshold part of neuron dynamics.
+
+    Parameters
+    ----------
+    decay : array or Quantity
+        Per-step multiplicative coefficients ``decay_t``, indexed along
+        ``axis``. Must be dimensionless (it multiplies the running state).
+    drive : array or Quantity
+        Per-step additive input ``drive_t``, indexed along ``axis`` and
+        broadcasting against ``decay``. May carry units; the output inherits
+        them.
+    reverse : bool, default False
+        If ``True``, run the recurrence backwards along ``axis``.
+    axis : int, default 0
+        The time axis of ``decay`` and ``drive``.
+
+    Returns
+    -------
+    array or Quantity
+        The sequence ``h_t`` with the same shape as ``drive`` (and ``drive``'s
+        units, if any).
+
+    See Also
+    --------
+    associative_scan, scan
+
+    Notes
+    -----
+    The associative combine operator is
+    ``(a_l, b_l) • (a_r, b_r) = (a_l * a_r, b_r + a_r * b_l)``; the second
+    component of the inclusive scan equals ``h_t``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax.numpy as jnp
+        >>> decay = jnp.array([0.9, 0.8, 0.7])
+        >>> drive = jnp.array([1.0, 2.0, 3.0])
+        >>> brainstate.transform.linear_recurrence(decay, drive)
+        Array([1.  , 2.8 , 4.96], dtype=float32)
+    """
+    def _op(left, right):
+        a_l, b_l = left
+        a_r, b_r = right
+        return a_l * a_r, b_r + a_r * b_l
+
+    _, h = jax.lax.associative_scan(_op, (decay, drive), reverse=reverse, axis=axis)
+    return h

--- a/brainstate/transform/_associative_scan_test.py
+++ b/brainstate/transform/_associative_scan_test.py
@@ -1,0 +1,112 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import brainunit as u
+
+import brainstate
+
+
+class TestExports(unittest.TestCase):
+    def test_symbols_exist(self):
+        self.assertTrue(callable(brainstate.transform.associative_scan))
+        self.assertTrue(callable(brainstate.transform.linear_recurrence))
+
+
+class TestAssociativeScan(unittest.TestCase):
+    def test_cumsum_matches_jax(self):
+        xs = jnp.arange(1.0, 6.0)
+        out = brainstate.transform.associative_scan(lambda a, b: a + b, xs)
+        ref = jax.lax.associative_scan(lambda a, b: a + b, xs)
+        self.assertTrue(jnp.allclose(out, ref))
+        self.assertTrue(jnp.allclose(out, jnp.cumsum(xs)))
+
+    def test_reverse(self):
+        xs = jnp.arange(1.0, 6.0)
+        out = brainstate.transform.associative_scan(lambda a, b: a + b, xs, reverse=True)
+        ref = jax.lax.associative_scan(lambda a, b: a + b, xs, reverse=True)
+        self.assertTrue(jnp.allclose(out, ref))
+
+    def test_axis(self):
+        xs = jnp.arange(12.0).reshape(3, 4)
+        out = brainstate.transform.associative_scan(lambda a, b: a + b, xs, axis=1)
+        ref = jax.lax.associative_scan(lambda a, b: a + b, xs, axis=1)
+        self.assertTrue(jnp.allclose(out, ref))
+
+    def test_pytree_tuple(self):
+        a = jnp.arange(1.0, 5.0)
+        b = jnp.arange(5.0, 9.0)
+        out = brainstate.transform.associative_scan(
+            lambda l, r: (l[0] + r[0], l[1] + r[1]), (a, b)
+        )
+        self.assertTrue(jnp.allclose(out[0], jnp.cumsum(a)))
+        self.assertTrue(jnp.allclose(out[1], jnp.cumsum(b)))
+
+    def test_quantity_units_preserved(self):
+        q = jnp.arange(1.0, 6.0) * u.mV
+        out = brainstate.transform.associative_scan(lambda a, b: a + b, q)
+        self.assertTrue(isinstance(out, u.Quantity))
+        self.assertEqual(u.get_unit(out), u.get_unit(q))
+        self.assertTrue(jnp.allclose(out.to_decimal(u.mV), jnp.cumsum(jnp.arange(1.0, 6.0))))
+
+
+def _sequential_linrec(decay, drive):
+    # Reference implementation: h_t = decay_t * h_{t-1} + drive_t, h_0 = 0.
+    h = jnp.zeros_like(drive[0])
+    out = []
+    for t in range(drive.shape[0]):
+        h = decay[t] * h + drive[t]
+        out.append(h)
+    return jnp.stack(out)
+
+
+class TestLinearRecurrence(unittest.TestCase):
+    def test_matches_sequential_scalar_series(self):
+        decay = jnp.array([0.9, 0.8, 0.7, 0.5])
+        drive = jnp.array([1.0, 2.0, 3.0, 4.0])
+        out = brainstate.transform.linear_recurrence(decay, drive)
+        ref = _sequential_linrec(decay, drive)
+        self.assertTrue(jnp.allclose(out, ref))
+
+    def test_matches_sequential_vector_series(self):
+        # Time axis = 0, feature dim = 3.
+        decay = jnp.array([[0.9, 0.5, 0.1]] * 5)
+        drive = jnp.arange(15.0).reshape(5, 3)
+        out = brainstate.transform.linear_recurrence(decay, drive)
+        ref = _sequential_linrec(decay, drive)
+        self.assertTrue(jnp.allclose(out, ref))
+
+    def test_under_jit(self):
+        decay = jnp.array([0.9, 0.8, 0.7, 0.5])
+        drive = jnp.array([1.0, 2.0, 3.0, 4.0])
+        out = jax.jit(brainstate.transform.linear_recurrence)(decay, drive)
+        ref = _sequential_linrec(decay, drive)
+        self.assertTrue(jnp.allclose(out, ref))
+
+    def test_units(self):
+        decay = jnp.array([0.9, 0.8, 0.7])             # dimensionless multiplier
+        drive = jnp.array([1.0, 2.0, 3.0]) * u.mV       # carries voltage units
+        out = brainstate.transform.linear_recurrence(decay, drive)
+        self.assertTrue(isinstance(out, u.Quantity))
+        self.assertEqual(u.get_unit(out), u.mV)
+        ref = _sequential_linrec(decay, drive.to_decimal(u.mV))
+        self.assertTrue(jnp.allclose(out.to_decimal(u.mV), ref))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add brainstate.transform.associative_scan, a unit- and pytree-aware surface
over jax.lax.associative_scan (brainunit Quantity leaves pass through and keep
their units), and brainstate.transform.linear_recurrence, a log-depth parallel
solver for first-order linear recurrences h_t = decay_t * h_{t-1} + drive_t
built on the associative combine operator (a_l*a_r, b_r + a_r*b_l). Enables
O(log n) parallelization of SSM / linear-RNN / linear-neuron dynamics.

## Summary by Sourcery

Add parallel, unit-aware scan utilities and a linear recurrence solver to brainstate.transform.

New Features:
- Introduce brainstate.transform.associative_scan as a pytree- and unit-aware wrapper over JAX's associative_scan.
- Add brainstate.transform.linear_recurrence to solve first-order linear recurrences in parallel using an associative scan backend.

Tests:
- Add unit tests validating associative_scan behavior (including reverse, axis, pytrees, and unit preservation) against JAX and cumsum.
- Add unit tests verifying linear_recurrence matches a sequential implementation, works under jit, and preserves physical units.