### PR TITLE
Add state-aware shard_map transform

### DIFF
--- a/brainstate/transform/__init__.py
+++ b/brainstate/transform/__init__.py
@@ -46,6 +46,9 @@ from ._mapping1 import (
 from ._mapping2 import (
     StatefulMapping, vmap2, pmap2, map, vmap2_new_states, pmap2_new_states,
 )
+from ._shard_map import (
+    shard_map,
+)
 
 # Gradient transformations
 from ._grad_grad import (
@@ -136,6 +139,7 @@ __all__ = [
     'pmap2',
     'pmap2_new_states',
     'map',
+    'shard_map',
 
     # Gradient transformations
     'vector_grad',

--- a/brainstate/transform/_shard_map.py
+++ b/brainstate/transform/_shard_map.py
@@ -1,0 +1,198 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import inspect
+from functools import wraps
+from typing import Callable, Dict, Optional, Union
+
+import jax
+from jax.sharding import NamedSharding, PartitionSpec
+
+from brainstate._state import State
+from brainstate._utils import set_module_as
+from ._make_jaxpr import StatefulFunction
+
+__all__ = ['shard_map']
+
+# Resolve jax.shard_map across versions: it was promoted to the top level in
+# JAX 0.8.0 (with the ``check_vma`` flag); older releases (0.6.x/0.7.x) expose
+# it as ``jax.experimental.shard_map.shard_map`` with a ``check_rep`` flag.
+_jax_shard_map = getattr(jax, 'shard_map', None)
+if _jax_shard_map is None:  # pragma: no cover - depends on installed jax
+    from jax.experimental.shard_map import shard_map as _jax_shard_map
+_shard_map_params = set(inspect.signature(_jax_shard_map).parameters)
+if 'check_vma' in _shard_map_params:
+    _CHECK_KW = 'check_vma'
+elif 'check_rep' in _shard_map_params:
+    _CHECK_KW = 'check_rep'
+else:  # pragma: no cover - unexpected jax signature
+    _CHECK_KW = None
+
+
+def _prep_spec_table(table):
+    """Pre-key a {State: PartitionSpec} table by id; pass through None / single spec."""
+    if isinstance(table, dict):
+        return {id(k): v for k, v in table.items()}
+    return table
+
+
+def _resolve_state_spec(state: State, table) -> PartitionSpec:
+    """Resolve the PartitionSpec for a state: replicate by default."""
+    if table is None:
+        return PartitionSpec()
+    if isinstance(table, dict):
+        return table.get(id(state), PartitionSpec())
+    return table  # a single PartitionSpec applied to all states
+
+
+@set_module_as("brainstate.transform")
+def shard_map(
+    fun: Callable,
+    mesh,
+    in_specs,
+    out_specs,
+    *,
+    state_in_specs: Optional[Union[PartitionSpec, Dict[State, PartitionSpec]]] = None,
+    state_out_specs: Optional[Union[PartitionSpec, Dict[State, PartitionSpec]]] = None,
+    check_vma: bool = True,
+):
+    """Map a stateful function over shards of data across a device mesh (SPMD).
+
+    A state-aware wrapper over :func:`jax.shard_map`. The function's
+    :class:`~brainstate.State` objects are sharded or replicated across ``mesh``
+    according to ``state_in_specs``/``state_out_specs`` (replicated by default),
+    while positional arguments are sharded per ``in_specs``. Inputs are placed on
+    the mesh automatically (via :func:`jax.device_put`), so the wrapper works
+    both eagerly and under :func:`jit`.
+
+    Parameters
+    ----------
+    fun : callable
+        The function to shard. May read and write ``State`` objects. Keyword
+        arguments are broadcast (closed over), not sharded.
+    mesh : jax.sharding.Mesh
+        The device mesh, e.g. ``jax.make_mesh((4,), ('x',))``.
+    in_specs : PartitionSpec or tuple of PartitionSpec
+        Sharding spec for each positional argument. A tuple must match the
+        number of positional arguments; a single spec is applied to all.
+    out_specs : PartitionSpec or PyTree of PartitionSpec
+        Sharding spec for the function's output.
+    state_in_specs : PartitionSpec or dict of {State: PartitionSpec}, optional
+        Input sharding for states. A single spec applies to all states; a dict
+        maps specific states. States not covered are replicated (``PartitionSpec()``).
+    state_out_specs : PartitionSpec or dict of {State: PartitionSpec}, optional
+        Output sharding for written states. Same conventions as
+        ``state_in_specs``.
+    check_vma : bool, default True
+        Forwarded to :func:`jax.shard_map` (varying-manual-axes checking).
+
+    Returns
+    -------
+    callable
+        A function with the same positional signature as ``fun`` that executes
+        under SPMD sharding and applies state writes.
+
+    See Also
+    --------
+    jax.shard_map, vmap, pmap
+
+    Notes
+    -----
+    ``jax.shard_map`` traces ``fun`` at per-shard shapes, so the wrapper re-runs
+    ``fun`` (rather than replaying a global jaxpr): it discovers the touched
+    states once via :class:`StatefulFunction`, injects per-shard values with
+    ``State.restore_value``, runs ``fun``, and restores every state afterward
+    (writes to their new values, reads to their originals).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax, jax.numpy as jnp
+        >>> from jax.sharding import PartitionSpec as P
+        >>>
+        >>> mesh = jax.make_mesh((jax.device_count(),), ('x',))
+        >>> w = brainstate.State(jnp.array(3.0))
+        >>> def fun(data):
+        ...     return data * w.value
+        >>> f = brainstate.transform.shard_map(fun, mesh, in_specs=(P('x'),), out_specs=P('x'))
+        >>> f(jnp.arange(jax.device_count() * 2, dtype=jnp.float32))  # doctest: +SKIP
+    """
+    arg_specs = tuple(in_specs) if isinstance(in_specs, (tuple, list)) else None
+    sin = _prep_spec_table(state_in_specs)
+    sout = _prep_spec_table(state_out_specs)
+
+    @wraps(fun)
+    def wrapped(*args, **kwargs):
+        # 1. Discover the states the function touches (shape-independent).
+        sf = StatefulFunction(fun, name='shard_map')
+        sf.make_jaxpr(*args, **kwargs)
+        cache = sf.get_arg_cache_key(*args, **kwargs)
+        trace = sf.get_state_trace_by_cache(cache)
+        all_states = tuple(trace.states)
+        write_states = tuple(sf.get_write_states(*args, **kwargs))
+
+        # 2. Resolve per-argument and per-state specs.
+        if arg_specs is None:
+            local_arg_specs = tuple(in_specs for _ in args)
+        else:
+            if len(arg_specs) != len(args):
+                raise ValueError(
+                    f"in_specs has {len(arg_specs)} entries but {len(args)} "
+                    "positional arguments were given."
+                )
+            local_arg_specs = arg_specs
+        in_state_specs = tuple(_resolve_state_spec(s, sin) for s in all_states)
+        out_state_specs = tuple(_resolve_state_spec(s, sout) for s in write_states)
+        orig_vals = tuple(s.value for s in all_states)
+
+        # 3. Build the re-runnable pure function (trace fresh at shard shapes).
+        def pure(state_vals, mapped_args):
+            for st, v in zip(all_states, state_vals):
+                st.restore_value(v)
+            out = fun(*mapped_args, **kwargs)
+            return out, tuple(st.value for st in write_states)
+
+        # 4. Place inputs on the mesh per their specs (required: no auto-reshard).
+        in_state_vals = tuple(
+            jax.device_put(v, NamedSharding(mesh, sp))
+            for v, sp in zip(orig_vals, in_state_specs)
+        )
+        sharded_args = tuple(
+            jax.device_put(a, NamedSharding(mesh, sp))
+            for a, sp in zip(args, local_arg_specs)
+        )
+
+        # 5. Run under jax.shard_map (flag name varies across jax versions).
+        sm_kwargs = dict(
+            mesh=mesh,
+            in_specs=(in_state_specs, local_arg_specs),
+            out_specs=(out_specs, out_state_specs),
+        )
+        if _CHECK_KW is not None:
+            sm_kwargs[_CHECK_KW] = check_vma
+        sharded = _jax_shard_map(pure, **sm_kwargs)
+        out, write_vals = sharded(in_state_vals, sharded_args)
+
+        # 6. Restore ALL states: writes -> new values, reads -> originals
+        #    (prevents shard tracers from leaking into global State objects).
+        wv_by_id = {id(s): v for s, v in zip(write_states, write_vals)}
+        for st, ov in zip(all_states, orig_vals):
+            st.restore_value(wv_by_id[id(st)] if id(st) in wv_by_id else ov)
+
+        return out
+
+    return wrapped

--- a/brainstate/transform/_shard_map_test.py
+++ b/brainstate/transform/_shard_map_test.py
@@ -1,0 +1,111 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+# Fake multiple CPU devices when this module is imported before JAX initializes.
+os.environ.setdefault('XLA_FLAGS', '--xla_force_host_platform_device_count=4')
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+
+import brainstate
+
+
+class TestExports(unittest.TestCase):
+    def test_symbol_exists(self):
+        self.assertTrue(callable(brainstate.transform.shard_map))
+
+
+class TestShardMap(unittest.TestCase):
+    def setUp(self):
+        self.n = jax.device_count()
+        self.mesh = jax.make_mesh((self.n,), ('x',))
+
+    def test_sharded_data_replicated_state(self):
+        w = brainstate.State(jnp.array(3.0))               # replicated scalar
+        out_state = brainstate.State(jnp.zeros(self.n * 2))  # sharded write state
+
+        def fun(data):
+            out_state.value = data * w.value
+            return out_state.value
+
+        f = brainstate.transform.shard_map(
+            fun, self.mesh, in_specs=(P('x'),), out_specs=P('x'),
+            state_out_specs=P('x'),
+        )
+        data = jnp.arange(self.n * 2, dtype=jnp.float32)
+        out = f(data)
+        self.assertTrue(jnp.allclose(out, data * 3.0))
+        self.assertTrue(jnp.allclose(out_state.value, data * 3.0))
+        self.assertTrue(jnp.allclose(w.value, 3.0))  # replicated read state unchanged
+
+    def test_no_state_function(self):
+        def fun(data):
+            return data + 1.0
+
+        f = brainstate.transform.shard_map(
+            fun, self.mesh, in_specs=(P('x'),), out_specs=P('x'),
+        )
+        data = jnp.arange(self.n * 2, dtype=jnp.float32)
+        self.assertTrue(jnp.allclose(f(data), data + 1.0))
+
+    def test_repeatable_no_tracer_leak(self):
+        w = brainstate.State(jnp.array(2.0))
+
+        def fun(data):
+            return data * w.value
+
+        f = brainstate.transform.shard_map(
+            fun, self.mesh, in_specs=(P('x'),), out_specs=P('x'),
+        )
+        d1 = jnp.arange(self.n * 2, dtype=jnp.float32)
+        out1 = f(d1)
+        self.assertTrue(jnp.allclose(out1, d1 * 2.0))
+        # Second call must not see a leaked tracer in w.
+        d2 = jnp.ones(self.n * 2)
+        out2 = f(d2)
+        self.assertTrue(jnp.allclose(out2, d2 * 2.0))
+        self.assertTrue(jnp.allclose(w.value, 2.0))
+
+    def test_under_jit(self):
+        w = brainstate.State(jnp.array(5.0))
+
+        def fun(data):
+            return data * w.value
+
+        f = brainstate.transform.shard_map(
+            fun, self.mesh, in_specs=(P('x'),), out_specs=P('x'),
+        )
+        data = jnp.arange(self.n * 2, dtype=jnp.float32)
+        out = jax.jit(f)(data)
+        self.assertTrue(jnp.allclose(out, data * 5.0))
+
+    def test_in_specs_length_mismatch_raises(self):
+        def fun(a, b):
+            return a + b
+
+        f = brainstate.transform.shard_map(
+            fun, self.mesh, in_specs=(P('x'),), out_specs=P('x'),  # only 1 spec for 2 args
+        )
+        d = jnp.arange(self.n * 2, dtype=jnp.float32)
+        with self.assertRaises(ValueError):
+            f(d, d)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary by Sourcery

Introduce a state-aware shard_map transform that integrates brainstate.State with JAX shard_map for SPMD execution.

New Features:
- Add a shard_map transform that maps stateful functions over device meshes with configurable sharding for states and arguments.

Tests:
- Add unit tests covering shard_map behavior with replicated and sharded state, pure functions, JIT usage, and error handling for spec mismatches.