### PR TITLE
Add state-aware pure_callback and io_callback transforms

### DIFF
--- a/brainstate/transform/__init__.py
+++ b/brainstate/transform/__init__.py
@@ -85,6 +85,9 @@ from ._associative_scan import (
 from ._error_if import (
     jit_error_if,
 )
+from ._callback import (
+    pure_callback, io_callback,
+)
 from ._find_state import (
     StateFinder,
 )
@@ -172,6 +175,8 @@ __all__ = [
 
     # Utilities
     'jit_error_if',
+    'pure_callback',
+    'io_callback',
     'StateFinder',
     'ProgressBar',
     'unvmap',

--- a/brainstate/transform/_callback.py
+++ b/brainstate/transform/_callback.py
@@ -1,0 +1,211 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import Any, Callable, Optional, Sequence, Union
+
+import jax
+from jax.experimental import io_callback as _jax_io_callback
+
+from brainstate._state import State
+from brainstate._utils import set_module_as
+
+__all__ = ['pure_callback', 'io_callback']
+
+
+def _as_state_tuple(states) -> tuple:
+    """Normalize None / a single State / a sequence of States to a tuple of States."""
+    if states is None:
+        return ()
+    if isinstance(states, State):
+        return (states,)
+    states = tuple(states)
+    if any(not isinstance(s, State) for s in states):
+        raise TypeError("read_states/write_states must be State instances.")
+    return states
+
+
+@set_module_as("brainstate.transform")
+def pure_callback(
+    callback: Callable,
+    result_shape_dtypes: Any,
+    *args,
+    read_states: Optional[Union[State, Sequence[State]]] = None,
+    sharding=None,
+    vmap_method: Optional[str] = None,
+):
+    """Call a pure host-Python function from inside transformed code.
+
+    A state-aware wrapper over :func:`jax.pure_callback`. The values of any
+    ``read_states`` are read at call time and appended to ``callback``'s
+    positional arguments, so host code can use current ``State`` values. The
+    callback must be pure (no side effects, same output for same input).
+
+    Parameters
+    ----------
+    callback : callable
+        Host-side function invoked as ``callback(*args, *read_state_values)``.
+        Must return arrays matching ``result_shape_dtypes``.
+    result_shape_dtypes : PyTree of jax.ShapeDtypeStruct
+        The shape/dtype structure of ``callback``'s return value.
+    *args
+        Positional arguments (traced arrays) passed to ``callback``.
+    read_states : State or sequence of State, optional
+        States whose current ``.value`` is appended (in order) to ``callback``'s
+        arguments.
+    sharding : jax.sharding.Sharding, optional
+        Optional output sharding, forwarded to :func:`jax.pure_callback`.
+    vmap_method : str, optional
+        How the callback behaves under :func:`vmap`, forwarded to
+        :func:`jax.pure_callback`.
+
+    Returns
+    -------
+    PyTree
+        The callback's result, matching ``result_shape_dtypes``.
+
+    See Also
+    --------
+    io_callback
+
+    Notes
+    -----
+    Because the callback must be pure, the compiler may deduplicate or drop it;
+    use :func:`io_callback` for side effects or for writing back into states.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax, jax.numpy as jnp
+        >>> import numpy as np
+        >>> w = brainstate.State(jnp.array([2.0, 3.0]))
+        >>> def host(x, w_val):
+        ...     return np.asarray(x) * np.asarray(w_val)
+        >>> x = jnp.array([5.0, 7.0])
+        >>> spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        >>> brainstate.transform.pure_callback(host, spec, x, read_states=w)
+        Array([10., 21.], dtype=float32)
+    """
+    states = _as_state_tuple(read_states)
+    if states:
+        state_vals = tuple(s.value for s in states)
+
+        def _wrapped(cb_args, cb_state_vals):
+            return callback(*cb_args, *cb_state_vals)
+
+        return jax.pure_callback(
+            _wrapped, result_shape_dtypes, args, state_vals,
+            sharding=sharding, vmap_method=vmap_method,
+        )
+    return jax.pure_callback(
+        callback, result_shape_dtypes, *args,
+        sharding=sharding, vmap_method=vmap_method,
+    )
+
+
+@set_module_as("brainstate.transform")
+def io_callback(
+    callback: Callable,
+    result_shape_dtypes: Any,
+    *args,
+    read_states: Optional[Union[State, Sequence[State]]] = None,
+    write_states: Optional[Union[State, Sequence[State]]] = None,
+    sharding=None,
+    ordered: bool = True,
+):
+    """Call a side-effecting host-Python function from inside transformed code.
+
+    A state-aware wrapper over :func:`jax.experimental.io_callback`. The values
+    of ``read_states`` are appended to ``callback``'s arguments, and the
+    callback's result is optionally written back into ``write_states``. Useful
+    for external (non-JAX) solvers, host-side data, and in-loop logging.
+
+    Parameters
+    ----------
+    callback : callable
+        Host-side function invoked as ``callback(*args, *read_state_values)``.
+        Must return arrays matching ``result_shape_dtypes``.
+    result_shape_dtypes : PyTree of jax.ShapeDtypeStruct
+        The shape/dtype structure of ``callback``'s return value. When
+        ``write_states`` is a sequence, this must be a matching sequence.
+    *args
+        Positional arguments (traced arrays) passed to ``callback``.
+    read_states : State or sequence of State, optional
+        States whose current ``.value`` is appended (in order) to ``callback``'s
+        arguments.
+    write_states : State or sequence of State, optional
+        States to overwrite with the callback's result. A single ``State`` is
+        assigned the whole result; a sequence is assigned element-by-element
+        from a result sequence of the same length.
+    sharding : jax.sharding.Sharding, optional
+        Optional output sharding, forwarded to the JAX callback.
+    ordered : bool, default True
+        If ``True``, the callbacks are executed in program order (recommended
+        when the callback has side effects or writes state).
+
+    Returns
+    -------
+    PyTree
+        The callback's result, matching ``result_shape_dtypes``.
+
+    See Also
+    --------
+    pure_callback
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax, jax.numpy as jnp
+        >>> import numpy as np
+        >>> state = brainstate.State(jnp.array([0.0, 0.0]))
+        >>> def host(x):
+        ...     return np.asarray(x) + 1.0
+        >>> x = jnp.array([1.0, 2.0])
+        >>> spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        >>> out = brainstate.transform.io_callback(host, spec, x, write_states=state)
+        >>> state.value
+        Array([2., 3.], dtype=float32)
+    """
+    in_states = _as_state_tuple(read_states)
+    if in_states:
+        in_vals = tuple(s.value for s in in_states)
+
+        def _wrapped(cb_args, cb_state_vals):
+            return callback(*cb_args, *cb_state_vals)
+
+        result = _jax_io_callback(
+            _wrapped, result_shape_dtypes, args, in_vals,
+            sharding=sharding, ordered=ordered,
+        )
+    else:
+        result = _jax_io_callback(
+            callback, result_shape_dtypes, *args,
+            sharding=sharding, ordered=ordered,
+        )
+
+    # Optional write-back into states.
+    if write_states is not None:
+        if isinstance(write_states, State):
+            write_states.value = result
+        else:
+            for st, val in zip(tuple(write_states), result):
+                if not isinstance(st, State):
+                    raise TypeError("write_states must be State instances.")
+                st.value = val
+
+    return result

--- a/brainstate/transform/_callback_test.py
+++ b/brainstate/transform/_callback_test.py
@@ -1,0 +1,129 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import brainstate
+
+
+class TestExports(unittest.TestCase):
+    def test_symbols_exist(self):
+        self.assertTrue(callable(brainstate.transform.pure_callback))
+        self.assertTrue(callable(brainstate.transform.io_callback))
+
+
+class TestPureCallback(unittest.TestCase):
+    def test_basic(self):
+        def host_fn(x):
+            return np.sin(np.asarray(x))
+
+        x = jnp.array([0.0, np.pi / 2])
+        spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        out = brainstate.transform.pure_callback(host_fn, spec, x)
+        self.assertTrue(jnp.allclose(out, jnp.sin(x)))
+
+    def test_read_states(self):
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        def host_fn(x, w_val):
+            return np.asarray(x) * np.asarray(w_val)
+
+        x = jnp.array([5.0, 7.0])
+        spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        out = brainstate.transform.pure_callback(host_fn, spec, x, read_states=w)
+        self.assertTrue(jnp.allclose(out, x * w.value))
+
+    def test_under_jit(self):
+        def host_fn(x):
+            return np.asarray(x) ** 2
+
+        @jax.jit
+        def f(x):
+            spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+            return brainstate.transform.pure_callback(host_fn, spec, x)
+
+        x = jnp.array([1.0, 2.0, 3.0])
+        self.assertTrue(jnp.allclose(f(x), x ** 2))
+
+
+class TestIoCallback(unittest.TestCase):
+    def test_basic_return(self):
+        def host_fn(x):
+            return np.asarray(x) + 1.0
+
+        x = jnp.array([1.0, 2.0])
+        spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        out = brainstate.transform.io_callback(host_fn, spec, x)
+        self.assertTrue(jnp.allclose(out, x + 1.0))
+
+    def test_read_states(self):
+        bias = brainstate.State(jnp.array([10.0, 20.0]))
+
+        def host_fn(x, b):
+            return np.asarray(x) + np.asarray(b)
+
+        x = jnp.array([1.0, 2.0])
+        spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        out = brainstate.transform.io_callback(host_fn, spec, x, read_states=bias)
+        self.assertTrue(jnp.allclose(out, x + bias.value))
+
+    def test_writeback_single_state(self):
+        state = brainstate.State(jnp.array([0.0, 0.0]))
+
+        def host_fn(x):
+            return np.asarray(x) + 1.0
+
+        x = jnp.array([1.0, 2.0])
+        spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        out = brainstate.transform.io_callback(host_fn, spec, x, write_states=state)
+        self.assertTrue(jnp.allclose(out, x + 1.0))
+        self.assertTrue(jnp.allclose(state.value, x + 1.0))
+
+    def test_writeback_multiple_states(self):
+        s1 = brainstate.State(jnp.array(0.0))
+        s2 = brainstate.State(jnp.array(0.0))
+
+        def host_fn(x):
+            xv = np.asarray(x)
+            return (xv + 1.0, xv + 2.0)
+
+        x = jnp.array(5.0)
+        specs = (jax.ShapeDtypeStruct((), x.dtype), jax.ShapeDtypeStruct((), x.dtype))
+        out = brainstate.transform.io_callback(host_fn, specs, x, write_states=[s1, s2])
+        self.assertTrue(jnp.allclose(s1.value, 6.0))
+        self.assertTrue(jnp.allclose(s2.value, 7.0))
+
+    def test_ordered_side_effect_under_jit(self):
+        log = []
+
+        def host_fn(x):
+            log.append(float(np.asarray(x)))
+            return np.asarray(x)
+
+        @jax.jit
+        def f(x):
+            spec = jax.ShapeDtypeStruct((), x.dtype)
+            return brainstate.transform.io_callback(host_fn, spec, x)
+
+        f(jnp.array(3.0))
+        self.assertEqual(log, [3.0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary by Sourcery

Add state-aware host callback utilities integrating JAX callbacks with Brainstate State objects.

New Features:
- Expose pure_callback and io_callback utilities from the brainstate.transform module to call host-side functions from transformed code while accessing State values.

Enhancements:
- Implement state-aware wrappers around jax.pure_callback and jax.experimental.io_callback that support reading from and writing to State instances, including ordered side-effecting callbacks under JIT.

Tests:
- Add unit tests covering basic behavior, state reading and writing, and JIT/ordered side-effect semantics for pure_callback and io_callback.