### PR TITLE
Add comprehensive graph-subpackage tests (77%->95%) + fix copy.deepcopy on nodes

### DIFF
--- a/brainstate/graph/_context_test.py
+++ b/brainstate/graph/_context_test.py
@@ -15,6 +15,8 @@
 
 from __future__ import annotations
 
+import jax.numpy as jnp
+
 import brainstate
 from absl.testing import absltest
 
@@ -66,6 +68,39 @@ class TestGraphUtils(absltest.TestCase):
 
         self.assertIs(m2, m1.layers[0])
         self.assertFalse(hasattr(ctx, 'index_ref'))
+
+
+class TestSplitMergeContextIdentity(absltest.TestCase):
+    """``treefy_split`` / ``treefy_merge`` preserve shared-node identity."""
+
+    def test_merge_restores_shared_state_identity(self):
+        """A state shared across slots remains aliased through split + merge."""
+        shared = brainstate.ParamState(jnp.ones((2,)))
+        g = {"a": shared, "b": shared}
+        graphdef, refs = brainstate.graph.treefy_split(g)
+        rebuilt = brainstate.graph.treefy_merge(graphdef, refs)
+        self.assertIs(rebuilt["a"], rebuilt["b"])
+
+    def test_split_then_merge_value_roundtrip(self):
+        """``treefy_split`` / ``treefy_merge`` round-trips values and statics."""
+        g = [brainstate.ParamState(jnp.arange(3.0)), 7, brainstate.ParamState(jnp.zeros((2,)))]
+        graphdef, refs = brainstate.graph.treefy_split(g)
+        rebuilt = brainstate.graph.treefy_merge(graphdef, refs)
+        self.assertTrue(bool(jnp.allclose(rebuilt[0].value, jnp.arange(3.0))))
+        self.assertEqual(rebuilt[1], 7)
+        self.assertTrue(bool(jnp.allclose(rebuilt[2].value, jnp.zeros((2,)))))
+
+    def test_context_managers_clean_up_state(self):
+        """The context managers tear down their thread-local reference tables."""
+        from brainstate.graph._context import split_context, merge_context
+
+        with split_context() as (ctx, index_ref):
+            self.assertIsNotNone(ctx)
+        self.assertFalse(hasattr(ctx, 'ref_index'))
+
+        with merge_context() as (mctx, idx):
+            self.assertIsNotNone(mctx)
+        self.assertFalse(hasattr(mctx, 'index_ref'))
 
 
 if __name__ == '__main__':

--- a/brainstate/graph/_convert_test.py
+++ b/brainstate/graph/_convert_test.py
@@ -1,0 +1,190 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for ``brainstate.graph`` graph<->pytree conversion utilities.
+
+Exercises :func:`graph_to_tree` / :func:`tree_to_graph` round-trips, the
+:class:`NodeStates` pytree wrapper, shared-reference aliasing (consistent,
+inconsistent, and disabled), ``map_non_graph_nodes``, and integration with a
+JAX transform.
+"""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+
+import brainstate
+from brainstate.graph import graph_to_tree, tree_to_graph, NodeStates
+from brainstate.graph import _convert
+
+
+class _Linear(brainstate.graph.Node):
+    """A tiny graph node holding two parameter states."""
+
+    def __init__(self, din, dout):
+        self.w = brainstate.ParamState(jnp.ones((din, dout)))
+        self.b = brainstate.ParamState(jnp.zeros((dout,)))
+
+
+class TestGraphToTreeRoundtrip(unittest.TestCase):
+    """``graph_to_tree`` then ``tree_to_graph`` reconstructs node values."""
+
+    def test_basic_roundtrip(self):
+        """A single node round-trips by parameter value and type."""
+        node = _Linear(2, 3)
+        tree, found_states = graph_to_tree(node)
+        rebuilt = tree_to_graph(tree)
+        self.assertIsInstance(rebuilt, _Linear)
+        self.assertTrue(bool(jnp.allclose(rebuilt.w.value, node.w.value)))
+        self.assertTrue(bool(jnp.allclose(rebuilt.b.value, node.b.value)))
+
+    def test_find_states_returned(self):
+        """``graph_to_tree`` returns a mapping of discovered states."""
+        node = _Linear(2, 3)
+        _, found_states = graph_to_tree(node)
+        # At least the two ParamStates should be discoverable.
+        self.assertGreaterEqual(len(jax.tree.leaves(found_states)), 2)
+
+    def test_tree_is_pure_pytree(self):
+        """``graph_to_tree`` output flattens to array leaves via ``jax.tree``."""
+        node = _Linear(2, 3)
+        tree, _ = graph_to_tree(node)
+        leaves = jax.tree.leaves(tree)
+        self.assertGreaterEqual(len(leaves), 2)
+        self.assertTrue(all(hasattr(x, "shape") for x in leaves))
+
+    def test_nodestates_is_pytree(self):
+        """The packed tree re-flattens/unflattens to the same structure."""
+        node = _Linear(2, 3)
+        tree, _ = graph_to_tree(node)
+        flat, treedef = jax.tree.flatten(tree)
+        rebuilt_tree = jax.tree.unflatten(treedef, flat)
+        self.assertEqual(jax.tree.structure(tree), jax.tree.structure(rebuilt_tree))
+
+    def test_shared_state_aliasing_preserved(self):
+        """A state shared in two slots stays a single object after round-trip."""
+        shared = brainstate.ParamState(jnp.ones((2,)))
+        g = {"a": shared, "b": shared}
+        tree, _ = graph_to_tree(g)
+        rebuilt = tree_to_graph(tree)
+        self.assertIs(rebuilt["a"], rebuilt["b"])
+
+    def test_map_non_graph_nodes_custom_fns(self):
+        """``map_non_graph_nodes=True`` routes plain leaves through custom fns.
+
+        The default ``split_fn`` only understands graph nodes, so exercising the
+        non-graph-leaf branch requires a custom ``split_fn`` / ``merge_fn`` pair.
+        """
+        g = {"x": jnp.zeros((3,))}
+        tree, _ = graph_to_tree(
+            g, map_non_graph_nodes=True,
+            split_fn=lambda ctx, path, prefix, leaf: leaf + 1.0,
+        )
+        self.assertTrue(bool(jnp.allclose(tree["x"], jnp.ones((3,)))))
+        back = tree_to_graph(
+            tree, map_non_graph_nodes=True,
+            merge_fn=lambda ctx, path, prefix, leaf: leaf - 1.0,
+        )
+        self.assertTrue(bool(jnp.allclose(back["x"], jnp.zeros((3,)))))
+
+    def test_roundtrip_usable_in_jit(self):
+        """The pure pytree from ``graph_to_tree`` flows through ``jit``."""
+        node = _Linear(2, 3)
+        tree, _ = graph_to_tree(node)
+
+        @brainstate.transform.jit
+        def double(t):
+            return jax.tree.map(lambda x: x * 2, t)
+
+        out = double(tree)
+        self.assertEqual(jax.tree.structure(out), jax.tree.structure(tree))
+
+
+class TestNodeStates(unittest.TestCase):
+    """The :class:`NodeStates` pytree wrapper and its constructors/properties."""
+
+    def test_from_split_exposes_graphdef_and_state(self):
+        """``from_split`` packs a graphdef plus exactly one state mapping."""
+        node = _Linear(2, 3)
+        graphdef, state = brainstate.graph.treefy_split(node)
+        ns = NodeStates.from_split(graphdef, state)
+        self.assertIs(ns.graphdef, graphdef)
+        self.assertIs(ns.state, state)
+        self.assertEqual(len(ns.states), 1)
+
+    def test_graphdef_property_raises_without_graphdef(self):
+        """Accessing ``graphdef`` when none was packed raises ``ValueError``."""
+        node = _Linear(2, 3)
+        _, state = brainstate.graph.treefy_split(node)
+        ns = NodeStates.from_states(state)
+        with self.assertRaises(ValueError):
+            _ = ns.graphdef
+
+    def test_state_property_requires_exactly_one(self):
+        """``state`` raises when there is not exactly one state mapping."""
+        node = _Linear(2, 3)
+        _, state = brainstate.graph.treefy_split(node)
+        ns = NodeStates.from_states(state, state)
+        with self.assertRaises(ValueError):
+            _ = ns.state
+
+    def test_from_prefixes(self):
+        """``from_prefixes`` stores the given prefixes as the state tuple."""
+        ns = NodeStates.from_prefixes([1, 2, 3], metadata="m")
+        self.assertEqual(ns.states, (1, 2, 3))
+        self.assertEqual(ns.metadata, "m")
+
+
+class TestAliasingChecks(unittest.TestCase):
+    """``check_consistent_aliasing`` accepts consistent and rejects conflicting refs."""
+
+    def test_consistent_shared_node_ok(self):
+        """A consistently-prefixed shared node does not raise."""
+        shared = _Linear(2, 3)
+        graph_to_tree([shared, shared], prefix=0)  # should not raise
+
+    def test_inconsistent_shared_node_raises(self):
+        """A shared node with conflicting prefixes raises ``ValueError``."""
+        shared = _Linear(2, 3)
+        with self.assertRaises(ValueError):
+            graph_to_tree([shared, shared], prefix=[0, 1])
+
+    def test_check_aliasing_can_be_disabled(self):
+        """``check_aliasing=False`` skips the consistency check."""
+        shared = _Linear(2, 3)
+        tree, _ = graph_to_tree([shared, shared], prefix=[0, 1], check_aliasing=False)
+        self.assertIsNotNone(tree)
+
+
+class TestConvertHelpers(unittest.TestCase):
+    """Internal helpers used by the conversion routines."""
+
+    def test_broadcast_prefix_replicates_over_leaves(self):
+        """A scalar prefix is broadcast to one entry per full-tree leaf."""
+        out = _convert.broadcast_prefix(7, {"a": 1, "b": 2, "c": 3})
+        self.assertEqual(out, [7, 7, 7])
+
+    def test_get_rand_state_returns_random_state_class(self):
+        """``_get_rand_state`` lazily imports and caches ``RandomState``."""
+        cls = _convert._get_rand_state()
+        from brainstate.random import RandomState
+        self.assertIs(cls, RandomState)
+        # Second call returns the cached class.
+        self.assertIs(_convert._get_rand_state(), RandomState)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/brainstate/graph/_flatten_test.py
+++ b/brainstate/graph/_flatten_test.py
@@ -1,0 +1,215 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the low-level ``flatten`` / ``unflatten`` encode-decode routines.
+
+Covers the encoder's State / bare-``TreefyState`` / static-attribute edges, the
+non-node-root error, and the decoder's ``index_ref_cache`` "update in place"
+path (state refresh, shell reuse, and type-mismatch detection).
+"""
+
+import unittest
+
+import jax.numpy as jnp
+
+import brainstate
+from brainstate.graph import flatten, unflatten, GraphDef
+from brainstate.graph import _flatten
+from brainstate._state import TreefyState
+
+
+class _Cell(brainstate.graph.Node):
+    """A graph node with a parameter state and a static attribute."""
+
+    def __init__(self, n=2, tag="cell"):
+        self.w = brainstate.ParamState(jnp.ones((n,)))
+        self.tag = tag  # static (inline) attribute
+
+
+class TestFlattenEncode(unittest.TestCase):
+    """Encoder edge cases for ``flatten``."""
+
+    def test_basic_flatten_returns_graphdef_and_nesteddict(self):
+        """``flatten`` returns a ``GraphDef`` plus a ``NestedDict`` state."""
+        gd, state = flatten(_Cell())
+        self.assertIsInstance(gd, GraphDef)
+        self.assertIsInstance(state, brainstate.util.NestedDict)
+
+    def test_flatten_non_node_root_raises(self):
+        """Flattening a bare ``State`` (not a node/pytree) raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            flatten(brainstate.ParamState(jnp.ones((2,))))
+
+    def test_flatten_bad_ref_index_type_raises(self):
+        """A non-``RefMap`` ``ref_index`` raises ``TypeError``."""
+        with self.assertRaises(TypeError):
+            flatten(_Cell(), ref_index={})
+
+    def test_static_attribute_roundtrips(self):
+        """A non-state static attribute is preserved verbatim through a round-trip."""
+        gd, state = flatten(_Cell(tag="hello"))
+        rebuilt = unflatten(gd, state)
+        self.assertEqual(rebuilt.tag, "hello")
+
+    def test_bare_treefystate_leaf_roundtrips(self):
+        """A bare ``TreefyState`` attribute is encoded as a leaf and restored."""
+        node = _Cell()
+        node.ref = brainstate.ParamState(jnp.arange(3.0)).to_state_ref()
+        self.assertIsInstance(node.ref, TreefyState)
+        gd, state = flatten(node)
+        rebuilt = unflatten(gd, state)
+        self.assertIsInstance(rebuilt.ref, TreefyState)
+        self.assertTrue(bool(jnp.allclose(rebuilt.ref.value, jnp.arange(3.0))))
+
+
+class TestUnflattenDecode(unittest.TestCase):
+    """Decoder behaviour for ``unflatten``."""
+
+    def test_unflatten_bad_graphdef_raises(self):
+        """A non-``GraphDef`` first argument raises ``TypeError``."""
+        _, state = flatten(_Cell())
+        with self.assertRaises(TypeError):
+            unflatten("not-a-graphdef", state)
+
+    def test_non_treefy_state_roundtrips(self):
+        """``treefy_state=False`` keeps raw ``State`` objects in the mapping."""
+        node = _Cell()
+        gd, state = flatten(node, treefy_state=False)
+        rebuilt = unflatten(gd, state)
+        self.assertTrue(bool(jnp.allclose(rebuilt.w.value, jnp.ones((2,)))))
+
+
+class TestIndexRefCacheUpdate(unittest.TestCase):
+    """The ``index_ref_cache`` "update existing objects in place" path."""
+
+    def _first_build(self):
+        """Build a node once and return (graphdef, populated index_ref)."""
+        node = _Cell()
+        gd, state = flatten(node)
+        index_ref = {}
+        rebuilt = unflatten(gd, state, index_ref=index_ref)
+        return gd, rebuilt, index_ref
+
+    def test_cache_reuses_shell_and_updates_state(self):
+        """A second unflatten with a cache reuses the node and updates its state."""
+        gd, rebuilt, cache = self._first_build()
+        # New values, identical structure -> matching global indices.
+        node2 = _Cell()
+        node2.w.value = jnp.full((2,), 9.0)
+        gd2, state2 = flatten(node2)
+        out = unflatten(gd2, state2, index_ref={}, index_ref_cache=cache)
+        self.assertIs(out, rebuilt)  # node shell reused from the cache
+        self.assertTrue(bool(jnp.allclose(out.w.value, 9.0)))  # state updated in place
+
+    def test_cache_update_non_treefy_state(self):
+        """The cache update path also handles raw (non-treefy) ``State`` values."""
+        gd, rebuilt, cache = self._first_build()
+        node2 = _Cell()
+        node2.w.value = jnp.full((2,), 5.0)
+        gd2, state2 = flatten(node2, treefy_state=False)
+        out = unflatten(gd2, state2, index_ref={}, index_ref_cache=cache)
+        self.assertIs(out, rebuilt)
+        self.assertTrue(bool(jnp.allclose(out.w.value, 5.0)))
+
+    def test_cache_type_mismatch_raises(self):
+        """A cached object of the wrong type at a node index raises ``ValueError``."""
+        gd, _, cache = self._first_build()
+        node_index = gd.node_specs[0].index
+        gd2, state2 = flatten(_Cell())
+        bad_cache = {node_index: object()}
+        with self.assertRaises(ValueError):
+            unflatten(gd2, state2, index_ref={}, index_ref_cache=bad_cache)
+
+
+class TestSharedStateAndMissing(unittest.TestCase):
+    """Shared-state deduplication and missing-state error handling."""
+
+    def test_shared_state_single_index(self):
+        """The same ``State`` referenced twice collapses to one index."""
+
+        class Twin(brainstate.graph.Node):
+            def __init__(self, st):
+                self.a = st
+                self.b = st  # same object as ``a``
+
+        shared = brainstate.ParamState(jnp.ones((2,)))
+        gd, state = flatten(Twin(shared))
+        rebuilt = unflatten(gd, state)
+        self.assertIs(rebuilt.a, rebuilt.b)
+
+    def test_missing_state_path_raises(self):
+        """A ``StateEdge`` whose path is absent (no cache) raises ``ValueError``."""
+        gd, _ = flatten(_Cell())
+        empty = brainstate.util.NestedDict()
+        with self.assertRaises(ValueError):
+            unflatten(gd, empty)
+
+
+class TestIndexRefCacheEdgeCases(unittest.TestCase):
+    """Less-common branches of the ``index_ref_cache`` decode path."""
+
+    @staticmethod
+    def _state_index(index_ref):
+        from brainstate._state import State
+        return next(i for i, v in index_ref.items() if isinstance(v, State))
+
+    def test_cache_restores_unwritten_state(self):
+        """An unmodified (non-written) cached ``State`` is refreshed via restore."""
+        node = _Cell()
+        gd, _ = flatten(node)
+        ref = {}
+        rebuilt = unflatten(gd, flatten(node)[1], index_ref=ref)
+        # A freshly-built node whose value was never reassigned -> restore path.
+        fresh = _Cell()
+        gd2, state2 = flatten(fresh, treefy_state=False)
+        out = unflatten(gd2, state2, index_ref={}, index_ref_cache=ref)
+        self.assertIs(out, rebuilt)
+        self.assertTrue(bool(jnp.allclose(out.w.value, jnp.ones((2,)))))
+
+    def test_cache_non_state_at_state_index_raises(self):
+        """A cached non-``State`` object at a state index raises ``ValueError``."""
+        node = _Cell()
+        gd, state = flatten(node)
+        ref = {}
+        unflatten(gd, flatten(node)[1], index_ref=ref)
+        bad_cache = {self._state_index(ref): object()}
+        with self.assertRaises(ValueError):
+            unflatten(gd, state, index_ref={}, index_ref_cache=bad_cache)
+
+    def test_cache_supplies_state_absent_from_mapping(self):
+        """A state missing from the mapping but present in the cache is reused."""
+        node = _Cell()
+        gd, _ = flatten(node)
+        ref = {}
+        unflatten(gd, flatten(node)[1], index_ref=ref)
+        empty = brainstate.util.NestedDict()
+        out = unflatten(gd, empty, index_ref={}, index_ref_cache=ref)
+        self.assertTrue(bool(jnp.allclose(out.w.value, jnp.ones((2,)))))
+
+
+class TestFormatPath(unittest.TestCase):
+    """The ``_format_path`` helper used in error messages."""
+
+    def test_empty_path_is_root(self):
+        """An empty path renders as ``<root>``."""
+        self.assertEqual(_flatten._format_path(()), "<root>")
+
+    def test_nested_path_is_dotted(self):
+        """A multi-part path renders dotted."""
+        self.assertEqual(_flatten._format_path(("a", "b", "c")), "a.b.c")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/brainstate/graph/_node.py
+++ b/brainstate/graph/_node.py
@@ -21,6 +21,8 @@ from abc import ABCMeta
 from copy import deepcopy
 from typing import Any, Callable, TypeVar, TYPE_CHECKING
 
+import jax
+
 from brainstate._error import TraceContextError
 from brainstate._state import State, TreefyState
 from brainstate.typing import Key
@@ -82,8 +84,14 @@ class Node(PrettyObject, metaclass=GraphNodeMeta):
 
     def __deepcopy__(self: G, memo=None) -> G:
         graphdef, state = treefy_split(self)
-        graphdef = deepcopy(graphdef)
-        state = deepcopy(state)
+        # ``state`` is a pytree of ``TreefyState`` whose only leaves are the
+        # array values; mapping ``deepcopy`` over it copies those values while
+        # leaving the (immutable, unpicklable) source-info metadata untouched.
+        # A plain ``deepcopy(state)`` would instead try to copy that metadata,
+        # which carries a ``jaxlib`` ``Traceback`` and is not picklable. The
+        # ``graphdef`` is static structure and safe to share; ``treefy_merge``
+        # rebuilds fresh ``State`` objects, so the returned node is independent.
+        state = jax.tree.map(deepcopy, state)
         return treefy_merge(graphdef, state)
 
     def check_valid_context(self, error_msg: Callable[[], str]) -> None:

--- a/brainstate/graph/_node_test.py
+++ b/brainstate/graph/_node_test.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 # ==============================================================================
 
+import copy
 import unittest
+
+import jax.numpy as jnp
 
 import brainstate
 from brainstate._state import State
@@ -583,6 +586,50 @@ class TestEdgeCases(unittest.TestCase):
         copied = brainstate.graph.treefy_merge(graphdef, state)
         self.assertIsNot(node, copied)
         self.assertEqual(copied.data, 'data')
+
+
+class TestNodeDeepCopy(unittest.TestCase):
+    """``copy.deepcopy`` produces an independent clone of a graph node.
+
+    Regression test: ``Node.__deepcopy__`` previously called
+    ``copy.deepcopy`` on the split state mapping, which (a) tripped a
+    ``KeyError`` in ``NestedDict.__getattr__`` while probing ``__deepcopy__``
+    and (b) tried to copy the state's unpicklable ``jaxlib`` source-info
+    traceback. ``copy.deepcopy`` on any node therefore raised.
+    """
+
+    def _make(self):
+        class Net(Node):
+            def __init__(self):
+                self.w = brainstate.ParamState(jnp.ones((2, 3)))
+                self.b = brainstate.ParamState(jnp.zeros((3,)))
+                self.tag = "net"  # static attribute
+
+        return Net()
+
+    def test_deepcopy_returns_equal_independent_node(self):
+        """The copy preserves type/values and shares no ``State`` objects."""
+        node = self._make()
+        clone = copy.deepcopy(node)
+        self.assertIsInstance(clone, type(node))
+        self.assertIsNot(clone, node)
+        self.assertIsNot(clone.w, node.w)
+        self.assertEqual(clone.tag, "net")
+        self.assertTrue(bool(jnp.allclose(clone.w.value, node.w.value)))
+        self.assertTrue(bool(jnp.allclose(clone.b.value, node.b.value)))
+
+    def test_deepcopy_is_independent(self):
+        """Mutating the copy does not affect the original."""
+        node = self._make()
+        clone = copy.deepcopy(node)
+        clone.w.value = jnp.full((2, 3), 7.0)
+        self.assertTrue(bool(jnp.allclose(node.w.value, jnp.ones((2, 3)))))
+
+    def test_deepcopy_real_module(self):
+        """A real ``nn`` module deep-copies without error."""
+        m = brainstate.nn.Linear(3, 4)
+        m2 = copy.deepcopy(m)
+        self.assertIsInstance(m2, brainstate.nn.Linear)
 
 
 if __name__ == '__main__':

--- a/brainstate/graph/_operation_test.py
+++ b/brainstate/graph/_operation_test.py
@@ -272,7 +272,7 @@ class TestGraphUtils(absltest.TestCase):
 
         assert len(state.to_flat()) == 1
 
-        x = jax.random.randint(jax.random.key(0), (2,), 0, 10)
+        x = brainstate.random.randint(0, 10, (2,))
         y = model(x)
         assert y.shape == (2, 10)
 
@@ -1012,6 +1012,113 @@ class TestThreading(parameterized.TestCase):
         thread = MyThread()
         thread.start()
         thread.join()
+
+
+class _Net(brainstate.graph.Node):
+    """A small node with two parameter states, used by the gap tests."""
+
+    def __init__(self):
+        self.w = brainstate.ParamState(jnp.ones((2,)))
+        self.b = brainstate.ParamState(jnp.zeros((2,)))
+
+
+class TestFilteredSplitAndStates(unittest.TestCase):
+    """Filtered ``treefy_split`` / ``treefy_states`` return single mappings."""
+
+    def test_single_filter_split_returns_one_mapping(self):
+        """A single filter yields one ``NestedDict`` partition."""
+        gd, params = brainstate.graph.treefy_split(_Net(), brainstate.ParamState)
+        self.assertIsInstance(params, brainstate.util.NestedDict)
+        self.assertEqual(len(params.to_flat()), 2)
+
+    def test_treefy_states_with_filter(self):
+        """``treefy_states`` with a filter returns the filtered mapping."""
+        ts = brainstate.graph.treefy_states(_Net(), brainstate.ParamState)
+        self.assertIsInstance(ts, brainstate.util.NestedDict)
+        self.assertEqual(len(ts.to_flat()), 2)
+
+
+class TestPopStates(unittest.TestCase):
+    """``pop_states`` removal semantics and error handling."""
+
+    def test_pop_removes_matching_states(self):
+        """Popping by type removes the matched states from the node."""
+        net = _Net()
+        popped = brainstate.graph.pop_states(net, brainstate.ParamState)
+        self.assertEqual(len(popped.to_flat()), 2)
+        self.assertFalse(hasattr(net, 'w'))
+        self.assertFalse(hasattr(net, 'b'))
+
+    def test_pop_requires_a_filter(self):
+        """Calling without any filter raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            brainstate.graph.pop_states(_Net())
+
+    def test_pop_from_immutable_subnode_raises(self):
+        """Popping a state nested inside a plain (pytree) container raises."""
+
+        class Holder(brainstate.graph.Node):
+            def __init__(self):
+                self.items = [brainstate.ParamState(jnp.ones((2,)))]
+
+        with self.assertRaises(ValueError):
+            brainstate.graph.pop_states(Holder(), brainstate.ParamState)
+
+
+class TestUpdateStates(unittest.TestCase):
+    """``update_states`` in-place update, re-add, merge, and error paths."""
+
+    def test_update_readds_popped_keys(self):
+        """States popped from a node can be restored via ``update_states``."""
+        net = _Net()
+        popped = brainstate.graph.pop_states(net, brainstate.ParamState)
+        brainstate.graph.update_states(net, popped)
+        self.assertTrue(hasattr(net, 'w'))
+        self.assertTrue(bool(jnp.allclose(net.w.value, jnp.ones((2,)))))
+
+    def test_update_merges_multiple_mappings(self):
+        """Extra mappings are merged before being applied."""
+        net = _Net()
+        _, full = brainstate.graph.treefy_split(net)
+        # Merging with an empty mapping exercises the merge branch.
+        brainstate.graph.update_states(net, full, brainstate.util.NestedDict())
+        self.assertTrue(bool(jnp.allclose(net.w.value, jnp.ones((2,)))))
+
+    def test_update_unsupported_value_type_raises(self):
+        """A value that is neither node, ``TreefyState``, nor leaf raises."""
+        net = _Net()
+        with self.assertRaises(ValueError):
+            brainstate.graph.update_states(net, brainstate.util.NestedDict({'w': 12345}))
+
+    def test_update_subgraph_with_state_leaf_raises(self):
+        """Updating a subgraph key with a bare state leaf raises ``ValueError``."""
+
+        class Outer(brainstate.graph.Node):
+            def __init__(self):
+                self.sub = _Net()
+
+        leaf = brainstate.ParamState(jnp.ones(())).to_state_ref()
+        with self.assertRaises(ValueError):
+            brainstate.graph.update_states(Outer(), brainstate.util.NestedDict({'sub': leaf}))
+
+
+class TestCloneAndGraphdef(unittest.TestCase):
+    """``clone`` and ``graphdef`` thin wrappers."""
+
+    def test_clone_is_independent(self):
+        """``clone`` returns a structurally identical, independent node."""
+        net = _Net()
+        c = brainstate.graph.clone(net)
+        self.assertIsNot(c, net)
+        self.assertIsNot(c.w, net.w)
+        self.assertTrue(bool(jnp.allclose(c.w.value, net.w.value)))
+
+    def test_graphdef_matches_split(self):
+        """``graphdef`` returns the same structure as ``treefy_split``."""
+        net = _Net()
+        gd = brainstate.graph.graphdef(net)
+        gd2, _ = brainstate.graph.treefy_split(net)
+        self.assertEqual(gd, gd2)
 
 
 if __name__ == '__main__':

--- a/brainstate/util/_pretty_pytree.py
+++ b/brainstate/util/_pretty_pytree.py
@@ -313,8 +313,18 @@ class PrettyDict(dict, PrettyRepr):
             The value associated with the key.
 
         Raises:
-            KeyError: If the key is not found in the dictionary.
+            AttributeError: If a dunder (``__x__``) attribute is missing. The
+                attribute protocol requires ``AttributeError`` here so that
+                ``copy.deepcopy``, ``pickle``, and ``hasattr`` probe special
+                methods (e.g. ``__deepcopy__``) correctly instead of crashing
+                on a ``KeyError``.
+            KeyError: If a non-dunder key is not found in the dictionary.
         """
+        # Dunder probes (``__deepcopy__``, ``__copy__``, ``__getstate__`` ...)
+        # are never stored as items; surfacing them as ``AttributeError`` lets
+        # the standard copy/pickle protocols fall back to their defaults.
+        if key.startswith('__') and key.endswith('__'):
+            raise AttributeError(key)
         return self[key]
 
     def treefy_state(self) -> Any:

--- a/brainstate/util/_pretty_pytree_test.py
+++ b/brainstate/util/_pretty_pytree_test.py
@@ -673,3 +673,38 @@ class TestEdgeCases(unittest.TestCase):
         self.assertEqual(merged['b'], 3)
         self.assertEqual(merged['a'], 1)
         self.assertEqual(merged['c'], 4)
+
+
+class TestGetattrProtocol(absltest.TestCase):
+    """``__getattr__`` honours the attribute protocol for dunder probes.
+
+    Regression test: ``__getattr__`` used to ``return self[key]`` for every
+    name, so probing a missing dunder (e.g. ``__deepcopy__``) raised
+    ``KeyError`` instead of ``AttributeError``. That broke ``copy.deepcopy``,
+    ``pickle``, and ``hasattr`` on any :class:`PrettyDict`.
+    """
+
+    def test_missing_dunder_raises_attribute_error(self):
+        """A missing dunder attribute raises ``AttributeError`` (not ``KeyError``)."""
+        d = NestedDict({'a': 1})
+        with self.assertRaises(AttributeError):
+            getattr(d, '__deepcopy__')
+        self.assertFalse(hasattr(d, '__deepcopy__'))
+
+    def test_missing_non_dunder_key_still_keyerror(self):
+        """A missing ordinary key is still surfaced as ``KeyError``."""
+        d = NestedDict({'a': 1})
+        with self.assertRaises(KeyError):
+            getattr(d, 'does_not_exist')
+
+    def test_deepcopy_roundtrips(self):
+        """``copy.deepcopy`` reproduces the mapping contents."""
+        import copy
+        d = NestedDict({'a': 1, 'b': {'c': 2}})
+        d2 = copy.deepcopy(d)
+        self.assertEqual(d2.to_dict(), {'a': 1, 'b': {'c': 2}})
+
+    def test_existing_key_attribute_access_still_works(self):
+        """Accessing an existing key as an attribute still returns its value."""
+        d = NestedDict({'a': 5})
+        self.assertEqual(d.a, 5)


### PR DESCRIPTION
## Summary

Comprehensive test audit of the `brainstate.graph` subpackage, raising coverage from a **77% baseline to 95% TOTAL with every module at ≥90%** line + branch. The audit surfaced and fixed two latent bugs that made `copy.deepcopy()` crash for **every** graph `Node` / `nn` `Module` (each reproduced with a regression test first, per the repo's bug-fix rule).

## Bug fixes — `copy.deepcopy(node)` was broken at two layers

1. **`PrettyDict.__getattr__` violated the attribute protocol.** It did `return self[key]` for every name, so probing a missing dunder (e.g. `__deepcopy__`) raised `KeyError` instead of `AttributeError` — breaking `copy.deepcopy`, `pickle`, and `hasattr` on any `NestedDict`/`FlattedDict`. Now dunder probes raise `AttributeError`, while ordinary missing-item access still raises `KeyError` (documented behavior preserved).
2. **`Node.__deepcopy__` deep-copied unpicklable state metadata.** After the protocol fix it next failed because the split state's `State` metadata carries a `jaxlib` `Traceback`. It now deep-copies via the state *pytree* (whose only leaves are the array values), leaving the immutable source-info metadata untouched and sharing the static `graphdef`; `treefy_merge` rebuilds fresh `State` objects, so the copy is fully independent.

## New dedicated test files

- `_convert_test.py` — `graph_to_tree`/`tree_to_graph` round-trips, the `NodeStates` pytree wrapper and its constructors/properties, shared-node aliasing (consistent, conflicting → raises, and `check_aliasing=False`), `map_non_graph_nodes` via custom split/merge fns, and `jit` integration.
- `_flatten_test.py` — encoder edges (static attrs, non-node-root error, bad `ref_index`), and the `index_ref_cache` "update in place" decode path: shell reuse, state refresh (treefy + raw), type-mismatch detection, and the missing-state error.

## Deepened existing suites

- `_operation_test.py` — filtered `treefy_split`/`treefy_states`, `pop_states` (including the immutable-subnode error), `update_states` (re-add popped keys, merge, and the unsupported-value / subgraph-leaf error paths), and `clone`/`graphdef`; dropped direct `jax.random` for `brainstate.random` (rule #7).
- `_context_test.py` — split/merge shared-identity round-trips and context-manager teardown.

## Testing

- Full project suite: **3601 passed, 1 skipped** (no regressions; the core `_pretty_pytree.py` change is exercised library-wide).
- All new tests use `brainstate.random` for RNG and follow NumPy-doc docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
