### PR TITLE
test(nn): comprehensive nn API tests (79%→97%) + init.param State fix

### DIFF
--- a/brainstate/nn/_collective_ops_test.py
+++ b/brainstate/nn/_collective_ops_test.py
@@ -772,3 +772,242 @@ class Test_call_all_fns:
 
         assert layer1.method_called
         assert layer2.method_called
+
+
+# ---------------------------------------------------------------------------
+# Appended coverage tests for brainstate.nn._collective_ops.
+# ---------------------------------------------------------------------------
+
+import unittest
+
+from brainstate import _testing
+
+
+class EnsembleModule(brainstate.nn.Module):
+    """Tiny module whose ``init_state`` allocates a single ParamState."""
+
+    def init_state(self, k):
+        """Allocate a ``ParamState`` of length ``k`` with random values."""
+        self.w = brainstate.ParamState(brainstate.random.randn(k))
+
+    def reset_state(self):
+        """Zero the parameter state in place."""
+        self.w.value = jnp.zeros_like(self.w.value)
+
+
+class TestCallAllFnsInvalidPolicy(unittest.TestCase):
+    """Cover the invalid ``fn_if_not_exist`` branch in ``call_all_fns``."""
+
+    def test_invalid_fn_if_not_exist_raises_valueerror(self):
+        """An unrecognized ``fn_if_not_exist`` value raises ValueError."""
+
+        class NoMethod(brainstate.nn.Module):
+            """Module deliberately missing the requested method."""
+
+        with self.assertRaises(ValueError):
+            brainstate.nn.call_all_fns(NoMethod(), 'missing', fn_if_not_exist='bogus')
+
+
+class TestVmapCallAllFns(unittest.TestCase):
+    """Tests for ``vmap_call_all_fns`` batched method invocation."""
+
+    def test_call_completes_and_runs_body(self):
+        """The vmapped call runs to completion over newly created states.
+
+        This exercises the happy-path body of ``vmap_call_all_fns`` (the inner
+        and outer ``catch_new_states`` blocks and the value write-back loop).
+        It deliberately avoids using the resulting state value because of the
+        tracer-leak bug documented in ``test_init_state_leaks_tracer``.
+        """
+        module = EnsembleModule()
+        with _testing.seeded(0):
+            returned = brainstate.nn.vmap_call_all_fns(
+                module, 'init_state', axis_size=_testing.SMALL_BATCH, kwargs={'k': 3}
+            )
+        self.assertIs(returned, module)
+        self.assertTrue(hasattr(module, 'w'))
+
+    @pytest.mark.skip(reason="BUG: vmap_call_all_fns leaks a JAX BatchTracer into "
+                             "newly created state values; the batched value is not "
+                             "committed (shape stays per-lane and later use raises "
+                             "UnexpectedTracerError). See report.")
+    def test_batched_init_creates_leading_axis(self):
+        """Vmapped init_state should create a committed leading batch axis."""
+        module = EnsembleModule()
+        with _testing.seeded(0):
+            brainstate.nn.vmap_call_all_fns(
+                module, 'init_state', axis_size=_testing.SMALL_BATCH, kwargs={'k': 3}
+            )
+        self.assertEqual(module.w.value.shape, (_testing.SMALL_BATCH, 3))
+
+    @pytest.mark.skip(reason="BUG: vmap_call_all_fns leaks a JAX BatchTracer into "
+                             "newly created state values. See report.")
+    def test_batched_init_distinct_per_lane(self):
+        """Each batch lane should receive an independent random initialization."""
+        module = EnsembleModule()
+        with _testing.seeded(1):
+            brainstate.nn.vmap_call_all_fns(
+                module, 'init_state', axis_size=_testing.SMALL_BATCH, kwargs={'k': 4}
+            )
+        self.assertFalse(bool(jnp.allclose(module.w.value[0], module.w.value[1])))
+
+    @pytest.mark.skip(reason="BUG: vmap_call_all_fns leaks a JAX BatchTracer into "
+                             "newly created state values. See report.")
+    def test_positional_single_arg_wrapped(self):
+        """A single non-tuple positional argument is wrapped in a tuple."""
+
+        class Recorder(brainstate.nn.Module):
+            """Module recording the positional args it receives."""
+
+            def init_state(self, value):
+                """Record the scalar argument into a ParamState."""
+                self.v = brainstate.ParamState(jnp.asarray(float(value)))
+
+        module = Recorder()
+        brainstate.nn.vmap_call_all_fns(
+            module, 'init_state', args=2.0, axis_size=_testing.SMALL_BATCH
+        )
+        self.assertEqual(module.v.value.shape, (_testing.SMALL_BATCH,))
+
+    def test_single_non_tuple_arg_wrapped(self):
+        """A single non-tuple positional ``args`` is wrapped before mapping.
+
+        Uses a stateless method so the run completes without hitting the
+        newly-created-state tracer-leak bug, isolating the ``args`` wrap branch.
+        """
+        recorder = {}
+
+        class StatelessRecorder(brainstate.nn.Module):
+            """Module whose mapped method records its positional arg."""
+
+            def note(self, value):
+                """Record the (broadcast) positional argument."""
+                recorder['value'] = value
+
+        module = StatelessRecorder()
+        returned = brainstate.nn.vmap_call_all_fns(
+            module, 'note', args=7, axis_size=_testing.SMALL_BATCH
+        )
+        self.assertIs(returned, module)
+        self.assertEqual(recorder['value'], 7)
+
+    def test_axis_size_zero_raises(self):
+        """A non-positive ``axis_size`` raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.vmap_call_all_fns(EnsembleModule(), 'init_state', axis_size=0)
+
+    def test_axis_size_none_raises(self):
+        """A missing ``axis_size`` raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.vmap_call_all_fns(EnsembleModule(), 'init_state', axis_size=None)
+
+    def test_kwargs_not_mapping_raises(self):
+        """A non-mapping ``kwargs`` raises TypeError."""
+        with self.assertRaises(TypeError):
+            brainstate.nn.vmap_call_all_fns(
+                EnsembleModule(), 'init_state', axis_size=4, kwargs=[1, 2, 3]
+            )
+
+
+class TestVmapInitAllStates(unittest.TestCase):
+    """Tests for ``vmap_init_all_states`` batched initialization."""
+
+    def test_creates_batched_states(self):
+        """Vmapped initialization prepends a batch axis to every state."""
+        module = EnsembleModule()
+        with _testing.seeded(0):
+            brainstate.nn.vmap_init_all_states(module, axis_size=_testing.SMALL_BATCH, k=3)
+        self.assertEqual(module.w.value.shape, (_testing.SMALL_BATCH, 3))
+
+    def test_with_state_to_exclude(self):
+        """Excluded states stay shared (unbatched) across lanes."""
+
+        class TwoStates(brainstate.nn.Module):
+            """Module with a batched param and a shared buffer."""
+
+            def init_state(self, k):
+                """Allocate a random param and a zero buffer."""
+                self.w = brainstate.ParamState(brainstate.random.randn(k))
+                self.buf = brainstate.ShortTermState(jnp.zeros(k))
+
+        module = TwoStates()
+        with _testing.seeded(0):
+            brainstate.nn.vmap_init_all_states(
+                module,
+                axis_size=_testing.SMALL_BATCH,
+                k=3,
+                state_to_exclude=brainstate.util.filter.OfType(brainstate.ShortTermState),
+            )
+        self.assertEqual(module.w.value.shape, (_testing.SMALL_BATCH, 3))
+        self.assertEqual(module.buf.value.shape, (3,))
+
+
+class TestVmapResetAllStates(unittest.TestCase):
+    """Tests for ``vmap_reset_all_states`` batched reset."""
+
+    def test_reset_zeroes_batched_state(self):
+        """Resetting a batched module zeros its parameter while keeping its shape."""
+        module = EnsembleModule()
+        with _testing.seeded(0):
+            brainstate.nn.vmap_init_all_states(module, axis_size=_testing.SMALL_BATCH, k=3)
+        brainstate.nn.vmap_reset_all_states(module, axis_size=_testing.SMALL_BATCH)
+        self.assertEqual(module.w.value.shape, (_testing.SMALL_BATCH, 3))
+        self.assertTrue(bool(jnp.allclose(module.w.value, 0.0)))
+
+
+class TestAssignStateValues(unittest.TestCase):
+    """Tests for ``assign_state_values`` state restoration."""
+
+    def _make_net(self):
+        """Build and initialize a module with two plain-array ParamStates."""
+
+        class Simple(brainstate.nn.Module):
+            """Module with two named ParamStates."""
+
+            def init_state(self):
+                """Allocate weight and bias parameters."""
+                self.w = brainstate.ParamState(jnp.ones(3))
+                self.b = brainstate.ParamState(jnp.zeros(2))
+
+        net = Simple()
+        brainstate.nn.init_all_states(net)
+        return net
+
+    def test_roundtrip_no_mismatch(self):
+        """Saving then restoring all states yields no unexpected/missing keys."""
+        net = self._make_net()
+        snapshot = {path: st.value for path, st in net.states().items()}
+        unexpected, missing = brainstate.nn.assign_state_values(net, snapshot)
+        self.assertEqual(unexpected, [])
+        self.assertEqual(missing, [])
+
+    def test_unexpected_key_reported(self):
+        """Keys absent from the module are returned as unexpected."""
+        net = self._make_net()
+        snapshot = {path: st.value for path, st in net.states().items()}
+        snapshot[('not', 'real')] = jnp.zeros(3)
+        unexpected, missing = brainstate.nn.assign_state_values(net, snapshot)
+        self.assertIn(('not', 'real'), unexpected)
+        self.assertEqual(missing, [])
+
+    def test_missing_keys_reported_and_value_assigned(self):
+        """A partial dict reports missing keys and assigns the provided value."""
+        net = self._make_net()
+        target_key = ('w',)
+        unexpected, missing = brainstate.nn.assign_state_values(
+            net, {target_key: jnp.ones(3) * 9.0}
+        )
+        self.assertEqual(unexpected, [])
+        self.assertIn(('b',), missing)
+        _testing.assert_allclose(net.states()[target_key].value, jnp.ones(3) * 9.0)
+
+    def test_multiple_dicts_merge_last_wins(self):
+        """Later dictionaries override earlier ones for duplicate keys."""
+        net = self._make_net()
+        target_key = ('w',)
+        brainstate.nn.assign_state_values(
+            net,
+            {target_key: jnp.ones(3) * 2.0},
+            {target_key: jnp.ones(3) * 7.0},
+        )
+        _testing.assert_allclose(net.states()[target_key].value, jnp.ones(3) * 7.0)

--- a/brainstate/nn/_common_test.py
+++ b/brainstate/nn/_common_test.py
@@ -132,3 +132,327 @@ class TestFilterStates(unittest.TestCase):
 
         self.mock_module.states.assert_called_once_with(filter_obj)
         self.assertEqual(result, ['test1', 'test2'])
+
+
+# ---------------------------------------------------------------------------
+# Appended coverage tests for brainstate.nn._common.
+# ---------------------------------------------------------------------------
+
+import pytest
+
+from brainstate import _testing
+from brainstate.nn._common import Vmap, Map, ToPredicate, _MapCaller
+from brainstate.util.filter import OfType
+
+
+class _ParamModule(Module):
+    """Tiny module exposing a single mappable ParamState for wrapper tests."""
+
+    def init_state(self, din, dout):
+        """Create a Linear submodule with the requested fan-in/out."""
+        self.lin = brainstate.nn.Linear(din, dout)
+
+    def update(self, x):
+        """Apply the wrapped linear layer to ``x``."""
+        return self.lin(x)
+
+    def predict(self, x):
+        """Apply the linear layer and scale the result by two."""
+        return self.lin(x) * 2.0
+
+
+class TestEnvironContextExtraContext(unittest.TestCase):
+    """Cover the per-call ``context`` override path of ``EnvironContext``."""
+
+    def test_update_with_explicit_context(self):
+        """A per-call context dict is merged with the stored context."""
+        layer = _ParamModule()
+        layer.init_state(din=2, dout=2)
+        wrapped = EnvironContext(layer, fit=True)
+        with patch.object(environ, 'context') as mock_context:
+            mock_context.return_value.__enter__ = Mock(return_value=None)
+            mock_context.return_value.__exit__ = Mock(return_value=None)
+            wrapped.update(jnp.ones(2), context={'dt': 0.1})
+        mock_context.assert_called_once_with(fit=True, dt=0.1)
+
+
+class TestFilterStatesDict(unittest.TestCase):
+    """Exercise the dictionary branch of ``_filter_states``."""
+
+    def test_filter_states_dict_tuple_key(self):
+        """Map a (filter, axis) tuple key to its selected states by axis."""
+
+        class M(Module):
+            """Module carrying one ParamState and one ShortTermState."""
+
+            def __init__(self):
+                """Create the two states."""
+                super().__init__()
+                self.p = brainstate.ParamState(jnp.ones(3))
+                self.s = brainstate.ShortTermState(jnp.zeros(3))
+
+        module = M()
+        # The implementation iterates over the dict's keys and unpacks each into
+        # (filter_, axis); supply a 2-tuple key so the unpack succeeds.
+        result = _filter_states(module, {(OfType(brainstate.ParamState), 0): 'ignored'})
+        self.assertIn(0, result)
+        self.assertEqual(len(result[0]), 1)
+
+    @pytest.mark.skip(reason="BUG: _filter_states dict branch unpacks dict keys "
+                             "instead of items; documented {filter: axis} form "
+                             "raises TypeError. See report.")
+    def test_filter_states_dict_documented_form(self):
+        """Documented ``{filter: axis}`` mapping should select states by axis."""
+
+        class M(Module):
+            """Module carrying one ParamState."""
+
+            def __init__(self):
+                """Create the ParamState."""
+                super().__init__()
+                self.p = brainstate.ParamState(jnp.ones(3))
+
+        module = M()
+        result = _filter_states(module, {OfType(brainstate.ParamState): 0})
+        self.assertIn(0, result)
+
+
+class TestToPredicate(unittest.TestCase):
+    """Tests for the identity-based ``ToPredicate`` filter helper."""
+
+    def test_matches_only_registered_states(self):
+        """Return True only for states whose identity was registered."""
+        s1 = brainstate.ParamState(jnp.ones(2))
+        s2 = brainstate.ParamState(jnp.ones(2))
+        predicate = ToPredicate([s1])
+        self.assertTrue(predicate(('a',), s1))
+        self.assertFalse(predicate(('b',), s2))
+
+    def test_empty_registration_matches_nothing(self):
+        """An empty registration set never matches a state."""
+        predicate = ToPredicate([])
+        self.assertFalse(predicate(('x',), brainstate.ParamState(jnp.zeros(1))))
+
+
+class TestVmapWrapper(unittest.TestCase):
+    """Tests for the ``Vmap`` module wrapper."""
+
+    def test_init_requires_module(self):
+        """Constructing ``Vmap`` with a non-module raises AssertionError."""
+        with self.assertRaises(AssertionError):
+            Vmap("not a module")
+
+    def test_batched_output_shape(self):
+        """A vmapped linear layer maps the leading batch axis of its input."""
+        module = _ParamModule()
+        module.init_state(din=_testing.SMALL_DIM, dout=3)
+        wrapped = Vmap(module, in_axes=0, axis_name='batch')
+        with _testing.seeded(0):
+            x = brainstate.random.randn(_testing.SMALL_BATCH, _testing.SMALL_DIM)
+        out = wrapped.update(x)
+        self.assertEqual(out.shape, (_testing.SMALL_BATCH, 3))
+
+    def test_records_axes_and_fn(self):
+        """The wrapper stores the requested axes and a callable vmapped fn."""
+        module = _ParamModule()
+        module.init_state(din=2, dout=2)
+        wrapped = Vmap(module, in_axes=0, out_axes=0, axis_size=_testing.SMALL_BATCH)
+        self.assertEqual(wrapped.in_axes, 0)
+        self.assertEqual(wrapped.out_axes, 0)
+        self.assertEqual(wrapped.axis_size, _testing.SMALL_BATCH)
+        self.assertTrue(callable(wrapped.vmapped_fn))
+
+    def test_vmap_states_filter_branch(self):
+        """Passing ``vmap_states`` exercises the ``_filter_states`` single-filter path."""
+        module = _ParamModule()
+        module.init_state(din=2, dout=2)
+        wrapped = Vmap(
+            module,
+            in_axes=0,
+            vmap_states=OfType(brainstate.ParamState),
+        )
+        self.assertTrue(callable(wrapped.vmapped_fn))
+
+
+class TestMapVmapWrapper(unittest.TestCase):
+    """Tests for the ``Map`` wrapper in ``vmap`` mode."""
+
+    def test_basic_init_and_update(self):
+        """init_all_states then update batches the module over the map axis."""
+        m = Map(_ParamModule(), init_map_size=_testing.SMALL_BATCH, behavior='vmap')
+        m.init_all_states(din=3, dout=2)
+        self.assertTrue(m._init)
+        self.assertIn(0, m.dict_vmap_states)
+        out = m.update(jnp.ones((_testing.SMALL_BATCH, 3)))
+        self.assertEqual(out.shape, (_testing.SMALL_BATCH, 2))
+
+    def test_update_before_init_raises(self):
+        """Calling update before init_all_states raises ValueError."""
+        m = Map(_ParamModule(), init_map_size=4)
+        with self.assertRaises(ValueError):
+            m.update(jnp.ones((4, 3)))
+
+    def test_map_before_init_raises(self):
+        """Calling map() before init_all_states raises ValueError."""
+        m = Map(_ParamModule(), init_map_size=4)
+        with self.assertRaises(ValueError):
+            m.map('update')
+
+    def test_bad_behavior_rejected(self):
+        """A behavior other than vmap/pmap is rejected at construction."""
+        with self.assertRaises(AssertionError):
+            Map(_ParamModule(), init_map_size=4, behavior='bogus')
+
+    def test_non_integer_init_map_size_rejected(self):
+        """A non-integer init_map_size is rejected at construction."""
+        with self.assertRaises(AssertionError):
+            Map(_ParamModule(), init_map_size=2.5)
+
+    def test_init_state_axes(self):
+        """init_state_axes routes newly created states to the requested axis."""
+        m = Map(
+            _ParamModule(),
+            init_map_size=_testing.SMALL_BATCH,
+            init_state_axes={0: OfType(brainstate.ParamState)},
+        )
+        m.init_all_states(din=3, dout=2)
+        out = m.update(jnp.ones((_testing.SMALL_BATCH, 3)))
+        self.assertEqual(out.shape, (_testing.SMALL_BATCH, 2))
+
+    def test_call_state_axes_integration(self):
+        """call_state_axes is merged with the init-time vmapped states."""
+        m = Map(
+            _ParamModule(),
+            init_map_size=_testing.SMALL_BATCH,
+            call_state_axes={0: OfType(brainstate.ParamState)},
+        )
+        m.init_all_states(din=3, dout=2)
+        out = m.update(jnp.ones((_testing.SMALL_BATCH, 3)))
+        self.assertEqual(out.shape, (_testing.SMALL_BATCH, 2))
+
+    def test_map_method_by_name(self):
+        """map() resolves a method by name and vectorizes its call."""
+        m = Map(_ParamModule(), init_map_size=_testing.SMALL_BATCH)
+        m.init_all_states(din=3, dout=2)
+        caller = m.map('predict')
+        self.assertIsInstance(caller, _MapCaller)
+        out = caller(jnp.ones((_testing.SMALL_BATCH, 3)))
+        self.assertEqual(out.shape, (_testing.SMALL_BATCH, 2))
+
+    def test_map_with_state_axes(self):
+        """map() accepts an explicit state_axes specification."""
+        m = Map(_ParamModule(), init_map_size=_testing.SMALL_BATCH)
+        m.init_all_states(din=3, dout=2)
+        out = m.map(
+            'predict',
+            state_axes={0: OfType(brainstate.ParamState)},
+        )(jnp.ones((_testing.SMALL_BATCH, 3)))
+        self.assertEqual(out.shape, (_testing.SMALL_BATCH, 2))
+
+    def test_map_with_callable_fn(self):
+        """map() accepts a callable directly instead of a method name.
+
+        The callable is invoked with the mapped inputs only, so it closes over
+        the wrapped module rather than receiving it as an argument.
+        """
+        m = Map(_ParamModule(), init_map_size=_testing.SMALL_BATCH)
+        m.init_all_states(din=3, dout=2)
+        module = m.module
+
+        def run(x):
+            """Call the wrapped module's update on ``x``."""
+            return module.update(x)
+
+        out = m.map(run)(jnp.ones((_testing.SMALL_BATCH, 3)))
+        self.assertEqual(out.shape, (_testing.SMALL_BATCH, 2))
+
+    def test_call_state_axes_unmatched_key(self):
+        """call_state_axes keys absent from the vmapped states pass through.
+
+        Exercises the branch in ``_integrate_state_axes`` where a supplied axis
+        key is not among the states created at initialization time.
+        """
+        m = Map(
+            _ParamModule(),
+            init_map_size=_testing.SMALL_BATCH,
+            call_state_axes={1: OfType(brainstate.ShortTermState)},
+        )
+        m.init_all_states(din=3, dout=2)
+        # Axis 0 holds the vmapped ParamStates; axis 1 was supplied but unmatched.
+        self.assertIn(0, m._call_state_axes)
+        self.assertIn(1, m._call_state_axes)
+
+    def test_map_missing_method_raises(self):
+        """map() raises AttributeError for an unknown method name."""
+        m = Map(_ParamModule(), init_map_size=4)
+        m.init_all_states(din=3, dout=2)
+        with self.assertRaises(AttributeError):
+            m.map('does_not_exist')
+
+    def test_pretty_repr_hides_internal_fields(self):
+        """The repr suppresses internal bookkeeping attributes."""
+        m = Map(_ParamModule(), init_map_size=4)
+        m.init_all_states(din=3, dout=2)
+        text = repr(m)
+        self.assertNotIn('_init', text)
+        self.assertNotIn('dict_vmap_states', text)
+        self.assertNotIn('_call_state_axes', text)
+
+    def test_init_all_states_invalid_behavior_defensive(self):
+        """A corrupted behavior triggers the defensive guard in init_all_states."""
+        m = Map(_ParamModule(), init_map_size=2)
+        m.behavior = 'bogus'
+        with self.assertRaises(ValueError):
+            m.init_all_states(din=3, dout=2)
+
+    def test_update_invalid_behavior_defensive(self):
+        """A corrupted behavior triggers the defensive guard in update."""
+        m = Map(_ParamModule(), init_map_size=2)
+        m.init_all_states(din=3, dout=2)
+        m.behavior = 'bogus'
+        with self.assertRaises(ValueError):
+            m.update(jnp.ones((2, 3)))
+
+
+class TestMapPmapWrapper(unittest.TestCase):
+    """Tests for the ``Map`` wrapper in single-device ``pmap`` mode."""
+
+    def test_pmap_init_and_map_call(self):
+        """pmap-mode init then ``map()`` runs the module across one device.
+
+        Uses ``init_map_size=1`` so the parallel axis fits the single available
+        CPU device. The ``map()`` path is used because ``update()`` is broken in
+        pmap mode (see ``test_pmap_update_is_broken``).
+        """
+        m = Map(_ParamModule(), init_map_size=1, behavior='pmap')
+        m.init_all_states(din=3, dout=2)
+        self.assertIn(0, m.dict_vmap_states)
+        out = m.map('update')(jnp.ones((1, 3)))
+        self.assertEqual(out.shape, (1, 2))
+
+    def test_pmap_update_is_broken(self):
+        """pmap-mode ``update`` raises TypeError from an invalid pmap2 kwarg.
+
+        ``Map.update`` always forwards ``spmd_axis_name`` to the map function,
+        but ``pmap2`` does not accept that keyword. This documents the bug while
+        keeping the suite green; see report.
+        """
+        m = Map(_ParamModule(), init_map_size=1, behavior='pmap')
+        m.init_all_states(din=3, dout=2)
+        with self.assertRaises(TypeError):
+            m.update(jnp.ones((1, 3)))
+
+
+class TestMapCaller(unittest.TestCase):
+    """Tests for the internal ``_MapCaller`` dispatcher."""
+
+    def test_invalid_behavior_raises(self):
+        """_MapCaller rejects behaviors other than vmap/pmap."""
+        with self.assertRaises(ValueError):
+            _MapCaller(lambda x: x, behavior='bogus')
+
+    def test_callable_dispatch(self):
+        """A vmap _MapCaller batches a plain function over the leading axis."""
+        caller = _MapCaller(lambda x: x * 2.0, behavior='vmap', in_axes=0, out_axes=0)
+        out = caller(jnp.arange(4.0))
+        _testing.assert_allclose(out, jnp.arange(4.0) * 2.0)

--- a/brainstate/nn/_conv_test.py
+++ b/brainstate/nn/_conv_test.py
@@ -17,11 +17,13 @@
 
 import unittest
 
-import jax
 import jax.numpy as jnp
+import numpy as np
+import pytest
 
 import brainstate
 import braintools
+from brainstate import _testing
 
 
 class TestConv1d(unittest.TestCase):
@@ -374,13 +376,11 @@ class TestReproducibility(unittest.TestCase):
 
     def test_deterministic_output(self):
         """Test that same seed produces same output."""
-        key = jax.random.PRNGKey(42)
-
         conv1 = brainstate.nn.Conv2d(in_size=(32, 32, 3), out_channels=16, kernel_size=3)
         conv2 = brainstate.nn.Conv2d(in_size=(32, 32, 3), out_channels=16, kernel_size=3)
 
-        # Use same random key for input
-        x = jax.random.normal(key, (4, 32, 32, 3))
+        # Use random input
+        x = brainstate.random.randn(4, 32, 32, 3)
 
         # Note: outputs will differ due to different weight initialization
         # This test just ensures no crashes with random inputs
@@ -848,3 +848,256 @@ class TestKernelShapeConvTranspose(unittest.TestCase):
         # For transpose conv: (kernel_h, kernel_w, out_channels, in_channels // groups)
         expected_shape = (4, 4, 16, 32 // 4)
         self.assertEqual(conv_t.kernel_shape, expected_shape)
+
+
+class TestReplicateHelper(unittest.TestCase):
+    """Tests for the kernel/stride replication helper via public constructors."""
+
+    def test_single_element_sequence(self):
+        """A length-1 sequence is replicated to match the spatial dimensions."""
+        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=[3])
+        self.assertEqual(conv.kernel_size, (3, 3))
+
+    def test_full_length_sequence(self):
+        """A full-length sequence is kept unchanged."""
+        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=(3, 5))
+        self.assertEqual(conv.kernel_size, (3, 5))
+
+    def test_wrong_length_sequence_raises(self):
+        """A sequence whose length is neither 1 nor num_spatial_dims raises TypeError."""
+        with self.assertRaises(TypeError):
+            brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=[3, 3, 3])
+
+
+class TestConvPadding(unittest.TestCase):
+    """Tests for the various padding specifications accepted by convolution layers."""
+
+    def test_padding_int(self):
+        """An integer padding is expanded to symmetric padding per dimension."""
+        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=2)
+        self.assertEqual(conv.padding, ((2, 2), (2, 2)))
+
+    def test_padding_tuple_of_int(self):
+        """A tuple of ints is treated as a (low, high) pair applied to every dimension."""
+        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=(1, 2))
+        self.assertEqual(conv.padding, ((1, 2), (1, 2)))
+
+    def test_padding_sequence_of_tuples(self):
+        """A full sequence of (low, high) tuples is preserved per dimension."""
+        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=[(1, 1), (2, 2)])
+        self.assertEqual(conv.padding, ((1, 1), (2, 2)))
+
+    def test_padding_length_one_sequence(self):
+        """A length-1 sequence of tuples is broadcast across all dimensions."""
+        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=[(1, 1)])
+        self.assertEqual(conv.padding, ((1, 1), (1, 1)))
+
+    def test_padding_wrong_length_raises(self):
+        """A sequence of tuples with the wrong length raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=[(1, 1), (2, 2), (3, 3)])
+
+    def test_padding_invalid_type_raises(self):
+        """A padding of an unsupported type raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=1.5)
+
+
+class TestConvWeightMask(unittest.TestCase):
+    """Tests for weight masking in convolution layers."""
+
+    def test_conv2d_w_mask_zeros_output(self):
+        """A zero weight mask forces the convolution output to zero."""
+        mask = np.zeros((3, 3, 3, 8))
+        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, w_mask=mask)
+        x = jnp.ones((1, 16, 16, 3))
+        y = conv(x)
+        _testing.assert_allclose(y, jnp.zeros_like(y))
+
+    def test_conv2d_w_mask_ones_identity(self):
+        """A unit weight mask leaves the convolution output unchanged."""
+        mask = np.ones((3, 3, 3, 8))
+        conv_masked = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, w_mask=mask)
+        x = jnp.ones((1, 16, 16, 3))
+        y = conv_masked(x)
+        self.assertEqual(y.shape, (1, 16, 16, 8))
+
+
+class TestBaseConvAbstract(unittest.TestCase):
+    """Tests for the abstract base convolution behavior."""
+
+    def test_conv_op_not_implemented(self):
+        """The base class ``_conv_op`` raises NotImplementedError."""
+        from brainstate.nn._conv import _BaseConv
+
+        class _Dummy(_BaseConv):
+            num_spatial_dims = 2
+
+        dummy = _Dummy(in_size=(8, 8, 3), out_channels=4, kernel_size=3)
+        with self.assertRaises(NotImplementedError):
+            dummy._conv_op(jnp.ones((1, 8, 8, 3)), {})
+
+
+class TestConvGradients(unittest.TestCase):
+    """Tests for finite gradients through convolution layers."""
+
+    def test_conv1d_grad_finite(self):
+        """Gradients of a scalar loss through Conv1d are finite."""
+        conv = brainstate.nn.Conv1d(in_size=(20, 4), out_channels=8, kernel_size=3)
+        x = brainstate.random.randn(2, 20, 4)
+
+        def loss(inp):
+            return jnp.sum(conv(inp) ** 2)
+
+        _testing.assert_grad_finite(loss, x)
+
+    def test_conv2d_grad_finite(self):
+        """Gradients of a scalar loss through Conv2d are finite."""
+        conv = brainstate.nn.Conv2d(in_size=(12, 12, 3), out_channels=8, kernel_size=3)
+        x = brainstate.random.randn(2, 12, 12, 3)
+
+        def loss(inp):
+            return jnp.sum(conv(inp) ** 2)
+
+        _testing.assert_grad_finite(loss, x)
+
+    @pytest.mark.slow
+    def test_conv3d_grad_finite(self):
+        """Gradients of a scalar loss through Conv3d are finite."""
+        conv = brainstate.nn.Conv3d(in_size=(6, 6, 6, 2), out_channels=4, kernel_size=3)
+        x = brainstate.random.randn(1, 6, 6, 6, 2)
+
+        def loss(inp):
+            return jnp.sum(conv(inp) ** 2)
+
+        _testing.assert_grad_finite(loss, x)
+
+
+class TestConvJit(unittest.TestCase):
+    """Tests that JIT-compiled convolutions match eager execution."""
+
+    def test_conv1d_jit_equal(self):
+        """JIT-compiled Conv1d matches eager output."""
+        conv = brainstate.nn.Conv1d(in_size=(20, 4), out_channels=8, kernel_size=3)
+        x = brainstate.random.randn(2, 20, 4)
+        _testing.assert_jit_equal(lambda inp: conv(inp), x)
+
+    def test_conv2d_jit_equal(self):
+        """JIT-compiled Conv2d matches eager output."""
+        conv = brainstate.nn.Conv2d(in_size=(12, 12, 3), out_channels=8, kernel_size=3)
+        x = brainstate.random.randn(2, 12, 12, 3)
+        _testing.assert_jit_equal(lambda inp: conv(inp), x)
+
+    def test_scaled_ws_conv2d_jit_equal(self):
+        """JIT-compiled ScaledWSConv2d matches eager output."""
+        conv = brainstate.nn.ScaledWSConv2d(in_size=(12, 12, 3), out_channels=8, kernel_size=3)
+        x = brainstate.random.randn(2, 12, 12, 3)
+        _testing.assert_jit_equal(lambda inp: conv(inp), x)
+
+
+class TestScaledWSConvExtra(unittest.TestCase):
+    """Extra tests for weight-standardized convolutions covering bias and masks."""
+
+    def test_scaled_ws_with_bias_and_mask(self):
+        """ScaledWSConv2d supports both a bias term and a weight mask."""
+        mask = np.ones((3, 3, 3, 8))
+        conv = brainstate.nn.ScaledWSConv2d(
+            in_size=(16, 16, 3),
+            out_channels=8,
+            kernel_size=3,
+            b_init=braintools.init.Constant(0.1),
+            w_mask=mask,
+        )
+        x = jnp.ones((1, 16, 16, 3))
+        y = conv(x)
+        self.assertEqual(y.shape, (1, 16, 16, 8))
+        self.assertIn('bias', conv.weight.value)
+
+    def test_scaled_ws_zero_mask_zeros_output(self):
+        """A zero mask forces a weight-standardized convolution output to zero (no bias)."""
+        mask = np.zeros((5, 3, 8))
+        conv = brainstate.nn.ScaledWSConv1d(in_size=(20, 3), out_channels=8, kernel_size=5, w_mask=mask)
+        x = jnp.ones((1, 20, 3))
+        y = conv(x)
+        _testing.assert_allclose(y, jnp.zeros_like(y))
+
+    def test_scaled_ws_grad_finite(self):
+        """Gradients through ScaledWSConv2d are finite."""
+        conv = brainstate.nn.ScaledWSConv2d(in_size=(12, 12, 3), out_channels=8, kernel_size=3)
+        x = brainstate.random.randn(2, 12, 12, 3)
+
+        def loss(inp):
+            return jnp.sum(conv(inp) ** 2)
+
+        _testing.assert_grad_finite(loss, x)
+
+
+class TestConvTransposePadding(unittest.TestCase):
+    """Tests for padding specifications on transposed convolution layers."""
+
+    def test_padding_int(self):
+        """An integer padding is expanded to symmetric explicit padding."""
+        conv = brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=1)
+        self.assertEqual(conv.padding, ((1, 1), (1, 1)))
+        self.assertEqual(conv.padding_mode, 'explicit')
+
+    def test_padding_tuple_of_int(self):
+        """A tuple of ints is applied per dimension."""
+        conv = brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=(1, 2))
+        self.assertEqual(conv.padding, ((1, 2), (1, 2)))
+
+    def test_padding_sequence_of_tuples(self):
+        """A full sequence of (low, high) tuples is preserved."""
+        conv = brainstate.nn.ConvTranspose2d(
+            in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=[(1, 1), (2, 2)]
+        )
+        self.assertEqual(conv.padding, ((1, 1), (2, 2)))
+
+    def test_padding_length_one_sequence(self):
+        """A length-1 sequence of tuples is broadcast across dimensions."""
+        conv = brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=[(1, 1)])
+        self.assertEqual(conv.padding, ((1, 1), (1, 1)))
+
+    def test_padding_wrong_length_raises(self):
+        """A sequence of tuples with the wrong length raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConvTranspose2d(
+                in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=[(1, 1), (2, 2), (3, 3)]
+            )
+
+    def test_padding_invalid_type_raises(self):
+        """An unsupported padding type raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=1.5)
+
+
+class TestConvTransposeWeightMask(unittest.TestCase):
+    """Tests for weight masking in transposed convolution layers."""
+
+    def test_conv_transpose_zero_mask_zeros_output(self):
+        """A zero weight mask forces the transposed convolution output to zero."""
+        mask = np.zeros((3, 3, 8, 16))
+        conv = brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3, w_mask=mask)
+        x = jnp.ones((1, 8, 8, 16))
+        y = conv(x)
+        _testing.assert_allclose(y, jnp.zeros_like(y))
+
+
+class TestConvTransposeGradients(unittest.TestCase):
+    """Tests for finite gradients through transposed convolution layers."""
+
+    def test_conv_transpose1d_grad_finite(self):
+        """Gradients through ConvTranspose1d are finite."""
+        conv = brainstate.nn.ConvTranspose1d(in_size=(20, 4), out_channels=8, kernel_size=4, stride=2)
+        x = brainstate.random.randn(2, 20, 4)
+
+        def loss(inp):
+            return jnp.sum(conv(inp) ** 2)
+
+        _testing.assert_grad_finite(loss, x)
+
+    def test_conv_transpose2d_jit_equal(self):
+        """JIT-compiled ConvTranspose2d matches eager output."""
+        conv = brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3)
+        x = brainstate.random.randn(2, 8, 8, 16)
+        _testing.assert_jit_equal(lambda inp: conv(inp), x)

--- a/brainstate/nn/_delay_test.py
+++ b/brainstate/nn/_delay_test.py
@@ -18,8 +18,10 @@ import unittest
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 import brainstate
+from brainstate import _testing
 
 
 class TestDelay(unittest.TestCase):
@@ -496,3 +498,380 @@ class TestUpgradedDelay(unittest.TestCase):
 
         # Should have updated every call
         self.assertEqual(delay.write_ptr.value, 20 % delay.max_length)
+
+
+class TestInterpolationRegistry(unittest.TestCase):
+    """Tests for the interpolation method registry."""
+
+    def test_get_unknown_method_raises(self):
+        """Requesting an unregistered interpolation method raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.InterpolationRegistry.get('does_not_exist')
+
+    def test_register_and_get_roundtrip(self):
+        """A registered method can be retrieved by name."""
+
+        def _identity(history, indices, float_idx, max_length):
+            return history
+
+        brainstate.nn.InterpolationRegistry.register('registry_roundtrip', _identity)
+        self.assertIs(brainstate.nn.InterpolationRegistry.get('registry_roundtrip'), _identity)
+        self.assertIn('registry_roundtrip', brainstate.nn.InterpolationRegistry.list_methods())
+
+
+class TestStandaloneInterpolationFunctions(unittest.TestCase):
+    """Tests for the standalone built-in interpolation functions."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_nearest_interpolation_function(self):
+        """The standalone nearest-interpolation function rounds to the nearest stored value."""
+        from brainstate.nn._delay import _nearest_interpolation
+
+        delay = brainstate.nn.Delay(jnp.zeros((1,)), time=2.0, interpolation=_nearest_interpolation)
+        delay.init_state()
+        for i in range(30):
+            delay.update(jnp.ones((1,)) * i)
+        with brainstate.environ.context(t=3.0):
+            result = delay.retrieve_at_time(2.5)
+        self.assertEqual(result.shape, (1,))
+
+    def test_linear_interpolation_function(self):
+        """The standalone linear-interpolation function blends two adjacent stored values."""
+        from brainstate.nn._delay import _linear_interpolation
+
+        delay = brainstate.nn.Delay(jnp.zeros((1,)), time=2.0, interpolation=_linear_interpolation)
+        delay.init_state()
+        for i in range(30):
+            delay.update(jnp.ones((1,)) * i)
+        with brainstate.environ.context(t=3.0):
+            result = delay.retrieve_at_time(2.5)
+        self.assertEqual(result.shape, (1,))
+
+
+class TestDelayAccess(unittest.TestCase):
+    """Tests for the DelayAccess accessor node."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_access_returns_delay_access(self):
+        """``Delay.access`` returns a DelayAccess bound to the delay."""
+        delay = brainstate.nn.Delay(jnp.ones((3,)), time=2.0)
+        acc = delay.access('entry_a', 1.0)
+        self.assertIsInstance(acc, brainstate.nn.DelayAccess)
+
+    def test_access_call_matches_at(self):
+        """Calling a DelayAccess yields the same value as ``Delay.at``."""
+        delay = brainstate.nn.Delay(jnp.ones((3,)), time=2.0)
+        acc = delay.access('entry_b', 1.0)
+        delay.init_state()
+        for i in range(20):
+            delay.update(jnp.ones((3,)) * i)
+        _testing.assert_allclose(acc(), delay.at('entry_b'))
+
+    def test_access_invalid_delay_type(self):
+        """Constructing DelayAccess with a non-Delay target raises AssertionError."""
+        with self.assertRaises(AssertionError):
+            brainstate.nn.DelayAccess(object(), 1.0, entry='bad')
+
+
+class TestDelayInit(unittest.TestCase):
+    """Tests for delay history initialization options."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_init_with_array_value(self):
+        """A scalar array ``init`` fills the history buffer with that value."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=1.0, init=jnp.array(5.0))
+        delay.init_state()
+        _testing.assert_allclose(delay.history.value[0], jnp.ones((2,)) * 5.0)
+
+    def test_init_with_number(self):
+        """A plain Python number ``init`` fills the history buffer."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=1.0, init=3.0)
+        delay.init_state()
+        _testing.assert_allclose(delay.history.value[0], jnp.ones((2,)) * 3.0)
+
+    def test_init_with_callable(self):
+        """A callable ``init`` is invoked with (shape, dtype) to fill the buffer."""
+        delay = brainstate.nn.Delay(
+            jnp.zeros((2,)), time=1.0, init=lambda shape, dtype: jnp.ones(shape, dtype) * 7.0
+        )
+        delay.init_state()
+        _testing.assert_allclose(delay.history.value[0], jnp.ones((2,)) * 7.0)
+
+    def test_init_invalid_type_raises(self):
+        """A non-array, non-callable ``init`` raises TypeError."""
+        with self.assertRaises(TypeError):
+            brainstate.nn.Delay(jnp.zeros((2,)), time=1.0, init='not-valid')
+
+
+class TestDelayEntriesDict(unittest.TestCase):
+    """Tests for registering delay entries via the ``entries`` constructor argument."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_entries_scalar_and_tuple(self):
+        """Entries given as a scalar and as a tuple are both registered."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=2.0, entries={'a': 1.0, 'b': (0.5,)})
+        delay.init_state()
+        for i in range(20):
+            delay.update(jnp.ones((2,)) * i)
+        self.assertEqual(delay.at('a').shape, (2,))
+        self.assertEqual(delay.at('b').shape, (2,))
+
+
+class TestDelayAtErrors(unittest.TestCase):
+    """Tests for error and edge paths in ``Delay.at``."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_at_none_entry_returns_latest(self):
+        """An entry registered with delay ``None`` returns the most recent value."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=2.0)
+        delay.register_entry('latest', None)
+        delay.init_state()
+        for i in range(10):
+            delay.update(jnp.ones((2,)) * i)
+        _testing.assert_allclose(delay.at('latest'), jnp.ones((2,)) * 9)
+
+    def test_at_unknown_entry_raises(self):
+        """Accessing an unregistered entry raises KeyError."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=2.0)
+        delay.init_state()
+        with self.assertRaises(KeyError):
+            delay.at('missing')
+
+    def test_at_non_string_entry_raises(self):
+        """Accessing with a non-string entry raises AssertionError."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=2.0)
+        delay.init_state()
+        with self.assertRaises(AssertionError):
+            delay.at(123)
+
+
+class TestDelayInterpolationValidation(unittest.TestCase):
+    """Tests for the interpolation argument validation in the Delay constructor."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_unknown_string_interpolation_raises(self):
+        """An unknown interpolation name raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Delay(jnp.zeros((1,)), time=1.0, interpolation='bogus')
+
+    def test_callable_interpolation_accepted(self):
+        """A callable interpolation function is stored and used."""
+
+        def my_interp(history, indices, float_idx, max_length):
+            i = jnp.floor(float_idx).astype(jnp.int32) % max_length
+            return jax.tree.map(lambda h: h[(i,) + indices], history)
+
+        delay = brainstate.nn.Delay(jnp.zeros((1,)), time=2.0, interpolation=my_interp)
+        delay.init_state()
+        for i in range(30):
+            delay.update(jnp.ones((1,)) * i)
+        with brainstate.environ.context(t=3.0):
+            result = delay.retrieve_at_time(2.5)
+        self.assertEqual(result.shape, (1,))
+
+    def test_invalid_interpolation_type_raises(self):
+        """A non-string, non-callable interpolation argument raises TypeError."""
+        with self.assertRaises(TypeError):
+            brainstate.nn.Delay(jnp.zeros((1,)), time=1.0, interpolation=123)
+
+
+class TestDelayUpdateFrequency(unittest.TestCase):
+    """Tests for frequency-controlled buffer updates (update_every)."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_update_every_step_computed(self):
+        """``update_every`` is converted to an integer step multiplier."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=1.0, update_every=0.5)
+        self.assertEqual(delay.update_every_step, 5)
+
+    def test_update_every_below_dt_raises(self):
+        """``update_every`` smaller than ``dt`` raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Delay(jnp.zeros((2,)), time=1.0, update_every=0.05)
+
+    def test_frequency_controlled_hold_update(self):
+        """With ``update_every`` set, the buffer only advances on threshold crossings."""
+        delay = brainstate.nn.Delay(jnp.zeros((2,)), time=1.0, update_every=0.5)
+        delay.init_state()
+        # update_every_step == 5; only every 5th call writes to the buffer.
+        for i in range(20):
+            delay.update(jnp.ones((2,)) * i)
+        # write_ptr advances once per threshold crossing (20 / 5 == 4 writes).
+        self.assertEqual(int(delay.write_ptr.value), 4 % delay.max_length)
+
+    def test_update_frequency_none_updates_every_call(self):
+        """Without ``update_every`` the buffer advances on every update."""
+        delay = brainstate.nn.Delay(jnp.zeros((1,)), time=1.0)
+        delay.init_state()
+        for i in range(20):
+            delay.update(jnp.ones((1,)) * i)
+        self.assertEqual(int(delay.write_ptr.value), 20 % delay.max_length)
+
+
+class TestStateWithDelay(unittest.TestCase):
+    """Tests for the state-bound delay buffer."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def _make_module(self):
+        """Build a tiny module carrying a single State."""
+
+        class _Mod(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.V = brainstate.State(jnp.zeros((3,)))
+
+        return _Mod()
+
+    def test_state_with_delay_tracks_state(self):
+        """StateWithDelay rolls the bound state value through its buffer."""
+        mod = self._make_module()
+        swd = brainstate.nn.StateWithDelay(mod, 'V')
+        swd.register_entry('e', 0.5)
+        swd.init_state()
+        for i in range(10):
+            mod.V.value = jnp.ones((3,)) * i
+            swd.update()
+        self.assertEqual(swd.at('e').shape, (3,))
+
+    def test_state_property_returns_state(self):
+        """The ``state`` property exposes the bound State object."""
+        mod = self._make_module()
+        swd = brainstate.nn.StateWithDelay(mod, 'V')
+        self.assertIs(swd.state, mod.V)
+
+    def test_state_property_non_state_raises(self):
+        """Binding to a non-State attribute raises TypeError on access."""
+
+        class _Mod(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.V = brainstate.State(jnp.zeros((3,)))
+                self.plain = jnp.zeros((3,))
+
+        mod = _Mod()
+        swd = brainstate.nn.StateWithDelay(mod, 'plain')
+        with self.assertRaises(TypeError):
+            _ = swd.state
+
+    def test_state_with_delay_reset(self):
+        """StateWithDelay supports reset_state after init_state."""
+        mod = self._make_module()
+        swd = brainstate.nn.StateWithDelay(mod, 'V')
+        # Register an entry so the ring buffer is longer than one step,
+        # which lets the write pointer advance past zero.
+        swd.register_entry('e', 0.5)
+        swd.init_state()
+        for i in range(3):
+            mod.V.value = jnp.ones((3,)) * i
+            swd.update()
+        self.assertNotEqual(int(swd.write_ptr.value), 0)
+        swd.reset_state()
+        self.assertEqual(int(swd.write_ptr.value), 0)
+
+
+class TestDelayUnitAware(unittest.TestCase):
+    """Tests for unit-aware delay retrieval."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_take_aware_unit_update_records_unit(self):
+        """A unit-aware delay records the unit of the incoming data on update."""
+        import brainunit as u
+        delay = brainstate.nn.Delay(jnp.zeros((2,)) * u.mV, time=1.0, take_aware_unit=True)
+        delay.init_state()
+        for i in range(5):
+            delay.update(jnp.ones((2,)) * i * u.mV)
+        self.assertEqual(delay._unit, u.mV)
+
+    @pytest.mark.skip(reason="BUG: take_aware_unit retrieval fails with pytree node mismatch "
+                             "(Quantity history vs Unit _unit) in _retrieve_at_step_impl")
+    def test_take_aware_unit_retrieval(self):
+        """A unit-aware delay should return values carrying the original unit."""
+        import brainunit as u
+        delay = brainstate.nn.Delay(jnp.zeros((2,)) * u.mV, time=1.0, take_aware_unit=True)
+        delay.register_entry('e', 0.5)
+        delay.init_state()
+        for i in range(10):
+            delay.update(jnp.ones((2,)) * i * u.mV)
+        result = delay.at('e')
+        self.assertEqual(u.get_unit(result), u.mV)
+
+
+class TestDelayMethodBackwardCompat(unittest.TestCase):
+    """Tests for the deprecated delay_method argument handling."""
+
+    def setUp(self):
+        """Configure the integration time step."""
+        brainstate.environ.set(dt=0.1)
+
+    def tearDown(self):
+        """Restore the environment."""
+        brainstate.environ.pop('dt')
+
+    def test_delay_method_none_defaults_to_rotation(self):
+        """Passing ``delay_method=None`` falls back to the rotation ring buffer."""
+        delay = brainstate.nn.Delay(jnp.zeros((1,)), time=1.0, delay_method=None)
+        delay.init_state()
+        self.assertEqual(delay.delay_method, 'rotation')

--- a/brainstate/nn/_dynamics_test.py
+++ b/brainstate/nn/_dynamics_test.py
@@ -18,9 +18,46 @@
 
 import unittest
 
+import brainunit as u
+import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import brainstate
+from brainstate import _testing
+from brainstate.nn._dynamics import (
+    Dynamics,
+    Prefetch,
+    PrefetchDelay,
+    PrefetchDelayAt,
+    OutputDelayAt,
+    init_maybe_prefetch,
+    receive_update_output,
+    not_receive_update_output,
+    receive_update_input,
+    not_receive_update_input,
+    _get_prefetch_item,
+    _get_prefetch_item_delay,
+    _get_prefetch_delay_key,
+    _get_output_delay_key,
+)
+
+
+class _Neuron(Dynamics):
+    """Minimal concrete ``Dynamics`` subclass holding a single voltage state.
+
+    Used across the dynamics tests to exercise state init, prefetch, and delay
+    helpers without depending on a full neuron model implementation.
+    """
+
+    def init_state(self, *args, **kwargs):
+        """Allocate the voltage hidden state with the module's variable shape."""
+        self.V = brainstate.HiddenState(jnp.zeros(self.varshape))
+
+    def update(self, x=0.0):
+        """Accumulate the input into the voltage and return the new value."""
+        self.V.value = self.V.value + x
+        return self.V.value
 
 
 class TestModuleGroup(unittest.TestCase):
@@ -47,6 +84,447 @@ class TestDynamics(unittest.TestCase):
         self.assertEqual(dyn.varshape, (2, 3))
         dyn = brainstate.nn.Dynamics(in_size=(2, 3))
         self.assertEqual(dyn.varshape, (2, 3))
+
+
+class TestDynamicsSizeNormalization(unittest.TestCase):
+    """Verify ``in_size``/``out_size``/``varshape`` normalization and validation."""
+
+    def test_int_is_wrapped_in_tuple(self):
+        """A scalar ``in_size`` is normalized to a 1-tuple."""
+        dyn = Dynamics(in_size=7)
+        self.assertEqual(dyn.in_size, (7,))
+        self.assertEqual(dyn.out_size, (7,))
+        self.assertEqual(dyn.varshape, (7,))
+
+    def test_numpy_integer_is_accepted(self):
+        """A numpy integer scalar is accepted as ``in_size``."""
+        dyn = Dynamics(in_size=np.int64(5))
+        self.assertEqual(dyn.in_size, (5,))
+
+    def test_list_is_converted_to_tuple(self):
+        """A list ``in_size`` is converted to a tuple and preserved."""
+        dyn = Dynamics(in_size=[2, 3, 4])
+        self.assertEqual(dyn.in_size, (2, 3, 4))
+        self.assertEqual(dyn.varshape, (2, 3, 4))
+
+    def test_empty_sequence_raises(self):
+        """An empty sequence ``in_size`` raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            Dynamics(in_size=())
+
+    def test_non_integer_first_element_raises(self):
+        """A sequence whose first element is not an int raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            Dynamics(in_size=(1.5, 2))
+
+    def test_non_integer_scalar_raises(self):
+        """A non-int, non-sequence ``in_size`` raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            Dynamics(in_size=3.5)
+
+    def test_name_is_recorded(self):
+        """The optional ``name`` argument is exposed read-only."""
+        dyn = Dynamics(in_size=4, name='my_dyn')
+        self.assertEqual(dyn.name, 'my_dyn')
+
+
+class TestDynamicsUpdateHooks(unittest.TestCase):
+    """Cover registration, lookup, and dispatch of before/after update hooks."""
+
+    def test_before_updates_starts_none(self):
+        """Before/after update registries start as ``None``."""
+        dyn = Dynamics(3)
+        self.assertIsNone(dyn.before_updates)
+        self.assertIsNone(dyn.after_updates)
+
+    def test_add_and_get_before_update(self):
+        """A registered before-update is retrievable and reported as present."""
+        dyn = Dynamics(3)
+        fn = lambda: None
+        dyn.add_before_update('k', fn)
+        self.assertTrue(dyn.has_before_update('k'))
+        self.assertIs(dyn.get_before_update('k'), fn)
+
+    def test_add_and_get_after_update(self):
+        """A registered after-update is retrievable and reported as present."""
+        dyn = Dynamics(3)
+        fn = lambda ret: None
+        dyn.add_after_update('k', fn)
+        self.assertTrue(dyn.has_after_update('k'))
+        self.assertIs(dyn.get_after_update('k'), fn)
+
+    def test_duplicate_before_key_raises(self):
+        """Re-registering a before-update key raises ``KeyError``."""
+        dyn = Dynamics(3)
+        dyn.add_before_update('k', lambda: None)
+        with self.assertRaises(KeyError):
+            dyn.add_before_update('k', lambda: None)
+
+    def test_duplicate_after_key_raises(self):
+        """Re-registering an after-update key raises ``KeyError``."""
+        dyn = Dynamics(3)
+        dyn.add_after_update('k', lambda r: None)
+        with self.assertRaises(KeyError):
+            dyn.add_after_update('k', lambda r: None)
+
+    def test_get_missing_before_when_none_raises(self):
+        """Getting a before-update when none are registered raises ``KeyError``."""
+        dyn = Dynamics(3)
+        with self.assertRaises(KeyError):
+            dyn.get_before_update('missing')
+
+    def test_get_missing_before_when_present_raises(self):
+        """Getting an unknown before-update key raises ``KeyError``."""
+        dyn = Dynamics(3)
+        dyn.add_before_update('present', lambda: None)
+        with self.assertRaises(KeyError):
+            dyn.get_before_update('missing')
+
+    def test_get_missing_after_when_none_raises(self):
+        """Getting an after-update when none are registered raises ``KeyError``."""
+        dyn = Dynamics(3)
+        with self.assertRaises(KeyError):
+            dyn.get_after_update('missing')
+
+    def test_get_missing_after_when_present_raises(self):
+        """Getting an unknown after-update key raises ``KeyError``."""
+        dyn = Dynamics(3)
+        dyn.add_after_update('present', lambda r: None)
+        with self.assertRaises(KeyError):
+            dyn.get_after_update('missing')
+
+    def test_has_update_false_when_none(self):
+        """``has_*_update`` returns False when no registry exists."""
+        dyn = Dynamics(3)
+        self.assertFalse(dyn.has_before_update('x'))
+        self.assertFalse(dyn.has_after_update('x'))
+
+    def test_call_dispatches_hooks_in_order(self):
+        """``__call__`` runs before hooks, ``update``, then after hooks."""
+
+        class _N(Dynamics):
+            """Tiny dynamics returning input plus one."""
+
+            def update(self, x=0.0):
+                """Return ``x + 1``."""
+                return x + 1
+
+        dyn = _N(2)
+        log = []
+
+        class _BefInput:
+            """Before hook that receives the update input."""
+
+            def __call__(self, *a, **k):
+                log.append(('bef_in', a))
+
+        receive_update_input(_BefInput)
+        dyn.add_before_update('b_in', _BefInput())
+
+        class _BefNoInput:
+            """Before hook that takes no input."""
+
+            def __call__(self):
+                log.append(('bef_noin',))
+
+        dyn.add_before_update('b_noin', _BefNoInput())
+
+        class _AftOutput:
+            """After hook that receives the update output."""
+
+            def __call__(self, ret):
+                log.append(('aft_out', ret))
+
+        dyn.add_after_update('a_out', _AftOutput())
+
+        class _AftNoOutput:
+            """After hook that ignores the update output."""
+
+            def __call__(self):
+                log.append(('aft_noout',))
+
+        not_receive_update_output(_AftNoOutput)
+        dyn.add_after_update('a_noout', _AftNoOutput())
+
+        result = dyn(5)
+        self.assertEqual(result, 6)
+        self.assertEqual(
+            log,
+            [('bef_in', (5,)), ('bef_noin',), ('aft_out', 6), ('aft_noout',)],
+        )
+
+
+class TestUpdateDecorators(unittest.TestCase):
+    """Cover the receive/not-receive input/output marker decorators."""
+
+    def test_receive_then_not_receive_input(self):
+        """``receive_update_input`` sets a marker that ``not_receive`` removes."""
+
+        class _C:
+            """Marker test target."""
+
+        receive_update_input(_C)
+        self.assertTrue(hasattr(_C, '_receive_update_input'))
+        not_receive_update_input(_C)
+        self.assertFalse(hasattr(_C, '_receive_update_input'))
+
+    def test_not_receive_input_when_absent_is_noop(self):
+        """``not_receive_update_input`` is a no-op when the marker is absent."""
+
+        class _C:
+            """Marker test target."""
+
+        not_receive_update_input(_C)
+        self.assertFalse(hasattr(_C, '_receive_update_input'))
+
+    def test_not_receive_then_receive_output(self):
+        """``not_receive_update_output`` sets a marker that ``receive`` removes."""
+
+        class _C:
+            """Marker test target."""
+
+        not_receive_update_output(_C)
+        self.assertTrue(hasattr(_C, '_not_receive_update_output'))
+        receive_update_output(_C)
+        self.assertFalse(hasattr(_C, '_not_receive_update_output'))
+
+    def test_receive_output_when_absent_is_noop(self):
+        """``receive_update_output`` is a no-op when the marker is absent."""
+
+        class _C:
+            """Marker test target."""
+
+        receive_update_output(_C)
+        self.assertFalse(hasattr(_C, '_not_receive_update_output'))
+
+
+class TestPrefetch(unittest.TestCase):
+    """Cover the ``Prefetch`` reference object and its accessors."""
+
+    def test_prefetch_returns_prefetch(self):
+        """``Dynamics.prefetch`` returns a ``Prefetch`` bound to the module."""
+        dyn = _Neuron(3)
+        dyn.init_all_states()
+        pf = dyn.prefetch('V')
+        self.assertIsInstance(pf, Prefetch)
+        self.assertIs(pf.module, dyn)
+        self.assertEqual(pf.item, 'V')
+
+    def test_call_returns_state_value(self):
+        """Calling a ``Prefetch`` on a ``State`` returns its value array."""
+        dyn = _Neuron(3)
+        dyn.init_all_states()
+        pf = dyn.prefetch('V')
+        _testing.assert_allclose(pf(), jnp.zeros(3))
+
+    def test_get_item_value_matches_call(self):
+        """``get_item_value`` returns the same value as ``__call__``."""
+        dyn = _Neuron(3)
+        dyn.init_all_states()
+        pf = dyn.prefetch('V')
+        _testing.assert_allclose(pf.get_item_value(), pf())
+
+    def test_get_item_returns_state_object(self):
+        """``get_item`` returns the underlying ``State`` object, not its value."""
+        dyn = _Neuron(3)
+        dyn.init_all_states()
+        pf = dyn.prefetch('V')
+        self.assertIsInstance(pf.get_item(), brainstate.State)
+
+    def test_call_returns_plain_attribute(self):
+        """A prefetch of a non-State attribute returns the attribute itself."""
+        dyn = _Neuron(3)
+        dyn.plain = 42
+        pf = dyn.prefetch('plain')
+        self.assertEqual(pf(), 42)
+
+    def test_missing_attribute_raises(self):
+        """Prefetching a missing attribute raises ``AttributeError`` on access."""
+        dyn = _Neuron(3)
+        pf = dyn.prefetch('does_not_exist')
+        with self.assertRaises(AttributeError):
+            pf()
+
+    def test_delay_property_returns_prefetch_delay(self):
+        """The ``.delay`` property returns a ``PrefetchDelay``."""
+        dyn = _Neuron(3)
+        pd = dyn.prefetch('V').delay
+        self.assertIsInstance(pd, PrefetchDelay)
+        self.assertEqual(pd.item, 'V')
+
+
+class TestPrefetchDelay(unittest.TestCase):
+    """Cover the delayed-access prefetch chain (``PrefetchDelay``/``PrefetchDelayAt``)."""
+
+    def test_delay_at_returns_prefetch_delay_at(self):
+        """``PrefetchDelay.at`` returns a ``PrefetchDelayAt``."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            at = dyn.prefetch('V').delay.at(0.5 * u.ms)
+            self.assertIsInstance(at, PrefetchDelayAt)
+
+    def test_prefetch_delay_registers_after_update(self):
+        """``prefetch_delay`` registers a ``StateWithDelay`` after-update hook."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            dyn.prefetch_delay('V', 1.0 * u.ms)
+            key = _get_prefetch_delay_key('V', None)
+            self.assertTrue(dyn.has_after_update(key))
+
+    def test_prefetch_delay_retrieves_past_value(self):
+        """A registered prefetch delay retrieves the state value from the past."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            delayed = dyn.prefetch_delay('V', 1.0 * u.ms)
+            dyn.init_all_states()
+            for i in range(20):
+                with brainstate.environ.context(i=i, t=i * 0.1 * u.ms):
+                    dyn(jnp.ones(3))
+            # 10 steps of delay -> value 10 steps ago (current is 20).
+            _testing.assert_allclose(delayed(), jnp.ones(3) * 10.0)
+
+    def test_prefetch_delay_at_empty_time_returns_current(self):
+        """A ``PrefetchDelayAt`` built with no delay time returns the current value."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            dyn.init_all_states()
+            at = PrefetchDelayAt(dyn, 'V')
+            self.assertEqual(len(at.delay_time), 0)
+            _testing.assert_allclose(at(), jnp.zeros(3))
+
+    def test_prefetch_delay_at_unpacks_single_sequence(self):
+        """A single tuple of (time,) argument is unpacked to scalar delay time."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            at = PrefetchDelayAt(dyn, 'V', (1.0 * u.ms,))
+            self.assertEqual(len(at.delay_time), 1)
+
+    def test_prefetch_delay_at_requires_dynamics(self):
+        """Constructing a ``PrefetchDelayAt`` with a non-Dynamics module fails."""
+        with self.assertRaises(AssertionError):
+            PrefetchDelayAt(object(), 'V')
+
+
+class TestOutputDelay(unittest.TestCase):
+    """Cover the module output delay helper ``OutputDelayAt``."""
+
+    def test_output_delay_registers_after_update(self):
+        """``output_delay`` registers an output-delay after-update hook."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            dyn.output_delay(1.0 * u.ms)
+            self.assertTrue(dyn.has_after_update(_get_output_delay_key(None)))
+
+    def test_output_delay_retrieves_past_output(self):
+        """A registered output delay retrieves the module output from the past."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            delayed = dyn.output_delay(1.0 * u.ms)
+            dyn.init_all_states()
+            for i in range(20):
+                with brainstate.environ.context(i=i, t=i * 0.1 * u.ms):
+                    dyn(jnp.ones(3))
+            _testing.assert_allclose(delayed(), jnp.ones(3) * 10.0)
+
+    def test_output_delay_requires_dynamics(self):
+        """Constructing an ``OutputDelayAt`` with a non-Dynamics module fails."""
+        with self.assertRaises(AssertionError):
+            OutputDelayAt(object(), 1.0 * u.ms)
+
+
+class TestInitMaybePrefetch(unittest.TestCase):
+    """Cover the ``init_maybe_prefetch`` dispatcher over prefetch object types."""
+
+    def test_init_prefetch(self):
+        """Initializing a ``Prefetch`` resolves the referenced item."""
+        dyn = _Neuron(3)
+        dyn.init_all_states()
+        init_maybe_prefetch(dyn.prefetch('V'))  # should not raise
+
+    def test_init_prefetch_missing_attribute_raises(self):
+        """Initializing a ``Prefetch`` of a missing attribute raises ``AttributeError``."""
+        dyn = _Neuron(3)
+        with self.assertRaises(AttributeError):
+            init_maybe_prefetch(Prefetch(dyn, 'missing'))
+
+    def test_init_prefetch_delay_at_is_noop(self):
+        """Initializing a ``PrefetchDelayAt`` performs no action."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            at = dyn.prefetch_delay('V', 1.0 * u.ms)
+            init_maybe_prefetch(at)  # PrefetchDelayAt branch: pass
+
+    def test_init_prefetch_delay_hits_key_arity_bug(self):
+        """Initializing a ``PrefetchDelay`` hits the key-arity bug (documents BUG).
+
+        The intended behavior is to resolve the registered delay handler, but
+        ``_get_prefetch_item_delay`` calls ``_get_prefetch_delay_key(item)`` with
+        a single argument while that helper now requires ``(item, update_every)``,
+        so a ``TypeError`` is raised before the lookup can complete.
+        """
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            dyn.prefetch_delay('V', 1.0 * u.ms)
+            with self.assertRaises(TypeError):
+                init_maybe_prefetch(dyn.prefetch('V').delay)
+
+
+class TestPrefetchItemDelayHelper(unittest.TestCase):
+    """Cover reachable lines of the ``_get_prefetch_item_delay`` helper."""
+
+    def test_non_dynamics_module_asserts(self):
+        """The helper asserts that the target module is a ``Dynamics``."""
+
+        class _Fake:
+            """Stand-in target whose module is not a Dynamics."""
+
+            module = object()
+            item = 'V'
+
+        with self.assertRaises(AssertionError):
+            _get_prefetch_item_delay(_Fake())
+
+    def test_key_helper_arity_bug_raises_type_error(self):
+        """The helper hits the key-arity bug and raises ``TypeError`` (documents BUG)."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            dyn.prefetch_delay('V', 1.0 * u.ms)
+            with self.assertRaises(TypeError):
+                _get_prefetch_item_delay(dyn.prefetch('V').delay)
+
+
+class TestDelayRegistrationReuse(unittest.TestCase):
+    """Cover the reuse path when a delay hook is already registered."""
+
+    def test_second_prefetch_delay_reuses_hook(self):
+        """A second ``prefetch_delay`` on the same state reuses the after-update hook."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            first = dyn.prefetch_delay('V', 1.0 * u.ms)
+            second = dyn.prefetch_delay('V', 2.0 * u.ms)
+            # Both share the same StateWithDelay hook instance.
+            self.assertIs(first.state_delay, second.state_delay)
+
+    def test_second_output_delay_reuses_hook(self):
+        """A second ``output_delay`` reuses the registered output-delay hook."""
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            dyn = _Neuron(3)
+            first = dyn.output_delay(1.0 * u.ms)
+            second = dyn.output_delay(2.0 * u.ms)
+            self.assertIs(first.out_delay, second.out_delay)
+
+
+class TestDelayKeyHelpers(unittest.TestCase):
+    """Cover the internal delay-key formatting helpers."""
+
+    def test_prefetch_delay_key_format(self):
+        """``_get_prefetch_delay_key`` embeds the item and update_every."""
+        self.assertEqual(_get_prefetch_delay_key('V', None), 'V-prefetch-delay-None')
+        self.assertEqual(_get_prefetch_delay_key('V', 5.0), 'V-prefetch-delay-5.0')
+
+    def test_output_delay_key_format(self):
+        """``_get_output_delay_key`` embeds the update_every value."""
+        self.assertEqual(_get_output_delay_key(None), 'output-delay-None')
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_embedding_test.py
+++ b/brainstate/nn/_embedding_test.py
@@ -21,6 +21,8 @@ import jax
 import jax.numpy as jnp
 
 import brainstate as bs
+from brainstate import _testing
+from brainstate._testing import assert_allclose
 
 
 class TestEmbedding(unittest.TestCase):
@@ -150,6 +152,177 @@ class TestEmbedding(unittest.TestCase):
         row_norm = jnp.linalg.norm(embedding.weight.value[1])
         self.assertLessEqual(float(row_norm), 1.0 + 1e-6)
         self.assertTrue(jnp.allclose(embedding.weight.value[0], custom_weight[0]))
+
+
+class TestEmbeddingConstructionValidation(unittest.TestCase):
+    """Validation of Embedding constructor arguments and shapes."""
+
+    def test_empty_embedding_size_raises(self):
+        """Empty embedding_size must raise ValueError."""
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding(num_embeddings=4, embedding_size=())
+
+    def test_negative_embedding_size_raises(self):
+        """Negative embedding_size values must raise ValueError."""
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding(num_embeddings=4, embedding_size=(-3,))
+
+    def test_negative_num_embeddings_raises(self):
+        """Negative num_embeddings must raise ValueError."""
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding(num_embeddings=-1, embedding_size=3)
+
+    def test_padding_idx_out_of_range_raises(self):
+        """padding_idx outside [0, num_embeddings) must raise ValueError."""
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding(num_embeddings=4, embedding_size=3, padding_idx=4)
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding(num_embeddings=4, embedding_size=3, padding_idx=-1)
+
+    def test_non_positive_max_norm_raises(self):
+        """A non-positive max_norm must raise ValueError."""
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding(num_embeddings=4, embedding_size=3, max_norm=0.0)
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding(num_embeddings=4, embedding_size=3, max_norm=-1.0)
+
+    def test_multidim_embedding_size_shape(self):
+        """A tuple embedding_size yields a multi-dimensional weight table."""
+        embedding = bs.nn.Embedding(num_embeddings=5, embedding_size=(2, 3))
+        self.assertEqual(embedding.weight.value.shape, (5, 2, 3))
+        self.assertEqual(embedding.embedding_size, (2, 3))
+        self.assertEqual(embedding.out_size, (2, 3))
+
+
+class TestEmbeddingFromPretrainedValidation(unittest.TestCase):
+    """Validation of from_pretrained inputs."""
+
+    def test_from_pretrained_low_dim_raises(self):
+        """A 1-D pretrained array must raise ValueError."""
+        with self.assertRaises(ValueError):
+            bs.nn.Embedding.from_pretrained(jnp.arange(4.0))
+
+
+class TestEmbeddingUpdateValidation(unittest.TestCase):
+    """Behavior of Embedding.update under various index inputs."""
+
+    def setUp(self):
+        """Force fitting mode so running-state writes are exercised."""
+        settings = bs.environ.all()
+        self._prev_fit = settings.get('fit', None)
+        bs.environ.set(fit=True)
+
+    def tearDown(self):
+        """Restore the previous fit setting."""
+        if self._prev_fit is None:
+            bs.environ.pop('fit', None)
+        else:
+            bs.environ.set(fit=self._prev_fit)
+
+    def test_non_integer_indices_raise(self):
+        """Floating point indices must raise TypeError."""
+        embedding = bs.nn.Embedding(num_embeddings=4, embedding_size=3)
+        with self.assertRaises(TypeError):
+            embedding(jnp.array([0.0, 1.0]))
+
+    def test_empty_indices_lookup(self):
+        """Looking up an empty index array yields an empty embedding output."""
+        embedding = bs.nn.Embedding(num_embeddings=4, embedding_size=3)
+        out = embedding(jnp.zeros((0,), dtype=jnp.int32))
+        self.assertEqual(out.shape, (0, 3))
+
+    def test_empty_indices_zero_gradient(self):
+        """An empty index lookup produces an all-zero weight gradient."""
+        embedding = bs.nn.Embedding(num_embeddings=4, embedding_size=3)
+        lookup = embedding._lookup
+        weight = jnp.arange(12.0, dtype=jnp.float32).reshape(4, 3)
+        empty = jnp.zeros((0,), dtype=jnp.int32)
+
+        def loss_fn(w):
+            return jnp.sum(lookup(w, empty))
+
+        grad = jax.grad(loss_fn)(weight)
+        self.assertEqual(grad.shape, weight.shape)
+        self.assertTrue(jnp.allclose(grad, 0.0))
+
+    def test_max_norm_empty_indices_keeps_weight(self):
+        """max_norm with an empty index array leaves the weights unchanged."""
+        embedding = bs.nn.Embedding(num_embeddings=3, embedding_size=3, max_norm=1.0)
+        custom = jnp.array([[3.0, 4.0, 0.0], [0.0, 5.0, 12.0], [1.0, 1.0, 1.0]],
+                           dtype=jnp.float32)
+        embedding.weight.value = custom
+        _ = embedding(jnp.zeros((0,), dtype=jnp.int32))
+        assert_allclose(embedding.weight.value, custom)
+
+    def test_max_norm_all_padding_indices_keeps_weight(self):
+        """max_norm with only the padding index leaves the weights unchanged."""
+        embedding = bs.nn.Embedding(
+            num_embeddings=3, embedding_size=3, max_norm=1.0, padding_idx=0
+        )
+        custom = jnp.array([[0.0, 0.0, 0.0], [3.0, 4.0, 0.0], [0.5, 0.5, 0.5]],
+                           dtype=jnp.float32)
+        embedding.weight.value = custom
+        # Index 0 is the padding index, filtered out by _apply_max_norm.
+        _ = embedding(jnp.array([0, 0], dtype=jnp.int32))
+        assert_allclose(embedding.weight.value, custom)
+
+    def test_max_norm_skips_padding_row(self):
+        """max_norm renormalizes non-padding rows but never the padding row."""
+        embedding = bs.nn.Embedding(
+            num_embeddings=3, embedding_size=3, max_norm=1.0, padding_idx=0
+        )
+        custom = jnp.array([[0.0, 0.0, 0.0], [3.0, 4.0, 0.0], [6.0, 8.0, 0.0]],
+                           dtype=jnp.float32)
+        embedding.weight.value = custom
+        _ = embedding(jnp.array([0, 1, 2], dtype=jnp.int32))
+        # Padding row stays exactly zero.
+        assert_allclose(embedding.weight.value[0], custom[0])
+        # Non-padding rows are clipped to norm <= 1.
+        self.assertLessEqual(float(jnp.linalg.norm(embedding.weight.value[1])), 1.0 + 1e-6)
+        self.assertLessEqual(float(jnp.linalg.norm(embedding.weight.value[2])), 1.0 + 1e-6)
+
+
+class TestEmbeddingForwardSemantics(unittest.TestCase):
+    """End-to-end forward semantics of the lookup table."""
+
+    def setUp(self):
+        """Force fitting mode for these tests."""
+        settings = bs.environ.all()
+        self._prev_fit = settings.get('fit', None)
+        bs.environ.set(fit=True)
+
+    def tearDown(self):
+        """Restore the previous fit setting."""
+        if self._prev_fit is None:
+            bs.environ.pop('fit', None)
+        else:
+            bs.environ.set(fit=self._prev_fit)
+
+    def test_lookup_matches_weight_rows(self):
+        """The forward pass returns the matching rows of the weight table."""
+        weight = jnp.arange(12.0, dtype=jnp.float32).reshape(4, 3)
+        embedding = bs.nn.Embedding.from_pretrained(weight, freeze=False)
+        indices = jnp.array([3, 0, 2], dtype=jnp.int32)
+        out = embedding(indices)
+        assert_allclose(out, weight[indices])
+
+    def test_batched_indices_shape(self):
+        """Batched 2-D indices produce stacked embeddings."""
+        embedding = bs.nn.Embedding(num_embeddings=10, embedding_size=3)
+        indices = jnp.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=jnp.int32)
+        out = embedding(indices)
+        self.assertEqual(out.shape, (2, 4, 3))
+
+    def test_grad_finite_through_lookup(self):
+        """Gradients through the embedding lookup are finite."""
+        embedding = bs.nn.Embedding(num_embeddings=5, embedding_size=4)
+        indices = jnp.array([0, 2, 4], dtype=jnp.int32)
+
+        def loss_fn(weight):
+            embedding.weight.value = weight
+            return jnp.sum(embedding(indices) ** 2)
+
+        _testing.assert_grad_finite(loss_fn, embedding.weight.value)
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_event_fixedprob_test.py
+++ b/brainstate/nn/_event_fixedprob_test.py
@@ -16,10 +16,18 @@
 
 import jax.numpy
 import jax.numpy as jnp
+import brainunit as u
+import numpy as np
 import pytest
 
 import brainstate
 import braintools
+from brainstate.nn._event_fixedprob import (
+    FixedNumConn,
+    EventFixedNumConn,
+    EventFixedProb,
+    init_indices_without_replace,
+)
 
 
 class TestFixedProbCSR:
@@ -113,3 +121,140 @@ class TestFixedProbCSR:
         assert (jnp.allclose(o1, o2))
         # assert jnp.allclose(r1, r2), f'r1={r1}, r2={r2}'
         assert (jnp.allclose(r1, r2, rtol=1e-4, atol=1e-4))
+
+
+class TestInitIndicesWithoutReplace:
+    """Cover the ``init_indices_without_replace`` connection-index sampler."""
+
+    def test_vmap_method_shape(self):
+        """The ``'vmap'`` method returns indices of shape ``(n_pre, conn_num)``."""
+        idx = init_indices_without_replace(3, 5, 10, seed=42, method='vmap')
+        assert idx.shape == (5, 3)
+        assert bool((idx >= 0).all()) and bool((idx < 10).all())
+
+    def test_for_loop_method_shape(self):
+        """The ``'for_loop'`` method returns indices of shape ``(n_pre, conn_num)``."""
+        idx = init_indices_without_replace(3, 5, 10, seed=42, method='for_loop')
+        assert idx.shape == (5, 3)
+        assert bool((idx >= 0).all()) and bool((idx < 10).all())
+
+    def test_no_replacement_within_row(self):
+        """Sampling without replacement yields distinct indices within each row."""
+        idx = np.asarray(init_indices_without_replace(4, 6, 10, seed=7, method='for_loop'))
+        for row in idx:
+            assert len(set(row.tolist())) == len(row)
+
+    def test_unknown_method_raises(self):
+        """An unrecognized method name raises ``ValueError``."""
+        with pytest.raises(ValueError, match='Unknown method'):
+            init_indices_without_replace(3, 5, 10, seed=1, method='bogus')
+
+
+class TestFixedNumConnConstruction:
+    """Cover ``FixedNumConn`` construction branches and validation."""
+
+    def test_int_conn_num_is_used_directly(self):
+        """An integer ``conn_num`` is used as the literal connection count."""
+        m = FixedNumConn(20, 40, 5, 1.0, seed=1)
+        assert m.conn_num == 5
+
+    def test_float_conn_num_post_uses_out_size(self):
+        """A float ``conn_num`` with 'post' target scales by the output size."""
+        m = FixedNumConn(20, 40, 0.25, 1.0, efferent_target='post', seed=1)
+        assert m.conn_num == int(40 * 0.25)
+
+    def test_no_replacement_construction_for_loop(self):
+        """``allow_multi_conn=False`` with ``conn_init='for_loop'`` builds a valid module."""
+        m = FixedNumConn(20, 40, 0.2, 1.0, seed=3,
+                         allow_multi_conn=False, conn_init='for_loop')
+        out = m(brainstate.random.rand(20))
+        assert out.shape == (40,)
+
+    def test_invalid_efferent_target_raises(self):
+        """An ``efferent_target`` other than 'pre'/'post' raises ``AssertionError``."""
+        with pytest.raises(AssertionError):
+            FixedNumConn(20, 40, 0.1, 1.0, efferent_target='sideways', seed=1)
+
+    def test_afferent_ratio_out_of_range_raises(self):
+        """An ``afferent_ratio`` outside ``[0, 1]`` raises ``AssertionError``."""
+        with pytest.raises(AssertionError):
+            FixedNumConn(20, 40, 0.1, 1.0, afferent_ratio=1.5, seed=1)
+
+    def test_float_conn_prob_out_of_range_raises(self):
+        """A float connection probability outside ``[0, 1]`` raises ``AssertionError``."""
+        with pytest.raises(AssertionError):
+            FixedNumConn(20, 40, 1.5, 1.0, seed=1)
+
+    def test_afferent_ratio_post_csr_branch(self):
+        """A sub-unity ``afferent_ratio`` with 'post' target builds a CSR connection."""
+        m = FixedNumConn(20, 40, 0.2, 1.0, efferent_target='post',
+                         afferent_ratio=0.5, seed=1)
+        assert m.pre_selected.shape == (20,)
+        out = m(brainstate.random.rand(20))
+        assert out.shape == (40,)
+
+
+class TestFixedNumConnZeroConnection:
+    """Cover the zero-connection (FakeState) path of ``FixedNumConn``."""
+
+    def test_zero_conn_num_uses_fake_state(self):
+        """A connection probability of 0 yields zero connections and a FakeState weight."""
+        m = FixedNumConn(20, 40, 0.0, 1.0, seed=1)
+        assert m.conn_num == 0
+
+    def test_zero_conn_update_returns_zeros(self):
+        """Updating a zero-connection module returns an all-zero output of out_size."""
+        m = FixedNumConn(20, 40, 0.0, 1.0, seed=1)
+        out = m(brainstate.random.rand(20))
+        assert out.shape == (40,)
+        assert bool((u.get_magnitude(out) == 0).all())
+
+
+class TestEventFixedProbAlias:
+    """Cover the ``EventFixedProb``/``EventFixedNumConn`` event-array update path."""
+
+    def test_alias_identity(self):
+        """``EventFixedProb`` is an alias of ``EventFixedNumConn``."""
+        assert EventFixedProb is EventFixedNumConn
+
+    def test_event_update_matches_dense_reference(self):
+        """The event update equals a manual scatter-add reference computation."""
+        n_in, n_out = 20, 30
+        fn = EventFixedProb(n_in, n_out, 0.2, 1.5, seed=11)
+        spk = jax.numpy.asarray(brainstate.random.rand(n_in) < 0.3, dtype=float)
+        out = np.asarray(fn(spk))
+
+        indices = np.asarray(fn.conn.indices)
+        ref = np.zeros((n_out,))
+        # allow_multi_conn=True permits repeated post indices within a row, so the
+        # contributions must be accumulated (np.add.at), matching the sparse matmul.
+        for i in range(n_in):
+            np.add.at(ref, indices[i], 1.5 * float(spk[i]))
+        assert np.allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+
+class TestFixedNumConnKnownBugs:
+    """Document genuine construction bugs in the ``efferent_target='pre'`` path."""
+
+    @pytest.mark.skip(reason="BUG: efferent_target='pre' crashes in brainevent."
+                             " FixedNumConn builds indices of shape (n_pre, conn_num) = "
+                             "(out_size, conn_num) but brainevent.FixedPreNumConn(shape=(n_pre, "
+                             "n_post)) validates indices rows against shape[1]=n_post=in_size, "
+                             "raising 'Pre-synaptic row number mismatch. 40 != 20'.")
+    def test_efferent_target_pre_constructs(self):
+        """``efferent_target='pre'`` should construct a valid connection (currently crashes)."""
+        m = FixedNumConn(20, 40, 0.2, 1.0, efferent_target='pre', seed=1)
+        out = m(brainstate.random.rand(40))
+        assert out.shape == (20,)
+
+    @pytest.mark.skip(reason="BUG: efferent_target='pre' with afferent_ratio<1 triggers a native"
+                             " memory abort ('free(): invalid next size (fast)') inside the "
+                             "brainevent CSC path, because indices are sized for (n_pre, conn_num)"
+                             " = (out_size, conn_num) rather than the n_post=in_size rows the CSC "
+                             "shape expects.")
+    def test_efferent_target_pre_afferent_ratio_constructs(self):
+        """'pre' target with sub-unity afferent_ratio should build a CSC connection."""
+        m = FixedNumConn(20, 40, 0.2, 1.0, efferent_target='pre',
+                         afferent_ratio=0.5, seed=1)
+        out = m(brainstate.random.rand(40))
+        assert out.shape == (20,)

--- a/brainstate/nn/_hidata_test.py
+++ b/brainstate/nn/_hidata_test.py
@@ -20,6 +20,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from brainstate.nn import HiData
+from brainstate.nn import _hidata
 
 
 class TestAutoDataclass(unittest.TestCase):
@@ -457,6 +458,88 @@ class TestDataHierarchicalRepr(unittest.TestCase):
         self.assertIn("layers=3", result)
         self.assertIn("epochs=100", result)
         self.assertIn("weights=Array(shape=(10, 5), dtype=float", result)
+
+
+class TestModuleIsDataclassHelper(unittest.TestCase):
+    """Cover the module-level ``is_dataclass`` marker helper."""
+
+    def test_true_for_hidata(self):
+        """``HiData`` carries the ``_brainstate_dataclass`` marker."""
+        self.assertTrue(_hidata.is_dataclass(HiData))
+
+    def test_false_for_plain_type(self):
+        """A plain class without the marker returns ``False``."""
+        self.assertFalse(_hidata.is_dataclass(int))
+
+
+class TestHiDataLen(unittest.TestCase):
+    """Cover ``HiData.__len__``."""
+
+    def test_len_counts_children(self):
+        """``len`` reflects the number of children."""
+        self.assertEqual(len(HiData()), 0)
+        self.assertEqual(len(HiData(a=1, b=2, c=3)), 3)
+
+
+class TestHiDataAdd(unittest.TestCase):
+    """Cover ``HiData.add`` merging of dicts, HiData args, and kwargs."""
+
+    def test_add_kwargs(self):
+        """Keyword updates are merged into a new HiData."""
+        base = HiData(a=1)
+        merged = base.add(b=2, c=3)
+        self.assertEqual(sorted(merged.keys()), ['a', 'b', 'c'])
+        # Original is untouched.
+        self.assertEqual(sorted(base.keys()), ['a'])
+
+    def test_add_dict_arg(self):
+        """A dict positional argument is merged in."""
+        merged = HiData(a=1).add({'b': 2})
+        self.assertEqual(merged['b'], 2)
+
+    def test_add_hidata_arg(self):
+        """A HiData positional argument contributes its children."""
+        merged = HiData(a=1).add(HiData(z=9))
+        self.assertEqual(merged['z'], 9)
+
+    def test_add_invalid_arg_raises(self):
+        """A non HiData/dict positional argument raises ``AssertionError``."""
+        with self.assertRaises(AssertionError):
+            HiData(a=1).add(123)
+
+
+class TestHiDataPop(unittest.TestCase):
+    """Cover ``HiData.pop``."""
+
+    def test_pop_removes_keys(self):
+        """Named keys are removed in the returned HiData."""
+        base = HiData(a=1, b=2, c=3)
+        popped = base.pop('b', 'c')
+        self.assertEqual(sorted(popped.keys()), ['a'])
+        # Original is untouched.
+        self.assertEqual(sorted(base.keys()), ['a', 'b', 'c'])
+
+    def test_pop_missing_key_raises(self):
+        """Popping an absent key raises ``KeyError``."""
+        with self.assertRaises(KeyError):
+            HiData(a=1).pop('missing')
+
+
+class TestHiDataDtypeNestedSkip(unittest.TestCase):
+    """Cover the nested-child ``dtype`` ValueError/continue branch."""
+
+    def test_dtype_skips_array_less_nested_child(self):
+        """A nested child with no arrays is skipped while resolving ``dtype``."""
+        array_less = HiData(meta='no-arrays-here')
+        # Confirm the nested child itself has no resolvable dtype.
+        with self.assertRaises(ValueError):
+            _ = array_less.dtype
+
+        outer = HiData(children={
+            'bad': array_less,
+            'good': HiData(x=jnp.array([1.0], dtype=jnp.float32)),
+        })
+        self.assertEqual(outer.dtype, jnp.float32)
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_module_test.py
+++ b/brainstate/nn/_module_test.py
@@ -15,11 +15,15 @@
 
 import unittest
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
 import brainstate
+from brainstate import _testing
 from brainstate.nn import Module, Param, SoftplusT, L2Reg, L1Reg
+from brainstate.nn._module import Sequential, ElementWiseBlock
+from brainstate._error import BrainStateError
 
 
 class TestModule(unittest.TestCase):
@@ -741,3 +745,498 @@ class TestParamPrecompute(unittest.TestCase):
         # After outer context exits, all caches should be cleared
         self.assertFalse(mod.parent_param.cache_stats['valid'])
         self.assertFalse(mod.child.child_param.cache_stats['valid'])
+
+
+class TestModuleConstruction(unittest.TestCase):
+    """Cover ``Module`` construction, naming, and size normalization."""
+
+    def test_default_name_and_sizes_are_none(self):
+        """A freshly constructed module has no name and undefined sizes."""
+        mod = Module()
+        self.assertIsNone(mod.name)
+        self.assertIsNone(mod.in_size)
+        self.assertIsNone(mod.out_size)
+
+    def test_name_is_stored(self):
+        """A string ``name`` is stored and exposed by the property."""
+        mod = Module(name='layer')
+        self.assertEqual(mod.name, 'layer')
+
+    def test_non_string_name_raises(self):
+        """A non-string ``name`` raises ``AssertionError``."""
+        with self.assertRaises(AssertionError):
+            Module(name=123)
+
+    def test_name_is_read_only(self):
+        """Assigning to ``name`` raises ``AttributeError``."""
+        mod = Module(name='layer')
+        with self.assertRaises(AttributeError):
+            mod.name = 'other'
+
+    def test_in_size_int_normalized_to_tuple(self):
+        """An int ``in_size`` is normalized to a 1-tuple."""
+        mod = Module()
+        mod.in_size = 10
+        self.assertEqual(mod.in_size, (10,))
+
+    def test_in_size_sequence_preserved(self):
+        """A tuple ``in_size`` is preserved as a tuple."""
+        mod = Module()
+        mod.in_size = (2, 3)
+        self.assertEqual(mod.in_size, (2, 3))
+
+    def test_in_size_numpy_scalar(self):
+        """A numpy integer scalar is accepted as ``in_size``."""
+        mod = Module()
+        mod.in_size = np.int32(4)
+        self.assertEqual(mod.in_size, (4,))
+
+    def test_in_size_invalid_type_raises(self):
+        """A non-int, non-sequence ``in_size`` raises ``AssertionError``."""
+        mod = Module()
+        with self.assertRaises(AssertionError):
+            mod.in_size = 'bad'
+
+    def test_out_size_int_normalized_to_tuple(self):
+        """An int ``out_size`` is normalized to a 1-tuple."""
+        mod = Module()
+        mod.out_size = 5
+        self.assertEqual(mod.out_size, (5,))
+
+    def test_out_size_list_preserved(self):
+        """A list ``out_size`` is stored as a tuple."""
+        mod = Module()
+        mod.out_size = [4, 5]
+        self.assertEqual(mod.out_size, (4, 5))
+
+    def test_out_size_invalid_type_raises(self):
+        """A non-int, non-sequence ``out_size`` raises ``AssertionError``."""
+        mod = Module()
+        with self.assertRaises(AssertionError):
+            mod.out_size = 'bad'
+
+
+class TestModuleCall(unittest.TestCase):
+    """Cover ``Module.update``/``__call__`` dispatch and operator support."""
+
+    def test_bare_update_not_implemented(self):
+        """The base ``update`` raises ``NotImplementedError`` when un-overridden."""
+        mod = Module()
+        with self.assertRaises(NotImplementedError):
+            mod.update(1)
+
+    def test_call_forwards_to_update(self):
+        """``__call__`` forwards positional args to ``update``."""
+
+        class _Scale(Module):
+            """Module that scales its input by two."""
+
+            def update(self, x):
+                """Return ``x * 2``."""
+                return x * 2
+
+        mod = _Scale()
+        self.assertEqual(mod(3.0), 6.0)
+
+    def test_rrshift_operator(self):
+        """``x >> module`` invokes ``module(x)``."""
+
+        class _AddOne(Module):
+            """Module that adds one to its input."""
+
+            def update(self, x):
+                """Return ``x + 1``."""
+                return x + 1
+
+        mod = _AddOne()
+        self.assertEqual(5.0 >> mod, 6.0)
+
+    def test_pretty_repr_item_strips_underscore(self):
+        """``__pretty_repr_item__`` strips a leading underscore from names."""
+        mod = Module(name='abc')
+        self.assertEqual(mod.__pretty_repr_item__('_name', 'abc'), ('name', 'abc'))
+
+    def test_pretty_repr_item_hides_none_private(self):
+        """A private attribute with a ``None`` value is hidden from the repr."""
+        mod = Module()
+        self.assertIsNone(mod.__pretty_repr_item__('_in_size', None))
+
+    def test_pretty_repr_item_keeps_public(self):
+        """A public attribute is shown unchanged in the repr."""
+        mod = Module()
+        self.assertEqual(mod.__pretty_repr_item__('pub', 7), ('pub', 7))
+
+    def test_repr_contains_name(self):
+        """The default ``__repr__`` includes the module name."""
+        mod = Module(name='abc')
+        self.assertIn('abc', repr(mod))
+
+
+class TestModuleStateCollection(unittest.TestCase):
+    """Cover ``states``/``state_trees`` collection and filtering."""
+
+    def _make_model(self):
+        """Build a small two-state module for collection tests."""
+
+        class _M(Module):
+            """Module holding one generic state and one parameter state."""
+
+            def __init__(self):
+                super().__init__()
+                self.s = brainstate.State(jnp.ones(3))
+                self.p = Param(jnp.ones(2), fit=True)
+
+        return _M()
+
+    def test_states_collects_all(self):
+        """``states`` returns all states in the module."""
+        mod = self._make_model()
+        collected = mod.states()
+        self.assertEqual(len(collected), 2)
+
+    def test_states_filtered(self):
+        """``states`` with a filter returns only matching states."""
+        mod = self._make_model()
+        params = mod.states(brainstate.ParamState)
+        self.assertEqual(len(params), 1)
+
+    def test_state_trees_unfiltered(self):
+        """``state_trees`` returns a nested state tree."""
+        mod = self._make_model()
+        tree = mod.state_trees()
+        # The tree should contain both leaves.
+        leaves = jax.tree.leaves(tree, is_leaf=lambda x: isinstance(x, brainstate.State))
+        self.assertGreaterEqual(len(leaves), 1)
+
+    def test_state_trees_filtered(self):
+        """``state_trees`` with a filter narrows the returned tree."""
+        mod = self._make_model()
+        tree = mod.state_trees(brainstate.ParamState)
+        self.assertIsNotNone(tree)
+
+    def test_init_and_reset_state_are_noops(self):
+        """The base ``init_state``/``reset_state`` hooks do nothing and return None."""
+        mod = Module()
+        self.assertIsNone(mod.init_state())
+        self.assertIsNone(mod.reset_state())
+
+    def test_named_parameters_no_recurse(self):
+        """``named_parameters`` with ``recurse=False`` yields only direct params."""
+
+        class _Inner(Module):
+            """Inner module with one parameter."""
+
+            def __init__(self):
+                super().__init__()
+                self.w = Param(jnp.ones(2), fit=True)
+
+        class _Outer(Module):
+            """Outer module with a direct param and a child module."""
+
+            def __init__(self):
+                super().__init__()
+                self.direct = Param(jnp.ones(3), fit=True)
+                self.inner = _Inner()
+
+        mod = _Outer()
+        shallow = list(mod.named_parameters(recurse=False))
+        deep = list(mod.named_parameters(recurse=True))
+        self.assertEqual(len(shallow), 1)
+        self.assertEqual(len(deep), 2)
+
+
+class TestSequentialContainer(unittest.TestCase):
+    """Cover ``Sequential`` construction, indexing, and mutation methods."""
+
+    def test_basic_construction_sizes(self):
+        """A ``Sequential`` infers in/out sizes from its layers."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(10, 20),
+            brainstate.nn.Linear(20, 5),
+        )
+        self.assertEqual(seq.in_size, (10,))
+        self.assertEqual(seq.out_size, (5,))
+
+    def test_forward(self):
+        """A ``Sequential`` chains its layers when called."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(8, 4),
+            jax.nn.relu,
+            brainstate.nn.Linear(4, 2),
+        )
+        x = brainstate.random.randn(3, 8)
+        out = seq(x)
+        self.assertEqual(out.shape, (3, 2))
+
+    def test_getitem_int(self):
+        """Integer indexing returns the layer at that position."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(8, 4),
+            brainstate.nn.Linear(4, 2),
+        )
+        self.assertIsInstance(seq[0], brainstate.nn.Linear)
+
+    def test_getitem_slice(self):
+        """Slice indexing returns a new ``Sequential``."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(8, 4),
+            brainstate.nn.Linear(4, 2),
+        )
+        sub = seq[0:1]
+        self.assertIsInstance(sub, Sequential)
+        self.assertEqual(len(sub.layers), 1)
+
+    def test_getitem_tuple(self):
+        """Tuple indexing returns a ``Sequential`` of the selected layers."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(8, 4),
+            jax.nn.relu,
+            brainstate.nn.Linear(4, 2),
+        )
+        sub = seq[(0, 2)]
+        self.assertIsInstance(sub, Sequential)
+        self.assertEqual(len(sub.layers), 2)
+
+    def test_getitem_bad_key_raises(self):
+        """An unsupported index type raises ``KeyError``."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(8, 4))
+        with self.assertRaises(KeyError):
+            seq['bad']
+
+    def test_append_callable(self):
+        """Appending a callable wraps it and preserves the output size."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(8, 4))
+        seq.append(jax.nn.relu)
+        self.assertEqual(len(seq.layers), 2)
+        self.assertEqual(seq.out_size, (4,))
+
+    def test_append_module_updates_out_size(self):
+        """Appending a sized module updates the output size."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(8, 4))
+        seq.append(brainstate.nn.Linear(4, 2))
+        self.assertEqual(seq.out_size, (2,))
+
+    def test_extend_modules(self):
+        """Extending appends multiple modules with size inference."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(8, 4))
+        seq.extend([jax.nn.relu, brainstate.nn.Linear(4, 2)])
+        self.assertEqual(len(seq.layers), 3)
+        self.assertEqual(seq.out_size, (2,))
+
+    def test_insert_middle(self):
+        """Inserting at a middle index recalculates downstream sizes."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(8, 4),
+            brainstate.nn.Linear(4, 2),
+        )
+        seq.insert(1, jax.nn.relu)
+        self.assertEqual(len(seq.layers), 3)
+        self.assertTrue(callable(seq.layers[1]))
+
+    def test_insert_negative_index(self):
+        """A negative insert index follows Python list convention."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(8, 4),
+            brainstate.nn.Linear(4, 2),
+        )
+        seq.insert(-1, jax.nn.tanh)
+        self.assertEqual(len(seq.layers), 3)
+
+    def test_insert_out_of_range_raises(self):
+        """An out-of-range insert index raises ``IndexError``."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(8, 4))
+        with self.assertRaises(IndexError):
+            seq.insert(5, brainstate.nn.Linear(4, 2))
+
+    def test_describer_layer_is_built(self):
+        """A ``ParamDescriber`` layer is instantiated with the inferred in_size."""
+        seq = brainstate.nn.Sequential(
+            brainstate.nn.Linear(10, 30),
+            brainstate.nn.Linear.desc(out_size=5),
+        )
+        self.assertEqual(seq.out_size, (5,))
+        self.assertIsInstance(seq.layers[1], brainstate.nn.Linear)
+
+    def test_update_failure_wrapped(self):
+        """A layer failure during ``update`` is wrapped in ``BrainStateError``."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(10, 20))
+        with self.assertRaises(BrainStateError):
+            seq(jnp.ones((2, 5)))  # mismatched input dimension
+
+    def test_unsupported_layer_type_raises(self):
+        """Appending an unsupported (non-callable) layer raises ``BrainStateError``."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(8, 4))
+        with self.assertRaises(BrainStateError):
+            seq.append(12345)
+
+
+class TestSequentialEmpty(unittest.TestCase):
+    """Cover ``Sequential`` mutation methods on an empty container."""
+
+    def _empty(self):
+        """Build a ``Sequential`` instance with an empty layer list."""
+        seq = Sequential.__new__(Sequential)
+        Module.__init__(seq)
+        seq.layers = []
+        return seq
+
+    def test_append_to_empty_raises(self):
+        """Appending the first layer to an empty Sequential raises ``ValueError``."""
+        seq = self._empty()
+        with self.assertRaises(ValueError):
+            seq.append(jax.nn.relu)
+
+    def test_extend_empty_raises(self):
+        """Extending an empty Sequential raises ``ValueError``."""
+        seq = self._empty()
+        with self.assertRaises(ValueError):
+            seq.extend([brainstate.nn.Linear(2, 2)])
+
+    def test_insert_nonzero_index_raises(self):
+        """Inserting at a non-zero index into an empty Sequential raises ``ValueError``."""
+        seq = self._empty()
+        with self.assertRaises(ValueError):
+            seq.insert(1, brainstate.nn.Linear(2, 2))
+
+    def test_insert_callable_first_raises(self):
+        """Inserting a callable as the first layer raises ``ValueError``."""
+        seq = self._empty()
+        with self.assertRaises(ValueError):
+            seq.insert(0, lambda x: x)
+
+    def test_insert_module_first_ok(self):
+        """Inserting a module at index 0 of an empty Sequential succeeds."""
+        seq = self._empty()
+        seq.insert(0, brainstate.nn.Linear(3, 4))
+        self.assertEqual(len(seq.layers), 1)
+        self.assertEqual(seq.in_size, (3,))
+        self.assertEqual(seq.out_size, (4,))
+
+
+class TestModuleSizeSetterEdges(unittest.TestCase):
+    """Cover numpy-typed and invalid inputs to the size setters."""
+
+    def test_out_size_zero_d_integer_ndarray_bug(self):
+        """A 0-d integer ``np.ndarray`` ``out_size`` hits a source bug (documents BUG).
+
+        The setter calls ``np.issubdtype(out_size, np.integer)`` passing the array
+        itself rather than its ``.dtype``; numpy raises ``TypeError`` ("Cannot
+        construct a dtype from an array"), so a 0-d integer array cannot be used.
+        """
+        mod = Module()
+        with self.assertRaises(TypeError):
+            mod.out_size = np.array(6)
+
+    def test_in_size_non_integer_generic_raises(self):
+        """A non-integer ``np.generic`` ``in_size`` fails the type assertion."""
+        mod = Module()
+        with self.assertRaises(AssertionError):
+            mod.in_size = np.float64(3.0)
+
+
+class _UnsizedModule(Module):
+    """Module without declared in/out sizes, used for Sequential size tests."""
+
+    def update(self, x):
+        """Return the input unchanged."""
+        return x
+
+
+class TestSequentialSizeInferenceEdges(unittest.TestCase):
+    """Cover Sequential construction/mutation when sizes are undefined."""
+
+    def test_first_without_in_size(self):
+        """A Sequential whose first layer has no in_size leaves in_size unset."""
+        seq = brainstate.nn.Sequential(_UnsizedModule(), _UnsizedModule())
+        self.assertIsNone(seq.in_size)
+
+    def test_insert_module_into_empty_sets_sizes(self):
+        """Inserting a sized module into an empty Sequential sets in/out sizes."""
+        seq = Sequential.__new__(Sequential)
+        Module.__init__(seq)
+        seq.layers = []
+        seq.insert(0, brainstate.nn.Linear(3, 7))
+        self.assertEqual(seq.in_size, (3,))
+        self.assertEqual(seq.out_size, (7,))
+
+    def test_insert_module_into_empty_without_sizes(self):
+        """Inserting an unsized module into an empty Sequential leaves sizes None."""
+        seq = Sequential.__new__(Sequential)
+        Module.__init__(seq)
+        seq.layers = []
+        seq.insert(0, _UnsizedModule())
+        self.assertIsNone(seq.in_size)
+        self.assertIsNone(seq.out_size)
+
+    def test_insert_at_beginning_updates_in_size(self):
+        """Inserting a sized module at index 0 updates the Sequential in_size."""
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(5, 3))
+        seq.insert(0, brainstate.nn.Linear(8, 5))
+        self.assertEqual(seq.in_size, (8,))
+
+    def test_insert_middle_unsized_keeps_none_out_size(self):
+        """Inserting into an unsized chain leaves the out_size as None."""
+        seq = brainstate.nn.Sequential(_UnsizedModule(), _UnsizedModule())
+        seq.insert(1, _UnsizedModule())
+        self.assertEqual(len(seq.layers), 3)
+        self.assertIsNone(seq.out_size)
+
+    def test_extend_with_unsized_modules(self):
+        """Extending with unsized modules leaves the out_size unchanged."""
+        seq = brainstate.nn.Sequential(_UnsizedModule())
+        seq.extend([_UnsizedModule()])
+        self.assertEqual(len(seq.layers), 2)
+        self.assertIsNone(seq.out_size)
+
+    def test_describer_without_in_size_raises(self):
+        """A describer first layer with no in_size raises ``BrainStateError``."""
+        seq = brainstate.nn.Sequential(_UnsizedModule())
+        with self.assertRaises(BrainStateError):
+            seq.append(brainstate.nn.Linear.desc(out_size=4))
+
+    def test_elementwise_block_passthrough(self):
+        """An ``ElementWiseBlock`` layer passes the size through unchanged."""
+
+        class _EW(ElementWiseBlock):
+            """Identity element-wise block."""
+
+            def update(self, x):
+                """Return the input unchanged."""
+                return x
+
+        seq = brainstate.nn.Sequential(brainstate.nn.Linear(6, 4), _EW())
+        self.assertEqual(seq.out_size, (4,))
+
+
+class TestModuleTrainEval(unittest.TestCase):
+    """Cover train/eval behavior toggled via ``environ.context(fit=...)``."""
+
+    def test_fit_flag_changes_behavior(self):
+        """A module can branch on the ``fit`` environment flag."""
+
+        class _FitAware(Module):
+            """Module that doubles its input only during fitting."""
+
+            def update(self, x):
+                """Return ``x * 2`` when fitting, else ``x``."""
+                if brainstate.environ.get('fit', desc='fit flag'):
+                    return x * 2
+                return x
+
+        mod = _FitAware()
+        with brainstate.environ.context(fit=True):
+            _testing.assert_allclose(mod(jnp.ones(3)), jnp.ones(3) * 2)
+        with brainstate.environ.context(fit=False):
+            _testing.assert_allclose(mod(jnp.ones(3)), jnp.ones(3))
+
+    def test_dropout_eval_is_identity(self):
+        """Dropout passes inputs through unchanged when not fitting."""
+        drop = brainstate.nn.Dropout(0.5)
+        x = brainstate.random.randn(64)
+        with brainstate.environ.context(fit=False):
+            out = drop(x)
+        _testing.assert_allclose(out, x)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainstate/nn/_normalizations_test.py
+++ b/brainstate/nn/_normalizations_test.py
@@ -13,12 +13,26 @@
 # limitations under the License.
 # ==============================================================================
 
-from absl.testing import absltest
-from absl.testing import parameterized
+import unittest
+
+import brainunit as u
+import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
+from absl.testing import absltest
+from absl.testing import parameterized
 
 import brainstate
+from brainstate import _testing
+from brainstate._testing import assert_allclose
+from brainstate.nn._normalizations import (
+    canonicalize_dtype,
+    weight_standardization,
+    _canonicalize_axes,
+    _abs_sq,
+    _compute_stats,
+)
 
 
 class TestBatchNorm0d(parameterized.TestCase):
@@ -693,6 +707,246 @@ class TestNormalizationConsistency(parameterized.TestCase):
 
         # Should be deterministic
         np.testing.assert_allclose(output1, output2)
+
+
+class TestWeightStandardizationDetails(unittest.TestCase):
+    """Lower-level behavior of weight_standardization, including unit handling."""
+
+    def test_zeroes_mean_along_fan_in(self):
+        """Standardized weights have ~zero mean along the fan-in axes."""
+        with brainstate.random.seed_context(0):
+            w = brainstate.random.randn(3, 4, 5, 6)
+        w_std = weight_standardization(w)
+        mean = jnp.mean(w_std, axis=(0, 1, 2))
+        np.testing.assert_allclose(mean, 0.0, atol=1e-4)
+
+    def test_negative_out_axis(self):
+        """A negative out_axis is normalized to a positive index."""
+        with brainstate.random.seed_context(1):
+            w = brainstate.random.randn(4, 5)
+        a = weight_standardization(w, out_axis=-1)
+        b = weight_standardization(w, out_axis=1)
+        assert_allclose(a, b)
+
+    def test_unitless_quantity_input(self):
+        """A unitless Quantity input takes the dimensionless rsqrt branch."""
+        w = jnp.ones((3, 4)) * u.UNITLESS
+        w_std = weight_standardization(w)
+        self.assertEqual(u.math.shape(w_std), (3, 4))
+
+    @pytest.mark.skip(
+        reason="BUG: weight_standardization with a unit-carrying Quantity input "
+               "constructs u.Quantity(..., unit=1/unit**0.5); since 1/unit**0.5 "
+               "evaluates to a Quantity (not a Unit), Quantity.__init__ asserts."
+    )
+    def test_unit_carrying_quantity_input(self):
+        """A unit-carrying Quantity should be standardizable (currently buggy)."""
+        w = jnp.ones((3, 4)) * u.mV
+        w_std = weight_standardization(w, eps=1e-4 * u.mV ** 2)
+        self.assertEqual(u.math.shape(w_std), (3, 4))
+
+
+class TestCanonicalizeDtype(unittest.TestCase):
+    """Behavior of the canonicalize_dtype helper."""
+
+    def test_integer_args_promoted_to_float(self):
+        """Integer inputs are promoted to at least float32 when inexact=True."""
+        dtype = canonicalize_dtype(jnp.array([1, 2, 3]))
+        self.assertTrue(jnp.issubdtype(dtype, jnp.inexact))
+
+    def test_explicit_float_dtype_passthrough(self):
+        """An explicit inexact dtype is returned unchanged."""
+        self.assertEqual(canonicalize_dtype(jnp.array([1, 2]), dtype=jnp.float32),
+                         jnp.float32)
+
+    def test_explicit_non_inexact_dtype_raises(self):
+        """An explicit non-inexact dtype with inexact=True raises ValueError."""
+        with self.assertRaises(ValueError):
+            canonicalize_dtype(jnp.array([1, 2]), dtype=jnp.int32, inexact=True)
+
+    def test_non_inexact_allowed_when_flag_false(self):
+        """A non-inexact dtype is allowed when inexact=False."""
+        dtype = canonicalize_dtype(jnp.array([1, 2]), inexact=False)
+        self.assertTrue(jnp.issubdtype(dtype, jnp.integer))
+
+
+class TestNormalizationHelpers(unittest.TestCase):
+    """Tests for low-level normalization helper functions."""
+
+    def test_canonicalize_axes_invalid_raises(self):
+        """_canonicalize_axes rejects out-of-range axes."""
+        with self.assertRaises(ValueError):
+            _canonicalize_axes(2, (5,))
+
+    def test_canonicalize_axes_negative(self):
+        """_canonicalize_axes converts negative axes to positive indices."""
+        self.assertEqual(_canonicalize_axes(3, (-1, -2)), (2, 1))
+
+    def test_abs_sq_complex(self):
+        """_abs_sq computes squared magnitude for complex input."""
+        out = _abs_sq(jnp.array([3 + 4j], dtype=jnp.complex64))
+        np.testing.assert_allclose(np.asarray(out), [25.0], atol=1e-5)
+
+    def test_abs_sq_real(self):
+        """_abs_sq squares a real input."""
+        out = _abs_sq(jnp.array([2.0, -3.0]))
+        np.testing.assert_allclose(np.asarray(out), [4.0, 9.0])
+
+    def test_compute_stats_slow_variance(self):
+        """_compute_stats with use_fast_variance=False matches the fast path."""
+        with brainstate.random.seed_context(2):
+            x = brainstate.random.randn(8, 4)
+        mu_fast, var_fast = _compute_stats(x, axes=(0,), dtype=None,
+                                           use_fast_variance=True)
+        mu_slow, var_slow = _compute_stats(x, axes=(0,), dtype=None,
+                                           use_fast_variance=False)
+        assert_allclose(mu_fast, mu_slow, atol=1e-4)
+        assert_allclose(var_fast, var_slow, atol=1e-4)
+
+    def test_compute_stats_axis_name_pmean(self):
+        """_compute_stats reduces across a named (vmapped) axis via pmean."""
+        with brainstate.random.seed_context(3):
+            x = brainstate.random.randn(2, 6, 4)
+
+        def f(xi):
+            return _compute_stats(xi, axes=(0,), dtype=None, axis_name='b',
+                                  use_fast_variance=True)
+
+        mus, vars_ = jax.vmap(f, axis_name='b')(x)
+        # Means across the named axis are shared, so all replicas agree.
+        assert_allclose(mus[0], mus[1], atol=1e-5)
+        self.assertEqual(mus.shape, (2, 4))
+
+    def test_compute_stats_axis_name_single_array(self):
+        """A named axis with use_fast_variance=False uses single-array pmean calls."""
+        with brainstate.random.seed_context(11):
+            x = brainstate.random.randn(2, 6, 4)
+
+        def f(xi):
+            return _compute_stats(xi, axes=(0,), dtype=None, axis_name='b',
+                                  use_fast_variance=False)
+
+        mus, vars_ = jax.vmap(f, axis_name='b')(x)
+        # Means and variances are reduced across the named axis, so replicas agree.
+        assert_allclose(mus[0], mus[1], atol=1e-5)
+        assert_allclose(vars_[0], vars_[1], atol=1e-5)
+
+
+class TestComputeStatsDtype(unittest.TestCase):
+    """dtype handling inside _compute_stats."""
+
+    def test_default_dtype_inference(self):
+        """When dtype is None, statistics are computed at >=float32 precision."""
+        x = jnp.arange(12, dtype=jnp.int32).reshape(3, 4)
+        mu, var = _compute_stats(x, axes=(0,), dtype=None)
+        self.assertTrue(jnp.issubdtype(mu.dtype, jnp.floating))
+
+
+class TestBatchNormInvalidNdim(unittest.TestCase):
+    """BatchNorm rejects inputs with an unexpected number of dimensions."""
+
+    def setUp(self):
+        """Enter fitting mode."""
+        brainstate.environ.set(fit=True)
+
+    def test_batchnorm1d_wrong_ndim_raises(self):
+        """BatchNorm1d rejects a 1D input (needs 2D or 3D)."""
+        net = brainstate.nn.BatchNorm1d((20, 10))
+        with self.assertRaises(ValueError):
+            net(brainstate.random.randn(20))
+
+    def test_batchnorm0d_wrong_ndim_raises(self):
+        """BatchNorm0d rejects a 3D input (needs 1D or 2D)."""
+        net = brainstate.nn.BatchNorm0d((10,))
+        with self.assertRaises(ValueError):
+            net(brainstate.random.randn(4, 5, 10))
+
+    def test_batchnorm2d_wrong_ndim_raises(self):
+        """BatchNorm2d rejects a 2D input (needs 3D or 4D)."""
+        net = brainstate.nn.BatchNorm2d((8, 8, 3))
+        with self.assertRaises(ValueError):
+            net(brainstate.random.randn(8, 3))
+
+
+class TestBatchNormTrainEval(unittest.TestCase):
+    """Train vs eval behavior of the running statistics."""
+
+    def test_running_stats_update_in_fit(self):
+        """Running mean/var move away from their initial values during fitting."""
+        net = brainstate.nn.BatchNorm1d((6, 4), momentum=0.5)
+        mean0 = np.array(net.running_mean.value)
+        brainstate.environ.set(fit=True)
+        with brainstate.random.seed_context(4):
+            x = brainstate.random.randn(8, 6, 4) + 5.0
+        _ = net(x)
+        # Running mean should have shifted toward the batch mean.
+        self.assertFalse(np.allclose(mean0, np.array(net.running_mean.value)))
+
+    def test_eval_uses_frozen_running_stats(self):
+        """In eval mode the running statistics are used and not updated."""
+        net = brainstate.nn.BatchNorm1d((6, 4))
+        brainstate.environ.set(fit=True)
+        with brainstate.random.seed_context(5):
+            _ = net(brainstate.random.randn(8, 6, 4) + 3.0)
+        snap_mean = np.array(net.running_mean.value)
+        snap_var = np.array(net.running_var.value)
+
+        brainstate.environ.set(fit=False)
+        with brainstate.random.seed_context(6):
+            _ = net(brainstate.random.randn(8, 6, 4) - 2.0)
+        # Eval must not modify the running statistics.
+        np.testing.assert_allclose(snap_mean, np.array(net.running_mean.value))
+        np.testing.assert_allclose(snap_var, np.array(net.running_var.value))
+
+
+class TestGroupNormBranches(unittest.TestCase):
+    """Less-common GroupNorm code paths."""
+
+    def test_group_size_not_divisible_raises(self):
+        """group_size that does not divide the channel count raises ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.GroupNorm((15,), feature_axis=0, num_groups=None,
+                                    group_size=4)
+
+    def test_explicit_reduction_axes(self):
+        """GroupNorm honors explicit reduction_axes and preserves shape."""
+        net = brainstate.nn.GroupNorm((16,), feature_axis=0, num_groups=4,
+                                      reduction_axes=(1, 2, -1))
+        with brainstate.random.seed_context(7):
+            x = brainstate.random.randn(2, 4, 4, 16)
+        out = net(x)
+        self.assertEqual(out.shape, x.shape)
+
+    def test_groupnorm_with_mask(self):
+        """GroupNorm accepts a broadcastable mask and preserves shape."""
+        net = brainstate.nn.GroupNorm((16,), feature_axis=0, num_groups=4)
+        with brainstate.random.seed_context(8):
+            x = brainstate.random.randn(4, 16)
+        mask = jnp.ones((4, 16), dtype=bool)
+        out = net(x, mask=mask)
+        self.assertEqual(out.shape, x.shape)
+
+
+class TestNormalizationJitGrad(unittest.TestCase):
+    """JIT consistency and gradient finiteness for normalization layers."""
+
+    def test_layernorm_jit_equal(self):
+        """LayerNorm output is identical under JIT and eager execution."""
+        net = brainstate.nn.LayerNorm((8,))
+        with brainstate.random.seed_context(9):
+            x = brainstate.random.randn(4, 8)
+        _testing.assert_jit_equal(net.update, x)
+
+    def test_rmsnorm_grad_finite(self):
+        """Gradients through RMSNorm are finite."""
+        net = brainstate.nn.RMSNorm((8,))
+        with brainstate.random.seed_context(10):
+            x = brainstate.random.randn(4, 8)
+
+        def loss_fn(inp):
+            return jnp.sum(net(inp) ** 2)
+
+        _testing.assert_grad_finite(loss_fn, x)
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_paddings_test.py
+++ b/brainstate/nn/_paddings_test.py
@@ -719,5 +719,113 @@ class TestEdgeCases(unittest.TestCase):
         self.assertEqual(output.shape, (0, 6, 6, 3))
 
 
+class TestPaddingInvalidNdim(unittest.TestCase):
+    """Each padding layer rejects inputs with an unsupported number of dimensions."""
+
+    def test_reflection_pad2d_invalid_ndim(self):
+        """ReflectionPad2d rejects non 3D/4D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ReflectionPad2d(1)(jnp.ones((4, 4)))
+
+    def test_reflection_pad3d_invalid_ndim(self):
+        """ReflectionPad3d rejects non 4D/5D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ReflectionPad3d(1)(jnp.ones((4, 4, 4)))
+
+    def test_replication_pad1d_invalid_ndim(self):
+        """ReplicationPad1d rejects non 2D/3D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ReplicationPad1d(1)(jnp.ones((4,)))
+
+    def test_replication_pad2d_invalid_ndim(self):
+        """ReplicationPad2d rejects non 3D/4D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ReplicationPad2d(1)(jnp.ones((4, 4)))
+
+    def test_replication_pad3d_invalid_ndim(self):
+        """ReplicationPad3d rejects non 4D/5D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ReplicationPad3d(1)(jnp.ones((4, 4, 4)))
+
+    def test_zero_pad1d_invalid_ndim(self):
+        """ZeroPad1d rejects non 2D/3D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ZeroPad1d(1)(jnp.ones((4,)))
+
+    def test_zero_pad2d_invalid_ndim(self):
+        """ZeroPad2d rejects non 3D/4D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ZeroPad2d(1)(jnp.ones((4, 4)))
+
+    def test_zero_pad3d_invalid_ndim(self):
+        """ZeroPad3d rejects non 4D/5D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ZeroPad3d(1)(jnp.ones((4, 4, 4)))
+
+    def test_constant_pad1d_invalid_ndim(self):
+        """ConstantPad1d rejects non 2D/3D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConstantPad1d(1)(jnp.ones((4,)))
+
+    def test_constant_pad2d_invalid_ndim(self):
+        """ConstantPad2d rejects non 3D/4D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConstantPad2d(1)(jnp.ones((4, 4)))
+
+    def test_constant_pad3d_invalid_ndim(self):
+        """ConstantPad3d rejects non 4D/5D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConstantPad3d(1)(jnp.ones((4, 4, 4)))
+
+    def test_circular_pad1d_invalid_ndim(self):
+        """CircularPad1d rejects non 2D/3D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.CircularPad1d(1)(jnp.ones((4,)))
+
+    def test_circular_pad2d_invalid_ndim(self):
+        """CircularPad2d rejects non 3D/4D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.CircularPad2d(1)(jnp.ones((4, 4)))
+
+    def test_circular_pad3d_invalid_ndim(self):
+        """CircularPad3d rejects non 4D/5D input."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.CircularPad3d(1)(jnp.ones((4, 4, 4)))
+
+
+class TestPaddingInSize(unittest.TestCase):
+    """The optional in_size argument computes a correct out_size for all layers."""
+
+    def test_replication_pad3d_in_size(self):
+        """ReplicationPad3d records out_size from in_size."""
+        pad = brainstate.nn.ReplicationPad3d(1, in_size=(1, 4, 4, 4, 2))
+        self.assertEqual(pad.out_size, (1, 6, 6, 6, 2))
+
+    def test_zero_pad2d_in_size(self):
+        """ZeroPad2d records out_size from in_size."""
+        pad = brainstate.nn.ZeroPad2d([1, 2], in_size=(8, 8, 3))
+        self.assertEqual(pad.out_size, (10, 12, 3))
+
+    def test_constant_pad2d_in_size(self):
+        """ConstantPad2d records out_size from in_size."""
+        pad = brainstate.nn.ConstantPad2d([1, 2], value=1.0, in_size=(8, 8, 3))
+        self.assertEqual(pad.out_size, (10, 12, 3))
+
+    def test_constant_pad3d_in_size(self):
+        """ConstantPad3d records out_size from in_size."""
+        pad = brainstate.nn.ConstantPad3d(1, value=2.0, in_size=(1, 4, 4, 4, 2))
+        self.assertEqual(pad.out_size, (1, 6, 6, 6, 2))
+
+    def test_circular_pad3d_in_size(self):
+        """CircularPad3d records out_size from in_size."""
+        pad = brainstate.nn.CircularPad3d([1, 2, 3], in_size=(1, 4, 4, 4, 2))
+        self.assertEqual(pad.out_size, (1, 6, 8, 10, 2))
+
+    def test_reflection_pad2d_unbatched_in_size(self):
+        """ReflectionPad2d computes out_size from an unbatched in_size."""
+        pad = brainstate.nn.ReflectionPad2d(1, in_size=(4, 4, 3))
+        self.assertEqual(pad.out_size, (6, 6, 3))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/nn/_param_test.py
+++ b/brainstate/nn/_param_test.py
@@ -65,6 +65,7 @@ from brainstate.nn import (
     SimplexT,
 )
 from brainstate.nn import Param, IdentityT, SigmoidT, SoftplusT, Transform
+from brainstate.nn._param import _to_size, _expand_params_to_match_sizes
 
 
 class TestParamCachingBasic(unittest.TestCase):
@@ -1834,3 +1835,146 @@ class TestParamAllRegularizations(unittest.TestCase):
         param = Param(jnp.array([1.0]), reg=reg)
         loss = param.reg_loss()
         self.assertGreater(float(loss), 0.0)
+
+
+class TestParamCacheNonTrainable(unittest.TestCase):
+    """Cache and precompute behavior for non-trainable parameters."""
+
+    def test_cache_on_non_state_value(self):
+        """cache() reads directly from a plain array when fit=False."""
+        param = Param(jnp.array([1.0, 2.0]), t=SoftplusT(0.0), fit=False)
+        # val is a plain array (not a State) for fit=False.
+        self.assertNotIsInstance(param.val, brainstate.State)
+        cached = param.cache()
+        np.testing.assert_allclose(cached, jnp.array([1.0, 2.0]), rtol=1e-5)
+        self.assertTrue(param.cache_stats['valid'])
+
+    def test_cache_on_non_state_with_precompute(self):
+        """cache() applies precompute when fit=False and reads a plain array."""
+
+        def precompute_fn(x):
+            return x + 5.0
+
+        param = Param(jnp.array([1.0, 2.0]), fit=False, precompute=precompute_fn)
+        cached = param.cache()
+        np.testing.assert_allclose(cached, jnp.array([6.0, 7.0]), rtol=1e-5)
+
+
+class TestParamLoggingEvents(unittest.TestCase):
+    """Direct exercise of the cache logging event dispatcher."""
+
+    def test_log_event_miss_and_error(self):
+        """_log_cache_event handles 'miss' and 'error' event types when enabled."""
+        param = Param(jnp.array([1.0]), enable_cache_logging=True)
+        # These event names are dispatched but otherwise unused by Param itself.
+        param._log_cache_event('miss')
+        param._log_cache_event('error', error=ValueError('boom'))
+        self.assertIsNotNone(param._cache_logger)
+
+    def test_log_event_disabled_is_noop(self):
+        """_log_cache_event is a no-op when logging is disabled."""
+        param = Param(jnp.array([1.0]), enable_cache_logging=False)
+        # Should not initialize a logger nor raise.
+        param._log_cache_event('miss')
+        self.assertIsNone(param._cache_logger)
+
+    def test_log_event_hit_on_value(self):
+        """A cache hit during value() emits the 'hit' log event when enabled."""
+        param = Param(jnp.array([1.0, 2.0]), t=SoftplusT(0.0),
+                      enable_cache_logging=True)
+        param.cache()  # Populate cache so the next value() is a hit.
+        result = param.value()
+        np.testing.assert_allclose(result, jnp.array([1.0, 2.0]), rtol=1e-5)
+        self.assertIsNotNone(param._cache_logger)
+
+
+class TestParamPrettyRepr(unittest.TestCase):
+    """The __pretty_repr_item__ hook filters internal cache attributes."""
+
+    def test_internal_cache_fields_hidden(self):
+        """Internal cache and precompute attributes are filtered from repr."""
+        param = Param(jnp.array([1.0]))
+        for hidden in ('_enable_cache_logging', '_cache_lock', '_cached_value',
+                       '_cache_valid', '_cache_logger', 'precompute',
+                       '_cache_invalidation_hook_handle'):
+            self.assertIsNone(param.__pretty_repr_item__(hidden, getattr(param, hidden, None)))
+
+    def test_public_field_passthrough(self):
+        """Public attributes are returned unchanged."""
+        param = Param(jnp.array([1.0]))
+        self.assertEqual(param.__pretty_repr_item__('fit', True), ('fit', True))
+
+    def test_private_none_field_dropped(self):
+        """A leading-underscore field with a None value is dropped."""
+        param = Param(jnp.array([1.0]))
+        self.assertIsNone(param.__pretty_repr_item__('_secret', None))
+
+    def test_private_value_field_unprefixed(self):
+        """A leading-underscore field with a value is exposed without the prefix."""
+        param = Param(jnp.array([1.0]))
+        self.assertEqual(param.__pretty_repr_item__('_name', 'foo'), ('name', 'foo'))
+
+    def test_repr_does_not_raise(self):
+        """A full repr of a Param renders without raising."""
+        param = Param(jnp.array([1.0, 2.0]), t=SoftplusT(0.0))
+        self.assertIsInstance(repr(param), str)
+
+
+class TestParamPrivateHelpers(unittest.TestCase):
+    """Tests for module-private helper functions."""
+
+    def test_to_size_none(self):
+        """_to_size returns None unchanged."""
+        self.assertIsNone(_to_size(None))
+
+    def test_to_size_int(self):
+        """_to_size wraps an int into a 1-tuple."""
+        self.assertEqual(_to_size(5), (5,))
+
+    def test_to_size_sequence(self):
+        """_to_size passes through lists and tuples as tuples."""
+        self.assertEqual(_to_size([2, 3]), (2, 3))
+        self.assertEqual(_to_size((4, 5)), (4, 5))
+
+    def test_to_size_invalid_raises(self):
+        """_to_size raises ValueError for an unsupported type."""
+        with self.assertRaises(ValueError):
+            _to_size("invalid")
+
+    def test_expand_params_adds_leading_axes(self):
+        """_expand_params_to_match_sizes prepends axes to match the target rank."""
+        params = jnp.ones((3,))
+        expanded = _expand_params_to_match_sizes(params, (2, 3))
+        self.assertEqual(expanded.shape, (1, 3))
+
+    def test_expand_params_no_change_when_equal_rank(self):
+        """_expand_params_to_match_sizes is a no-op when ranks already match."""
+        params = jnp.ones((2, 3))
+        expanded = _expand_params_to_match_sizes(params, (2, 3))
+        self.assertEqual(expanded.shape, (2, 3))
+
+    def test_expand_params_multiple_axes(self):
+        """_expand_params_to_match_sizes prepends multiple axes when needed."""
+        params = jnp.ones((3,))
+        expanded = _expand_params_to_match_sizes(params, (4, 5, 3))
+        self.assertEqual(expanded.shape, (1, 1, 3))
+
+
+class TestParamInitNoSizes(unittest.TestCase):
+    """Param.init skips shape checking when sizes is None."""
+
+    def test_init_array_without_sizes(self):
+        """An array passed without sizes skips shape validation."""
+        param = Param.init(jnp.array([1.0, 2.0, 3.0]), sizes=None)
+        self.assertIsInstance(param, Const)
+        np.testing.assert_allclose(param.value(), jnp.array([1.0, 2.0, 3.0]))
+
+    def test_init_scalar_without_sizes(self):
+        """A scalar passed without sizes skips shape validation."""
+        param = Param.init(2.0, sizes=None)
+        self.assertIsInstance(param, Const)
+        np.testing.assert_allclose(float(param.value()), 2.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainstate/nn/_poolings_test.py
+++ b/brainstate/nn/_poolings_test.py
@@ -15,14 +15,25 @@
 
 # -*- coding: utf-8 -*-
 
+import unittest
+
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from absl.testing import absltest
 from absl.testing import parameterized
 
 import brainstate
 import brainstate.nn as nn
+from brainstate import _testing
+from brainstate._testing import (
+    SMALL_BATCH,
+    assert_allclose,
+    assert_grad_finite,
+    assert_jit_equal,
+    seeded,
+)
 
 
 class TestFlatten(parameterized.TestCase):
@@ -947,6 +958,476 @@ class TestPoolingMathematicalProperties(parameterized.TestCase):
 
         # Should be approximately equal (might have small numerical differences)
         self.assertTrue(jnp.allclose(out, arr, rtol=1e-5))
+
+
+class TestFlattenInSizePaths(unittest.TestCase):
+    """Cover the ``in_size``-aware branches of :class:`Flatten`."""
+
+    def test_flatten_in_size_shape_mismatch_raises(self):
+        """Flatten with ``in_size`` rejects a mismatched trailing shape."""
+        f = nn.Flatten(start_axis=0, in_size=(32, 8))
+        bad = brainstate.random.randn(16, 99, 8)
+        with self.assertRaises(ValueError):
+            f(bad)
+
+    def test_flatten_in_size_negative_start_axis(self):
+        """Flatten with ``in_size`` resolves a negative ``start_axis``."""
+        f = nn.Flatten(start_axis=-2, in_size=(32, 8))
+        out = f(brainstate.random.randn(16, 32, 8))
+        self.assertEqual(out.shape, (16, 32 * 8))
+
+    def test_flatten_out_size_inferred(self):
+        """Flatten records ``out_size`` when ``in_size`` is supplied."""
+        f = nn.Flatten(start_axis=1, in_size=(3, 4, 5))
+        self.assertEqual(f.out_size, (3, 20))
+
+    def test_flatten_grad_and_jit(self):
+        """Flatten yields finite gradients and matches its jitted form."""
+        f = nn.Flatten(start_axis=1)
+        with seeded(0):
+            x = brainstate.random.randn(SMALL_BATCH, 4, 5)
+        assert_jit_equal(f, x)
+        assert_grad_finite(lambda y: jnp.sum(f(y)), x)
+
+
+class TestMaxPoolConstructorValidation(unittest.TestCase):
+    """Cover the argument-validation branches in the ``_MaxPool`` base class."""
+
+    def test_kernel_size_wrong_length_raises(self):
+        """A kernel tuple whose length differs from ``pool_dim`` is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxPool2d((2, 2, 2))
+
+    def test_kernel_size_wrong_type_raises(self):
+        """A non-int, non-sequence kernel size is rejected."""
+        with self.assertRaises(TypeError):
+            nn.MaxPool2d(2.5)
+
+    def test_stride_wrong_length_raises(self):
+        """A stride tuple whose length differs from ``pool_dim`` is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxPool2d(2, stride=(2, 2, 2))
+
+    def test_stride_wrong_type_raises(self):
+        """A non-int, non-sequence stride is rejected."""
+        with self.assertRaises(TypeError):
+            nn.MaxPool2d(2, stride=2.5)
+
+    def test_padding_invalid_string_raises(self):
+        """An unknown padding string is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxPool2d(2, padding='FOO')
+
+    def test_padding_int_sequence_wrong_length_raises(self):
+        """A sequence of ints of the wrong length for padding is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxPool2d(2, padding=[1, 2, 3])
+
+    def test_padding_non_tuple_entries_raises(self):
+        """A padding sequence with non-tuple entries is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxPool2d(2, padding=[(1, 2), 3])
+
+    def test_padding_tuple_wrong_inner_length_raises(self):
+        """A padding entry that is not a 2-tuple is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxPool2d(2, padding=[(1, 2, 3), (1, 2)])
+
+    def test_padding_invalid_type_raises(self):
+        """A non-string, non-int, non-sequence padding is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxPool2d(2, padding=2.5)
+
+    def test_padding_int_expands(self):
+        """An int padding expands to a per-dim ``(p, p)`` sequence."""
+        p = nn.MaxPool2d(2, padding=1)
+        self.assertEqual(list(p.padding), [(1, 1), (1, 1)])
+
+    def test_padding_single_tuple_expands(self):
+        """A length-1 padding sequence is broadcast to ``pool_dim`` entries."""
+        p = nn.MaxPool2d(2, padding=[(1, 1)])
+        self.assertEqual(tuple(p.padding), ((1, 1), (1, 1)))
+
+    def test_in_size_infers_out_size(self):
+        """Supplying ``in_size`` triggers eager output-shape inference."""
+        p = nn.MaxPool2d(2, in_size=(8, 8, 3), channel_axis=-1)
+        self.assertEqual(p.out_size, (4, 4, 3))
+
+    def test_too_few_dims_raises(self):
+        """Calling a pool on an input with too few dimensions raises."""
+        p = nn.MaxPool2d(2, channel_axis=-1)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(4))
+
+    def test_invalid_channel_axis_raises(self):
+        """An out-of-range channel axis is rejected during the forward pass."""
+        p = nn.MaxPool1d(2, channel_axis=5)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(3, 4))
+
+
+class TestMaxPoolTransforms(unittest.TestCase):
+    """Gradient and jit consistency checks for the max-pooling variants."""
+
+    def test_maxpool1d_grad_and_jit(self):
+        """MaxPool1d is jit-stable and produces finite gradients."""
+        pool = nn.MaxPool1d(2, 2, channel_axis=-1)
+        with seeded(0):
+            x = brainstate.random.randn(SMALL_BATCH, 8, 3)
+        assert_jit_equal(pool, x)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+    def test_maxpool2d_grad_and_jit(self):
+        """MaxPool2d is jit-stable and produces finite gradients."""
+        pool = nn.MaxPool2d(2, 2, channel_axis=-1)
+        with seeded(1):
+            x = brainstate.random.randn(2, 8, 8, 3)
+        assert_jit_equal(pool, x)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+    @pytest.mark.slow
+    def test_maxpool3d_grad_large_kernel(self):
+        """MaxPool3d gradients remain finite with a larger kernel."""
+        pool = nn.MaxPool3d(3, 2, channel_axis=-1)
+        with seeded(2):
+            x = brainstate.random.randn(1, 12, 12, 12, 2)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+
+class TestAvgPoolExtra(unittest.TestCase):
+    """Additional coverage for the average-pooling base class."""
+
+    def test_avgpool_too_few_dims_raises(self):
+        """AvgPool rejects inputs with too few dimensions."""
+        p = nn.AvgPool2d(2, 2, channel_axis=-1)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(4))
+
+    def test_avgpool_same_padding_normalizes(self):
+        """AvgPool with SAME padding divides by per-window valid counts."""
+        x = jnp.ones((1, 5, 1))
+        pool = nn.AvgPool1d(3, 1, padding='SAME', channel_axis=-1)
+        out = pool(x)
+        # Constant ones input averages back to ones regardless of edge handling.
+        assert_allclose(out, jnp.ones_like(out))
+
+    def test_avgpool1d_grad_and_jit(self):
+        """AvgPool1d is jit-stable and produces finite gradients."""
+        pool = nn.AvgPool1d(2, 2, channel_axis=-1)
+        with seeded(3):
+            x = brainstate.random.randn(SMALL_BATCH, 8, 3)
+        assert_jit_equal(pool, x)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+
+class TestMaxUnpoolValidation(unittest.TestCase):
+    """Cover the validation and output-shape branches of ``_MaxUnpool``."""
+
+    def test_kernel_size_wrong_length_raises(self):
+        """An unpool kernel tuple of the wrong length is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxUnpool2d((2, 2, 2))
+
+    def test_kernel_size_wrong_type_raises(self):
+        """A non-int, non-sequence unpool kernel is rejected."""
+        with self.assertRaises(TypeError):
+            nn.MaxUnpool2d(2.5)
+
+    def test_stride_wrong_length_raises(self):
+        """An unpool stride tuple of the wrong length is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxUnpool2d(2, stride=(2, 2, 2))
+
+    def test_stride_wrong_type_raises(self):
+        """A non-int, non-sequence unpool stride is rejected."""
+        with self.assertRaises(TypeError):
+            nn.MaxUnpool2d(2, stride=2.5)
+
+    def test_padding_wrong_length_raises(self):
+        """An unpool padding tuple of the wrong length is rejected."""
+        with self.assertRaises(ValueError):
+            nn.MaxUnpool2d(2, padding=(1, 2, 3))
+
+    def test_padding_wrong_type_raises(self):
+        """A non-int, non-sequence unpool padding is rejected."""
+        with self.assertRaises(TypeError):
+            nn.MaxUnpool2d(2, padding=2.5)
+
+    def test_in_size_stored(self):
+        """Supplying ``in_size`` to an unpool layer records it."""
+        u = nn.MaxUnpool2d(2, in_size=(4, 4, 3))
+        self.assertEqual(u.in_size, (4, 4, 3))
+
+    def test_unpool_too_few_dims_raises(self):
+        """Unpooling an input with too few dimensions raises."""
+        up = nn.MaxUnpool2d(2, channel_axis=-1)
+        with self.assertRaises(ValueError):
+            up(brainstate.random.randn(4), jnp.zeros(4, dtype=jnp.int32))
+
+    def test_unpool_output_size_wrong_spatial_raises(self):
+        """An ``output_size`` with the wrong number of spatial dims raises."""
+        arr = brainstate.random.randn(1, 4, 4, 2)
+        pool = nn.MaxPool2d(2, 2, channel_axis=-1, return_indices=True)
+        pooled, idx = pool(arr)
+        unpool = nn.MaxUnpool2d(2, 2, channel_axis=-1)
+        with self.assertRaises(ValueError):
+            unpool(pooled, idx, output_size=(8,))
+
+    def test_unpool_output_size_spatial_only(self):
+        """An ``output_size`` giving only spatial dims is broadcast over batch/channel."""
+        arr = brainstate.random.randn(1, 4, 4, 2)
+        pool = nn.MaxPool2d(2, 2, channel_axis=-1, return_indices=True)
+        pooled, idx = pool(arr)
+        unpool = nn.MaxUnpool2d(2, 2, channel_axis=-1)
+        out = unpool(pooled, idx, output_size=(8, 8))
+        self.assertEqual(out.shape, (1, 8, 8, 2))
+
+    def test_unpool_output_size_full_shape(self):
+        """An ``output_size`` matching the full ndim is used verbatim."""
+        arr = brainstate.random.randn(1, 4, 4, 2)
+        pool = nn.MaxPool2d(2, 2, channel_axis=-1, return_indices=True)
+        pooled, idx = pool(arr)
+        unpool = nn.MaxUnpool2d(2, 2, channel_axis=-1)
+        out = unpool(pooled, idx, output_size=(1, 8, 8, 2))
+        self.assertEqual(out.shape, (1, 8, 8, 2))
+
+    def test_unpool_output_size_int(self):
+        """A scalar ``output_size`` is applied to every spatial dimension."""
+        arr = brainstate.random.randn(1, 4, 4, 2)
+        pool = nn.MaxPool2d(2, 2, channel_axis=-1, return_indices=True)
+        pooled, idx = pool(arr)
+        unpool = nn.MaxUnpool2d(2, 2, channel_axis=-1)
+        out = unpool(pooled, idx, output_size=8)
+        self.assertEqual(out.shape, (1, 8, 8, 2))
+
+    def test_unpool_channel_axis_none(self):
+        """Unpooling with ``channel_axis=None`` infers spatial dims from the tail."""
+        arr = brainstate.random.randn(4, 8, 8)
+        pool = nn.MaxPool2d(2, 2, channel_axis=None, return_indices=True)
+        pooled, idx = pool(arr)
+        unpool = nn.MaxUnpool2d(2, 2, channel_axis=None)
+        out = unpool(pooled, idx)
+        self.assertEqual(out.shape, (4, 8, 8))
+
+    def test_unpool_channel_first(self):
+        """Unpooling with a leading channel axis offsets the spatial start index."""
+        arr = brainstate.random.randn(8, 3, 8, 8)
+        pool = nn.MaxPool2d(2, 2, channel_axis=1, return_indices=True)
+        pooled, idx = pool(arr)
+        unpool = nn.MaxUnpool2d(2, 2, channel_axis=1)
+        out = unpool(pooled, idx)
+        self.assertEqual(out.shape, (8, 3, 8, 8))
+
+    def test_unpool_index_roundtrip_preserves_max(self):
+        """A pool/unpool roundtrip preserves the pooled maxima exactly."""
+        with seeded(7):
+            arr = brainstate.random.randn(1, 8, 3)
+        pool = nn.MaxPool1d(2, 2, channel_axis=-1, return_indices=True)
+        pooled, idx = pool(arr)
+        unpool = nn.MaxUnpool1d(2, 2, channel_axis=-1)
+        recon = unpool(pooled, idx)
+        self.assertEqual(recon.shape, (1, 8, 3))
+        # The non-zero entries of the reconstruction are exactly the pooled maxima.
+        assert_allclose(jnp.sum(recon), jnp.sum(pooled))
+
+
+class TestLPPoolValidation(unittest.TestCase):
+    """Cover the argument-validation branches in the ``_LPPool`` base class."""
+
+    def test_nonpositive_norm_type_raises(self):
+        """A non-positive ``norm_type`` is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(norm_type=0, kernel_size=2)
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(norm_type=-1.0, kernel_size=2)
+
+    def test_kernel_size_wrong_length_raises(self):
+        """An LP kernel tuple of the wrong length is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(2, (2, 2, 2))
+
+    def test_kernel_size_wrong_type_raises(self):
+        """A non-int, non-sequence LP kernel is rejected."""
+        with self.assertRaises(TypeError):
+            nn.LPPool2d(2, 2.5)
+
+    def test_stride_wrong_length_raises(self):
+        """An LP stride tuple of the wrong length is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(2, 2, stride=(2, 2, 2))
+
+    def test_stride_wrong_type_raises(self):
+        """A non-int, non-sequence LP stride is rejected."""
+        with self.assertRaises(TypeError):
+            nn.LPPool2d(2, 2, stride=2.5)
+
+    def test_padding_invalid_string_raises(self):
+        """An unknown LP padding string is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(2, 2, padding='FOO')
+
+    def test_padding_int_expands(self):
+        """An int LP padding expands to a per-dim ``(p, p)`` sequence."""
+        p = nn.LPPool2d(2, 2, padding=1)
+        self.assertEqual(list(p.padding), [(1, 1), (1, 1)])
+
+    def test_padding_int_sequence_expands(self):
+        """An LP padding int-sequence of correct length expands to ``(x, x)`` pairs."""
+        p = nn.LPPool2d(2, 2, padding=[1, 2])
+        self.assertEqual(list(p.padding), [(1, 1), (2, 2)])
+
+    def test_padding_int_sequence_wrong_length_raises(self):
+        """An LP padding int-sequence of the wrong length is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(2, 2, padding=[1, 2, 3])
+
+    def test_padding_non_tuple_entries_raises(self):
+        """An LP padding sequence with non-tuple entries is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(2, 2, padding=[(1, 2), 3])
+
+    def test_padding_tuple_wrong_inner_length_raises(self):
+        """An LP padding entry that is not a 2-tuple is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(2, 2, padding=[(1, 2, 3), (1, 2)])
+
+    def test_padding_single_tuple_expands(self):
+        """A length-1 LP padding sequence is broadcast to ``pool_dim`` entries."""
+        p = nn.LPPool2d(2, 2, padding=[(1, 1)])
+        self.assertEqual(tuple(p.padding), ((1, 1), (1, 1)))
+
+    def test_padding_invalid_type_raises(self):
+        """A non-string, non-int, non-sequence LP padding is rejected."""
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(2, 2, padding=2.5)
+
+    def test_in_size_infers_out_size(self):
+        """Supplying ``in_size`` to an LP pool triggers output-shape inference."""
+        p = nn.LPPool2d(2, 2, in_size=(8, 8, 3), channel_axis=-1)
+        self.assertEqual(p.out_size, (4, 4, 3))
+
+    def test_too_few_dims_raises(self):
+        """An LP pool rejects inputs with too few dimensions."""
+        p = nn.LPPool2d(2, 2, channel_axis=-1)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(4))
+
+    def test_invalid_channel_axis_raises(self):
+        """An out-of-range LP channel axis is rejected during the forward pass."""
+        p = nn.LPPool1d(2, 2, channel_axis=5)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(3, 4))
+
+
+class TestLPPoolTransforms(unittest.TestCase):
+    """Gradient and jit consistency checks for the LP-pooling variants."""
+
+    def test_lppool1d_grad_and_jit(self):
+        """LPPool1d is jit-stable and produces finite gradients."""
+        pool = nn.LPPool1d(2, 2, 2, channel_axis=-1)
+        with seeded(4):
+            x = brainstate.random.randn(SMALL_BATCH, 8, 3) + 1.0
+        assert_jit_equal(pool, x)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+    @pytest.mark.slow
+    def test_lppool3d_grad_large_kernel(self):
+        """LPPool3d gradients remain finite with a larger kernel."""
+        pool = nn.LPPool3d(2, 3, 2, channel_axis=-1)
+        with seeded(5):
+            x = brainstate.random.randn(1, 12, 12, 12, 2) + 1.0
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+
+class TestAdaptivePoolValidation(unittest.TestCase):
+    """Cover the validation and forward branches of ``_AdaptivePool``."""
+
+    def test_target_size_wrong_length_raises(self):
+        """A target-size tuple whose length differs from the spatial dims is rejected."""
+        with self.assertRaises(ValueError):
+            nn.AdaptiveAvgPool2d((5, 6, 7))
+
+    def test_target_size_wrong_type_raises(self):
+        """A non-int, non-sequence target size is rejected."""
+        with self.assertRaises(ValueError):
+            nn.AdaptiveAvgPool2d(2.5)
+
+    def test_in_size_infers_out_size(self):
+        """Supplying ``in_size`` triggers adaptive output-shape inference."""
+        p = nn.AdaptiveAvgPool2d((4, 4), in_size=(8, 8, 3), channel_axis=-1)
+        self.assertEqual(p.out_size, (4, 4, 3))
+
+    def test_invalid_channel_axis_raises(self):
+        """An out-of-range channel axis is rejected during the forward pass."""
+        p = nn.AdaptiveAvgPool1d(5, channel_axis=5)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(3, 4))
+
+    def test_too_few_dims_raises_with_channel(self):
+        """A valid channel axis but too few overall dims raises a dimension error."""
+        p = nn.AdaptiveAvgPool2d((2, 2), channel_axis=0)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(3, 4))
+
+    def test_too_few_dims_raises_no_channel(self):
+        """With ``channel_axis=None`` an input below the target rank raises."""
+        p = nn.AdaptiveAvgPool2d((2, 2), channel_axis=None)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(4))
+
+    def test_channel_axis_none_forward(self):
+        """Adaptive pooling with ``channel_axis=None`` pools the trailing axis."""
+        p = nn.AdaptiveAvgPool1d(5, channel_axis=None)
+        out = p(brainstate.random.randn(2, 32))
+        self.assertEqual(out.shape, (2, 5))
+
+    def test_negative_channel_axis_forward(self):
+        """Adaptive pooling resolves a negative channel axis."""
+        p = nn.AdaptiveMaxPool1d(5, channel_axis=-1)
+        out = p(brainstate.random.randn(2, 32, 4))
+        self.assertEqual(out.shape, (2, 5, 4))
+
+    @pytest.mark.skip(
+        reason="BUG: AdaptiveAvgPool2d/3d (and Max variants) document a `None` "
+               "target dim ('Use None for dimensions that should not be pooled') "
+               "but `_adaptive_pool1d` computes `size % target_size`, raising "
+               "`TypeError: unsupported operand type(s) for %: 'int' and 'NoneType'` "
+               "when target_size is None. Repro: "
+               "nn.AdaptiveAvgPool2d((None, 7), channel_axis=-1)(randn(1, 10, 9, 8))."
+    )
+    def test_adaptive_avg_pool_with_none_target_dim(self):
+        """A ``None`` entry in the target size leaves that dimension unchanged."""
+        p = nn.AdaptiveAvgPool2d((None, 7), channel_axis=-1)
+        out = p(brainstate.random.randn(1, 10, 9, 8))
+        self.assertEqual(out.shape, (1, 10, 7, 8))
+
+
+class TestAdaptivePoolTransforms(unittest.TestCase):
+    """Gradient and jit consistency checks for the adaptive-pooling variants."""
+
+    def test_adaptive_avg_pool1d_grad_and_jit(self):
+        """AdaptiveAvgPool1d is jit-stable and produces finite gradients."""
+        pool = nn.AdaptiveAvgPool1d(5, channel_axis=-1)
+        with seeded(6):
+            x = brainstate.random.randn(2, 16, 3)
+        assert_jit_equal(pool, x)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+    def test_adaptive_max_pool2d_grad_and_jit(self):
+        """AdaptiveMaxPool2d is jit-stable and produces finite gradients."""
+        pool = nn.AdaptiveMaxPool2d((3, 3), channel_axis=-1)
+        with seeded(8):
+            x = brainstate.random.randn(1, 8, 8, 2)
+        assert_jit_equal(pool, x)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
+
+    @pytest.mark.slow
+    def test_adaptive_max_pool3d_grad(self):
+        """AdaptiveMaxPool3d gradients remain finite on a moderate input."""
+        pool = nn.AdaptiveMaxPool3d((3, 3, 3), channel_axis=-1)
+        with seeded(9):
+            x = brainstate.random.randn(1, 8, 8, 8, 2)
+        assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_utils_test.py
+++ b/brainstate/nn/_utils_test.py
@@ -14,12 +14,26 @@
 # ==============================================================================
 
 import unittest
+import warnings
+
+import pytest
 from absl.testing import parameterized
 import jax
 import jax.numpy as jnp
 import numpy as np
 
 import brainstate
+from brainstate.nn import _utils as nn_utils
+
+
+def tearDownModule():
+    """Restore 64-bit precision to its default so later test modules are not polluted.
+
+    ``TestClipGradNorm.setUp`` enables ``jax_enable_x64`` globally without restoring
+    it, which leaks into sibling test modules (e.g. ``_hidata_test``) when the whole
+    suite runs in one process.  Reset it once this module finishes.
+    """
+    jax.config.update("jax_enable_x64", False)
 
 
 class TestClipGradNorm(parameterized.TestCase):
@@ -396,6 +410,155 @@ class TestClipGradNorm(parameterized.TestCase):
         except:
             # Expected if None values cause issues
             pass
+
+
+class TestClipGradNormExtraBranches(unittest.TestCase):
+    """Cover the remaining ``clip_grad_norm`` norm-type branches."""
+
+    def test_negative_inf_string_norm(self):
+        """The string ``'-inf'`` maps to the minimum-absolute-value norm."""
+        grads = {'param': jnp.array([2.0, -5.0, 1.0])}
+        clipped, norm = brainstate.nn.clip_grad_norm(
+            grads, max_norm=10.0, norm_type='-inf', return_norm=True
+        )
+        # -inf norm over a flattened vector is the minimum absolute value.
+        self.assertAlmostEqual(float(norm), 1.0, places=5)
+        # norm (1.0) < max_norm (10.0) so gradients are unchanged.
+        np.testing.assert_array_almost_equal(clipped['param'], grads['param'], decimal=5)
+
+    def test_negative_inf_jnp_norm_matches_string(self):
+        """``-jnp.inf`` produces the same norm as the ``'-inf'`` string alias."""
+        grads = {'param': jnp.array([2.0, -5.0, 1.0])}
+        _, norm_str = brainstate.nn.clip_grad_norm(
+            grads, max_norm=10.0, norm_type='-inf', return_norm=True
+        )
+        _, norm_val = brainstate.nn.clip_grad_norm(
+            grads, max_norm=10.0, norm_type=-jnp.inf, return_norm=True
+        )
+        self.assertAlmostEqual(float(norm_str), float(norm_val), places=6)
+
+
+class TestFormatParameterCount(unittest.TestCase):
+    """Cover ``_format_parameter_count`` magnitude scaling and rollover."""
+
+    def test_below_one_thousand_returns_plain_string(self):
+        """Counts under 1000 are returned verbatim without a suffix."""
+        self.assertEqual(nn_utils._format_parameter_count(0), "0")
+        self.assertEqual(nn_utils._format_parameter_count(999), "999")
+
+    def test_thousands_use_k_suffix(self):
+        """Counts in the thousands use the ``K`` suffix."""
+        self.assertEqual(nn_utils._format_parameter_count(1000), "1.00K")
+        self.assertEqual(nn_utils._format_parameter_count(1500), "1.50K")
+
+    def test_millions_use_m_suffix(self):
+        """Counts in the millions use the ``M`` suffix."""
+        self.assertEqual(nn_utils._format_parameter_count(1_500_000), "1.50M")
+
+    def test_precision_argument(self):
+        """The ``precision`` argument controls the number of decimal places."""
+        self.assertEqual(nn_utils._format_parameter_count(1234, precision=3), "1.234K")
+        self.assertEqual(nn_utils._format_parameter_count(2_500_000, precision=1), "2.5M")
+
+    def test_near_thousand_rolls_over_to_next_magnitude(self):
+        """A value that rounds up to 1000 of its magnitude rolls to the next suffix."""
+        # 999999 -> 1000.00K, which rounds up and is promoted to 1.00M.
+        self.assertEqual(nn_utils._format_parameter_count(999_999), "1.00M")
+
+
+class TestCountParameters(unittest.TestCase):
+    """Cover ``count_parameters`` totals, table return, and validation."""
+
+    def test_count_matches_param_numel(self):
+        """The returned total equals the sum of ParamState element counts."""
+        pytest.importorskip("prettytable")
+        model = brainstate.nn.Linear(4, 3)
+        total = brainstate.nn.count_parameters(model)
+        # weight (4x3) + bias (3) = 15.
+        self.assertEqual(total, 15)
+
+    def test_return_table_returns_pair(self):
+        """``return_table=True`` returns a ``(table, total)`` pair."""
+        prettytable = pytest.importorskip("prettytable")
+        model = brainstate.nn.Linear(4, 3)
+        table, total = brainstate.nn.count_parameters(model, return_table=True)
+        self.assertIsInstance(table, prettytable.PrettyTable)
+        self.assertEqual(total, 15)
+
+    def test_non_module_input_raises(self):
+        """A non-Module argument raises an ``AssertionError``."""
+        with self.assertRaises(AssertionError):
+            brainstate.nn.count_parameters(object())
+
+
+class TestGetValue(unittest.TestCase):
+    """Cover the ``get_value`` State-unwrapping helper."""
+
+    def test_unwraps_state(self):
+        """A State instance returns its ``.value``."""
+        state = brainstate.ParamState(jnp.array(1.5))
+        np.testing.assert_array_equal(nn_utils.get_value(state), jnp.array(1.5))
+
+    def test_passes_through_non_state(self):
+        """A plain value is returned unchanged."""
+        self.assertEqual(nn_utils.get_value(2.0), 2.0)
+        obj = object()
+        self.assertIs(nn_utils.get_value(obj), obj)
+
+
+class TestGetSize(unittest.TestCase):
+    """Cover the ``get_size`` normalization helper."""
+
+    def test_int_becomes_single_element_tuple(self):
+        """An int is wrapped into a single-element tuple."""
+        self.assertEqual(nn_utils.get_size(5), (5,))
+
+    def test_tuple_is_preserved(self):
+        """A tuple is returned as an equal tuple."""
+        self.assertEqual(nn_utils.get_size((3, 4)), (3, 4))
+
+    def test_list_becomes_tuple(self):
+        """A list is converted to a tuple."""
+        self.assertEqual(nn_utils.get_size([2, 3, 4]), (2, 3, 4))
+
+    def test_invalid_type_raises_value_error(self):
+        """A non int/tuple/list raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            nn_utils.get_size("not-a-size")
+
+
+class TestNNPackageGetattr(unittest.TestCase):
+    """Cover the lazy ``brainstate.nn.__getattr__`` deprecation dispatch."""
+
+    def test_dynamics_group_alias(self):
+        """``DynamicsGroup`` resolves to ``Module`` and warns about deprecation."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            obj = brainstate.nn.DynamicsGroup
+        self.assertIs(obj, brainstate.nn.Module)
+        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
+    def test_module_mapper_alias(self):
+        """``ModuleMapper`` resolves to ``Map`` and warns about deprecation."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            obj = brainstate.nn.ModuleMapper
+        self.assertIs(obj, brainstate.nn.Map)
+        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
+    def test_deprecated_name_forwards_to_brainpy(self):
+        """A name in ``_DEPRECATED_NAMES`` is forwarded to ``brainpy.state`` with a warning."""
+        brainpy = pytest.importorskip("brainpy")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            obj = brainstate.nn.IF
+        self.assertIs(obj, brainpy.state.IF)
+        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
+    def test_unknown_attribute_raises(self):
+        """An unrecognized attribute raises ``AttributeError``."""
+        with self.assertRaises(AttributeError):
+            _ = brainstate.nn.ThisAttributeDoesNotExist
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/init.py
+++ b/brainstate/nn/init.py
@@ -190,12 +190,15 @@ def param(
     else:
         raise ValueError(f'Unknown parameter type: {type(parameter)}')
 
+    # Resolve the underlying array: a ``State`` stores its array in ``.value`` and
+    # does not expose ``.shape`` directly, so resolve it before any shape checks.
+    param_value = parameter.value if isinstance(parameter, State) else parameter
+
     # Check if the shape of the parameter matches the given size
-    if not are_broadcastable_shapes(parameter.shape, sizes):
-        raise ValueError(f'The shape of the parameter {parameter.shape} does not match with the given size {sizes}')
+    if not are_broadcastable_shapes(param_value.shape, sizes):
+        raise ValueError(f'The shape of the parameter {param_value.shape} does not match with the given size {sizes}')
 
     # Expand the parameter to match the given batch size
-    param_value = parameter.value if isinstance(parameter, State) else parameter
     if batch_size is not None:
         if param_value.ndim <= len(sizes):
             # add a new axis to the params so that it matches the dimensionality of the given shape ``sizes``

--- a/brainstate/nn/init_test.py
+++ b/brainstate/nn/init_test.py
@@ -17,7 +17,15 @@
 
 import unittest
 
+import brainunit as u
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
 import brainstate
+from brainstate import _testing
+from brainstate._state import State
+from brainstate.nn import init as I
 
 
 class TestNormalInit(unittest.TestCase):
@@ -178,3 +186,401 @@ class TestIdentityInit(unittest.TestCase):
                     assert weights.shape == (size[0], size[0])
                 else:
                     assert weights.shape == size
+
+
+# ---------------------------------------------------------------------------
+# Appended coverage tests (target: brainstate/nn/init.py >= 90% line coverage).
+# ---------------------------------------------------------------------------
+
+
+_SHAPE = (_testing.SMALL_BATCH, _testing.SMALL_DIM)
+
+
+class TestToSizeHelper(unittest.TestCase):
+    """Tests for the ``to_size`` shape-normalising helper."""
+
+    def test_tuple_and_list(self):
+        """``to_size`` returns a tuple for tuple/list inputs."""
+        self.assertEqual(I.to_size([2, 3]), (2, 3))
+        self.assertEqual(I.to_size((4, 5)), (4, 5))
+
+    def test_int(self):
+        """``to_size`` wraps a bare integer in a one-tuple."""
+        self.assertEqual(I.to_size(7), (7,))
+
+    def test_none(self):
+        """``to_size`` passes ``None`` through unchanged."""
+        self.assertIsNone(I.to_size(None))
+
+    def test_invalid_raises(self):
+        """``to_size`` raises ``ValueError`` for unsupported types."""
+        with self.assertRaises(ValueError):
+            I.to_size('not-a-size')
+
+
+class TestFormatShapeHelper(unittest.TestCase):
+    """Tests for the ``_format_shape`` helper."""
+
+    def test_int(self):
+        """``_format_shape`` wraps an int into a one-tuple."""
+        self.assertEqual(I._format_shape(5), (5,))
+
+    def test_empty_raises(self):
+        """``_format_shape`` raises when the shape is empty."""
+        with self.assertRaises(ValueError):
+            I._format_shape(())
+
+    def test_single_nested(self):
+        """``_format_shape`` unwraps a single nested tuple/list element."""
+        self.assertEqual(I._format_shape([(3, 4)]), (3, 4))
+
+    def test_single_scalar(self):
+        """``_format_shape`` keeps a single scalar element as a one-tuple."""
+        self.assertEqual(I._format_shape((3,)), (3,))
+
+    def test_multi(self):
+        """``_format_shape`` returns multi-dim shapes unchanged."""
+        self.assertEqual(I._format_shape((2, 3, 4)), (2, 3, 4))
+
+
+class TestBroadcastHelpers(unittest.TestCase):
+    """Tests for ``are_broadcastable_shapes`` and ``_is_scalar``."""
+
+    def test_broadcastable_equal(self):
+        """Equal shapes are broadcastable."""
+        self.assertTrue(I.are_broadcastable_shapes((3,), (3,)))
+
+    def test_broadcastable_with_one(self):
+        """A leading 1 broadcasts against a larger dimension."""
+        self.assertTrue(I.are_broadcastable_shapes((1, 3), (4, 3)))
+
+    def test_not_broadcastable(self):
+        """Mismatched non-unit dimensions are not broadcastable."""
+        self.assertFalse(I.are_broadcastable_shapes((2, 3), (4, 3)))
+
+    def test_is_scalar(self):
+        """``_is_scalar`` distinguishes scalars from arrays."""
+        self.assertTrue(I._is_scalar(5))
+        self.assertFalse(I._is_scalar(np.ones((3,))))
+
+    def test_expand_params(self):
+        """``_expand_params_to_match_sizes`` adds leading axes."""
+        out = I._expand_params_to_match_sizes(np.ones((3,)), (2, 3))
+        self.assertEqual(out.shape, (1, 3))
+
+
+class TestCalculateInitGain(unittest.TestCase):
+    """Tests for ``calculate_init_gain`` across every nonlinearity branch."""
+
+    def test_linear_family(self):
+        """Linear and conv nonlinearities return a gain of 1."""
+        for name in ['linear', 'conv1d', 'conv2d', 'conv3d',
+                     'conv_transpose1d', 'conv_transpose2d', 'conv_transpose3d']:
+            self.assertEqual(I.calculate_init_gain(name), 1)
+
+    def test_sigmoid(self):
+        """Sigmoid returns a gain of 1."""
+        self.assertEqual(I.calculate_init_gain('sigmoid'), 1)
+
+    def test_tanh(self):
+        """Tanh returns a gain of 5/3."""
+        self.assertAlmostEqual(I.calculate_init_gain('tanh'), 5.0 / 3)
+
+    def test_relu(self):
+        """ReLU returns a gain of sqrt(2)."""
+        self.assertAlmostEqual(I.calculate_init_gain('relu'), np.sqrt(2.0))
+
+    def test_selu(self):
+        """SELU returns a gain of 3/4."""
+        self.assertEqual(I.calculate_init_gain('selu'), 3.0 / 4)
+
+    def test_leaky_relu_default(self):
+        """Leaky ReLU uses a default negative slope of 0.01."""
+        expected = np.sqrt(2.0 / (1 + 0.01 ** 2))
+        self.assertAlmostEqual(I.calculate_init_gain('leaky_relu'), expected)
+
+    def test_leaky_relu_param(self):
+        """Leaky ReLU honours an explicit numeric negative slope."""
+        expected = np.sqrt(2.0 / (1 + 0.2 ** 2))
+        self.assertAlmostEqual(I.calculate_init_gain('leaky_relu', 0.2), expected)
+
+    def test_leaky_relu_invalid_param(self):
+        """A non-numeric leaky-relu slope raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            I.calculate_init_gain('leaky_relu', 'bad')
+
+    def test_unsupported(self):
+        """An unknown nonlinearity raises ``ValueError``."""
+        with self.assertRaises(ValueError):
+            I.calculate_init_gain('does-not-exist')
+
+
+class TestParamFunction(unittest.TestCase):
+    """Tests for the ``param`` parameter-initialisation entry point."""
+
+    def test_none_allowed(self):
+        """``param`` returns ``None`` when ``parameter`` is ``None`` and allowed."""
+        self.assertIsNone(I.param(None, (3,)))
+
+    def test_none_disallowed(self):
+        """``param`` raises when ``None`` is given but not allowed."""
+        with self.assertRaises(ValueError):
+            I.param(None, (3,), allow_none=False)
+
+    def test_scalar_allowed(self):
+        """``param`` returns a scalar unchanged when scalars are allowed."""
+        self.assertEqual(I.param(5.0, (3,)), 5.0)
+
+    def test_callable(self):
+        """``param`` calls a callable initializer with the requested size."""
+        out = I.param(brainstate.nn.init.ZeroInit(), (3,))
+        self.assertEqual(out.shape, (3,))
+
+    def test_callable_with_batch(self):
+        """``param`` prepends the batch dimension for callable initializers."""
+        out = I.param(brainstate.nn.init.ZeroInit(), (3,), batch_size=2)
+        self.assertEqual(out.shape, (2, 3))
+
+    def test_ndarray_matching(self):
+        """``param`` accepts an array whose shape matches the requested size."""
+        out = I.param(np.ones((3,)), (3,), allow_scalar=False)
+        self.assertEqual(out.shape, (3,))
+
+    def test_ndarray_with_batch(self):
+        """``param`` broadcasts an array across a new batch dimension."""
+        out = I.param(np.ones((3,)), (3,), batch_size=2, allow_scalar=False)
+        self.assertEqual(out.shape, (2, 3))
+
+    def test_ndarray_shape_mismatch(self):
+        """``param`` raises when the array shape is not broadcastable."""
+        with self.assertRaises(ValueError):
+            I.param(np.ones((3,)), (5,), allow_scalar=False)
+
+    def test_unknown_type(self):
+        """``param`` raises for an unrecognised parameter type."""
+        with self.assertRaises(ValueError):
+            I.param(object(), (3,), allow_scalar=False)
+
+    def test_state_input(self):
+        """``param`` accepts a ``State`` parameter and returns a ``State``."""
+        out = I.param(State(np.ones((3,))), (3,), allow_scalar=False)
+        self.assertIsInstance(out, State)
+        self.assertEqual(out.value.shape, (3,))
+
+
+class TestInitializerRepr(unittest.TestCase):
+    """Tests for the pretty-repr machinery on ``Initializer``."""
+
+    def test_repr_contains_attrs(self):
+        """The repr lists public attributes and skips private ones."""
+        text = repr(brainstate.nn.init.Normal(scale=0.5, mean=0.1))
+        self.assertIn('Normal', text)
+        self.assertIn('scale', text)
+        self.assertIn('mean', text)
+
+    def test_base_call_not_implemented(self):
+        """The base ``Initializer.__call__`` raises ``NotImplementedError``."""
+        with self.assertRaises(NotImplementedError):
+            I.Initializer()((3,))
+
+    def test_repr_skips_private_attrs(self):
+        """The repr omits attributes whose name starts with an underscore."""
+
+        class _Custom(I.Initializer):
+            """Initializer carrying both a public and a private attribute."""
+
+            def __init__(self):
+                self.public = 1
+                self._private = 2
+
+        text = repr(_Custom())
+        self.assertIn('public', text)
+        self.assertNotIn('_private', text)
+
+
+class TestSeededDeterminism(unittest.TestCase):
+    """Stochastic initializers reproduce under a fixed RNG seed context."""
+
+    def _check(self, init, shape):
+        """Assert two seeded draws from ``init`` match exactly."""
+        with _testing.seeded(0):
+            a = init(shape)
+        with _testing.seeded(0):
+            b = init(shape)
+        _testing.assert_allclose(a, b)
+
+    def test_normal(self):
+        """``Normal`` is deterministic under a fixed seed."""
+        self._check(brainstate.nn.init.Normal(), _SHAPE)
+
+    def test_uniform(self):
+        """``Uniform`` is deterministic under a fixed seed."""
+        self._check(brainstate.nn.init.Uniform(), _SHAPE)
+
+    def test_truncated_normal(self):
+        """``TruncatedNormal`` is deterministic under a fixed seed."""
+        self._check(brainstate.nn.init.TruncatedNormal(lower=-2, upper=2), _SHAPE)
+
+    def test_variance_scaling(self):
+        """``VarianceScaling`` is deterministic under a fixed seed."""
+        init = brainstate.nn.init.VarianceScaling(
+            scale=1., mode='fan_in', distribution='normal')
+        self._check(init, _SHAPE)
+
+    def test_orthogonal(self):
+        """``Orthogonal`` is deterministic under a fixed seed."""
+        self._check(brainstate.nn.init.Orthogonal(), _SHAPE)
+
+
+class TestDtypeAndUnits(unittest.TestCase):
+    """Initializers honour the ``dtype`` kwarg and the ``unit`` argument."""
+
+    def test_zero_dtype(self):
+        """``ZeroInit`` respects an explicit dtype."""
+        out = brainstate.nn.init.ZeroInit()(_SHAPE, dtype=jnp.float16)
+        self.assertEqual(out.dtype, jnp.float16)
+
+    def test_constant_dtype(self):
+        """``Constant`` respects an explicit dtype and fills the value."""
+        out = brainstate.nn.init.Constant(value=3.0)(_SHAPE, dtype=jnp.float16)
+        self.assertEqual(out.dtype, jnp.float16)
+        self.assertTrue(bool((out == 3.0).all()))
+
+    def test_normal_unit(self):
+        """``Normal`` attaches the requested physical unit."""
+        out = brainstate.nn.init.Normal(unit=u.mV)(_SHAPE)
+        self.assertEqual(u.get_unit(out), u.mV)
+
+    def test_zero_unit(self):
+        """``ZeroInit`` attaches the requested physical unit."""
+        out = brainstate.nn.init.ZeroInit(unit=u.mV)(_SHAPE)
+        self.assertEqual(u.get_unit(out), u.mV)
+
+
+class TestZeroInitValues(unittest.TestCase):
+    """``ZeroInit`` produces all-zero arrays of the requested shape."""
+
+    def test_zeros(self):
+        """Every entry of a ``ZeroInit`` draw is zero."""
+        out = brainstate.nn.init.ZeroInit()(_SHAPE)
+        _testing.assert_allclose(out, jnp.zeros(_SHAPE))
+
+
+class TestConstantValues(unittest.TestCase):
+    """``Constant`` fills the array with the supplied value."""
+
+    def test_fill(self):
+        """Every entry equals the constant value."""
+        out = brainstate.nn.init.Constant(value=2.5)(_SHAPE)
+        _testing.assert_allclose(out, jnp.full(_SHAPE, 2.5))
+
+
+class TestIdentityValues(unittest.TestCase):
+    """``Identity`` produces a scaled identity matrix and validates rank."""
+
+    def test_one_d_square(self):
+        """A 1D shape yields a square identity matrix with scaled diagonal."""
+        out = brainstate.nn.init.Identity(value=2.0)((3,))
+        self.assertEqual(out.shape, (3, 3))
+        np.testing.assert_allclose(np.diag(np.asarray(out)), [2.0, 2.0, 2.0])
+
+    def test_three_d_raises(self):
+        """Identity rejects shapes with more than two dimensions."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.init.Identity()((3, 4, 5))
+
+
+class TestOrthogonalProperty(unittest.TestCase):
+    """``Orthogonal`` produces matrices with orthonormal columns."""
+
+    def test_orthonormal_columns(self):
+        """``w.T @ w`` approximates the identity for a tall matrix."""
+        w = jnp.asarray(brainstate.nn.init.Orthogonal()((8, 4)))
+        _testing.assert_allclose(w.T @ w, jnp.eye(4), atol=1e-4)
+
+    def test_scale_and_axis(self):
+        """``Orthogonal`` honours scale and axis arguments and shape."""
+        out = brainstate.nn.init.Orthogonal(scale=2., axis=0)((4, 6))
+        self.assertEqual(out.shape, (4, 6))
+
+
+class TestDeltaOrthogonalValidation(unittest.TestCase):
+    """``DeltaOrthogonal`` validates rank and fan ordering."""
+
+    def test_valid_shapes(self):
+        """3D/4D/5D shapes initialise to the requested shape."""
+        for shape in [(3, 4, 5), (3, 3, 4, 5), (3, 3, 3, 4, 5)]:
+            out = brainstate.nn.init.DeltaOrthogonal()(shape)
+            self.assertEqual(out.shape, shape)
+
+    def test_bad_rank(self):
+        """A 2D shape is rejected."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.init.DeltaOrthogonal()((3, 4))
+
+    def test_fan_in_gt_fan_out(self):
+        """A shape with fan_in > fan_out is rejected."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.init.DeltaOrthogonal()((3, 4, 2))
+
+
+class TestVarianceScalingBranches(unittest.TestCase):
+    """``VarianceScaling`` covers each mode/distribution combination."""
+
+    def test_modes_and_distributions(self):
+        """Each valid mode and distribution yields the requested shape."""
+        for mode in ['fan_in', 'fan_out', 'fan_avg']:
+            for dist in ['truncated_normal', 'normal', 'uniform']:
+                init = brainstate.nn.init.VarianceScaling(
+                    scale=1., mode=mode, distribution=dist)
+                out = init((10, 20))
+                self.assertEqual(out.shape, (10, 20))
+
+    def test_invalid_mode_assert(self):
+        """An invalid mode is rejected at construction."""
+        with self.assertRaises(AssertionError):
+            brainstate.nn.init.VarianceScaling(
+                scale=1., mode='bad', distribution='normal')
+
+    def test_invalid_distribution_assert(self):
+        """An invalid distribution is rejected at construction."""
+        with self.assertRaises(AssertionError):
+            brainstate.nn.init.VarianceScaling(
+                scale=1., mode='fan_in', distribution='bad')
+
+
+class TestTruncatedNormalBranches(unittest.TestCase):
+    """``TruncatedNormal`` validates scale and respects bounds."""
+
+    def test_scale_must_be_positive(self):
+        """A non-positive scale is rejected at construction."""
+        with self.assertRaises(AssertionError):
+            brainstate.nn.init.TruncatedNormal(scale=-1.)
+
+    def test_bounds_respected(self):
+        """Samples lie within the requested lower/upper bounds."""
+        init = brainstate.nn.init.TruncatedNormal(scale=1., lower=-1, upper=1, seed=0)
+        arr = np.asarray(init((200,)))
+        self.assertGreaterEqual(arr.min(), -1.001)
+        self.assertLessEqual(arr.max(), 1.001)
+
+    @pytest.mark.skip(reason="BUG: TruncatedNormal() with default lower/upper=None "
+                             "crashes in random.truncated_normal (None - array)")
+    def test_default_bounds(self):
+        """``TruncatedNormal`` should work with default (None) bounds."""
+        out = brainstate.nn.init.TruncatedNormal()((4,))
+        self.assertEqual(out.shape, (4,))
+
+
+class TestGammaExponential(unittest.TestCase):
+    """``Gamma`` and ``Exponential`` produce arrays of the requested shape."""
+
+    def test_gamma_shape(self):
+        """``Gamma`` returns an array of the requested shape."""
+        out = I.Gamma(shape=2.0, scale=1.0, seed=0)((4,))
+        self.assertEqual(out.shape, (4,))
+
+    def test_exponential_shape(self):
+        """``Exponential`` returns an array of the requested shape."""
+        out = I.Exponential(scale=1.0, seed=0)((4,))
+        self.assertEqual(out.shape, (4,))


### PR DESCRIPTION
## Summary

Comprehensive test audit of the `brainstate.nn` subpackage. Coverage rises
from **79% → 97%**, with **every nn module at ≥90%** line+branch coverage.
Full project suite: **4053 passed, 15 skipped, 0 failed**.

New and expanded tests cover dynamics, modules, collective ops, convolutions,
pooling, padding, normalization, embedding, delays, event-driven connectivity,
hidden data, parameters, initializers, and utilities — including edge cases,
gradient/JIT/vmap compatibility, and failure modes.

## Source fix included

- **`nn/init.py::param`** now accepts a `State` argument. It previously read
  `parameter.shape` directly during shape validation, but a `State` exposes its
  array via `.value`, raising `AttributeError`. `State` was already an accepted
  type and handled correctly at the expansion/return steps — only the shape
  check was broken. Regression test: `init_test.py::TestParamFunction::test_state_input`.

## Latent bugs surfaced (documented, not fixed here)

These were discovered while writing tests. Each has a `@pytest.mark.skip` with a
`BUG:` reason carrying a minimal repro, so they are tracked without blocking the
suite. They are left for dedicated follow-up fixes because they touch cross-cutting
or external (`brainevent`, `random`) behavior whose intended contract needs a
maintainer decision:

1. **`_collective_ops.vmap_call_all_fns`** — leaks a JAX `BatchTracer` into newly
   created state values; the batched value is never committed, so later use raises
   `UnexpectedTracerError`.
2. **`_common._filter_states`** — the dict branch iterates dict *keys* rather than
   *items*; the docstring's `{filter: axis}` form raises `TypeError`. Actual callers
   pass the axis-keyed `{axis: {filter}}` form, so the intended contract is ambiguous.
3. **`_delay` unit-aware retrieval** — `take_aware_unit` retrieval fails with a pytree
   node mismatch (`Quantity` history vs `Unit` `_unit`) in `_retrieve_at_step_impl`.
4. **`_event_fixedprob` `efferent_target='pre'`** — builds indices sized `(n_pre, conn_num)`
   but `brainevent.FixedPreNumConn` validates rows against `n_post`; crashes, and the
   `afferent_ratio<1` variant triggers a native memory abort in the CSC path.
5. **`init.TruncatedNormal()` default bounds** — `lower/upper=None` crashes in
   `random.truncated_normal` (`None - array`). Root cause lives in the `random` subpackage.
6. **`_normalizations.weight_standardization`** — a unit-carrying `Quantity` input builds
   `u.Quantity(..., unit=1/unit**0.5)`; `1/unit**0.5` evaluates to a `Quantity` (not a
   `Unit`), so `Quantity.__init__` asserts.
7. **`_poolings` adaptive pooling** — `AdaptiveAvgPool{2,3}d`/`MaxPool` document a `None`
   target dim ("Use None for dimensions that should not be pooled") but `_adaptive_pool1d`
   computes `size % target_size`, raising on `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
