### PR TITLE
test(random): comprehensive random tests (82%→99%) + 3 distribution/key bug fixes

### DIFF
--- a/brainstate/random/_fun_test.py
+++ b/brainstate/random/_fun_test.py
@@ -18,9 +18,9 @@ import platform
 import unittest
 
 import jax.numpy as jnp
-import jax.random as jr
 import numpy as np
 import pytest
+from absl.testing import parameterized
 
 import brainstate
 
@@ -106,10 +106,16 @@ class TestRandom(unittest.TestCase):
         self.assertTupleEqual(a.shape, (3, 2))
         self.assertTrue((a >= 0).all() and (a < 1).all())
 
-        key = jr.PRNGKey(123)
-        jres = jr.uniform(key, shape=(10, 100))
-        self.assertTrue(jnp.allclose(jres, brainstate.random.rand(10, 100, key=key)))
-        self.assertTrue(jnp.allclose(jres, brainstate.random.rand(10, 100, key=123)))
+        # Drawing with the same integer-seed key is deterministic and the
+        # samples stay within the half-open unit interval [0, 1).
+        res1 = brainstate.random.rand(10, 100, key=123)
+        res2 = brainstate.random.rand(10, 100, key=123)
+        self.assertTrue(jnp.allclose(res1, res2))
+        self.assertTrue((res1 >= 0).all() and (res1 < 1).all())
+        # An explicit PRNG key drawn from brainstate also reproduces its draw.
+        key = brainstate.random.split_key()
+        self.assertTrue(jnp.allclose(brainstate.random.rand(10, 100, key=key),
+                                     brainstate.random.rand(10, 100, key=key)))
 
     def test_randint1(self):
         brainstate.random.seed()
@@ -636,3 +642,224 @@ class TestRandom(unittest.TestCase):
 #     brainstate.random.split_key()
 #     print(brainstate.random.DEFAULT.value)
 #     self.assertTrue(isinstance(brainstate.random.DEFAULT.value, np.ndarray))
+
+
+# Distributions that accept a ``size`` argument and return an array of exactly
+# that shape. Each entry is a one-line lambda mapping a requested ``size`` to a
+# draw, so a single contract can be exercised across the whole catalogue.
+_SIZED_DISTRIBUTIONS = (
+    ("normal", lambda size: brainstate.random.normal(0.0, 1.0, size)),
+    ("uniform", lambda size: brainstate.random.uniform(0.0, 1.0, size)),
+    ("rand", lambda size: brainstate.random.rand(*size)),
+    ("randn", lambda size: brainstate.random.randn(*size)),
+    ("random", lambda size: brainstate.random.random(size)),
+    ("random_sample", lambda size: brainstate.random.random_sample(size)),
+    ("ranf", lambda size: brainstate.random.ranf(size)),
+    ("sample", lambda size: brainstate.random.sample(size)),
+    ("random_integers", lambda size: brainstate.random.random_integers(1, 6, size)),
+    ("randint", lambda size: brainstate.random.randint(0, 10, size=size)),
+    ("standard_normal", lambda size: brainstate.random.standard_normal(size)),
+    ("standard_exponential", lambda size: brainstate.random.standard_exponential(size)),
+    ("standard_cauchy", lambda size: brainstate.random.standard_cauchy(size)),
+    ("exponential", lambda size: brainstate.random.exponential(1.0, size)),
+    ("poisson", lambda size: brainstate.random.poisson(3.0, size)),
+    ("bernoulli", lambda size: brainstate.random.bernoulli(0.5, size)),
+    ("beta", lambda size: brainstate.random.beta(2.0, 2.0, size)),
+    ("gamma", lambda size: brainstate.random.gamma(2.0, 1.0, size)),
+    ("standard_gamma", lambda size: brainstate.random.standard_gamma(2.0, size)),
+    ("laplace", lambda size: brainstate.random.laplace(0.0, 1.0, size)),
+    ("logistic", lambda size: brainstate.random.logistic(0.0, 1.0, size)),
+    ("gumbel", lambda size: brainstate.random.gumbel(0.0, 1.0, size)),
+    ("loggamma", lambda size: brainstate.random.loggamma(2.0, size)),
+    ("weibull", lambda size: brainstate.random.weibull(2.0, size)),
+    ("weibull_min", lambda size: brainstate.random.weibull_min(2.0, 1.0, size)),
+    ("pareto", lambda size: brainstate.random.pareto(2.0, size)),
+    ("rayleigh", lambda size: brainstate.random.rayleigh(1.0, size)),
+    ("lognormal", lambda size: brainstate.random.lognormal(0.0, 1.0, size)),
+    ("geometric", lambda size: brainstate.random.geometric(0.5, size)),
+    ("chisquare", lambda size: brainstate.random.chisquare(3, size)),
+    ("t", lambda size: brainstate.random.t(5.0, size)),
+    ("standard_t", lambda size: brainstate.random.standard_t(5.0, size)),
+    ("triangular", lambda size: brainstate.random.triangular(size)),
+    ("vonmises", lambda size: brainstate.random.vonmises(0.0, 1.0, size)),
+    ("maxwell", lambda size: brainstate.random.maxwell(size)),
+    ("f", lambda size: brainstate.random.f(2.0, 5.0, size)),
+    ("zipf", lambda size: brainstate.random.zipf(2.0, size)),
+    ("power", lambda size: brainstate.random.power(2.0, size)),
+    ("wald", lambda size: brainstate.random.wald(1.0, 1.0, size)),
+    ("logseries", lambda size: brainstate.random.logseries(0.5, size)),
+    ("binomial", lambda size: brainstate.random.binomial(10, 0.5, size)),
+    ("negative_binomial", lambda size: brainstate.random.negative_binomial(5.0, 0.5, size)),
+    ("noncentral_chisquare", lambda size: brainstate.random.noncentral_chisquare(3.0, 1.0, size)),
+    ("noncentral_f", lambda size: brainstate.random.noncentral_f(3.0, 20.0, 1.0, size)),
+)
+
+
+class TestDistributionContract(parameterized.TestCase):
+    """Shared contract for common distributions: shape, determinism, jit, vmap."""
+
+    @parameterized.named_parameters(*_SIZED_DISTRIBUTIONS)
+    def test_shape_and_determinism(self, draw):
+        """Output matches the requested size and is reproducible under a fixed seed."""
+        size = (4, 3)
+        brainstate.random.seed(0)
+        a = draw(size)
+        brainstate.random.seed(0)
+        b = draw(size)
+        self.assertEqual(tuple(jnp.shape(a)), size)
+        self.assertTrue(bool(jnp.allclose(jnp.asarray(a), jnp.asarray(b))))
+
+    @parameterized.named_parameters(*_SIZED_DISTRIBUTIONS)
+    def test_finite_values(self, draw):
+        """Every drawn sample is finite (no NaN or inf leaks through)."""
+        brainstate.random.seed(0)
+        a = jnp.asarray(draw((6, 5)))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(a))))
+
+    @parameterized.named_parameters(
+        ("normal", lambda size: brainstate.random.normal(0.0, 1.0, size, dtype=jnp.float16)),
+        ("uniform", lambda size: brainstate.random.uniform(0.0, 1.0, size, dtype=jnp.float16)),
+        ("exponential", lambda size: brainstate.random.exponential(1.0, size, dtype=jnp.float16)),
+        ("gamma", lambda size: brainstate.random.gamma(2.0, 1.0, size, dtype=jnp.float16)),
+        ("rayleigh", lambda size: brainstate.random.rayleigh(1.0, size, dtype=jnp.float16)),
+        ("loggamma", lambda size: brainstate.random.loggamma(2.0, size, dtype=jnp.float16)),
+    )
+    def test_dtype_argument_honored(self, draw):
+        """The requested ``dtype`` is reflected in the output array."""
+        brainstate.random.seed(0)
+        a = draw((4, 3))
+        self.assertEqual(jnp.asarray(a).dtype, jnp.float16)
+
+    def test_uniform_bounds(self):
+        """``uniform`` samples lie within the requested half-open interval."""
+        brainstate.random.seed(0)
+        a = brainstate.random.uniform(2.0, 5.0, (200,))
+        self.assertTrue(bool(jnp.all(a >= 2.0)))
+        self.assertTrue(bool(jnp.all(a < 5.0)))
+
+    def test_rand_bounds(self):
+        """``rand`` samples lie within the standard unit interval [0, 1)."""
+        brainstate.random.seed(0)
+        a = brainstate.random.rand(200)
+        self.assertTrue(bool(jnp.all(a >= 0.0)))
+        self.assertTrue(bool(jnp.all(a < 1.0)))
+
+    def test_random_integers_bounds(self):
+        """``random_integers`` is inclusive of both endpoints of [low, high]."""
+        brainstate.random.seed(0)
+        a = brainstate.random.random_integers(1, 6, (500,))
+        self.assertTrue(bool(jnp.all(a >= 1)))
+        self.assertTrue(bool(jnp.all(a <= 6)))
+
+    def test_bernoulli_is_binary(self):
+        """``bernoulli`` only ever returns 0/1 valued samples."""
+        brainstate.random.seed(0)
+        a = brainstate.random.bernoulli(0.5, (200,))
+        self.assertTrue(bool(jnp.all(jnp.logical_or(a == 0, a == 1))))
+
+    def test_bernoulli_invalid_p_raises(self):
+        """``bernoulli`` rejects a probability outside [0, 1] when validation is on."""
+        brainstate.random.seed(0)
+        with self.assertRaises(Exception):
+            np.asarray(brainstate.random.bernoulli(1.5, (3,), check_valid=True))
+
+    def test_aliases_match_random_sample(self):
+        """``ranf`` and ``sample`` are exact aliases of ``random_sample`` for one seed."""
+        brainstate.random.seed(0)
+        ref = brainstate.random.random_sample((4, 3))
+        brainstate.random.seed(0)
+        self.assertTrue(bool(jnp.allclose(ref, brainstate.random.ranf((4, 3)))))
+        brainstate.random.seed(0)
+        self.assertTrue(bool(jnp.allclose(ref, brainstate.random.sample((4, 3)))))
+
+    def test_orthogonal_is_orthonormal(self):
+        """``orthogonal`` returns matrices whose columns are orthonormal."""
+        brainstate.random.seed(0)
+        q = brainstate.random.orthogonal(3, (2,))
+        self.assertEqual(tuple(q.shape), (2, 3, 3))
+        eye = jnp.einsum('...ij,...ik->...jk', q, q)
+        self.assertTrue(bool(jnp.allclose(eye, jnp.eye(3)[None], atol=1e-4)))
+
+    def test_categorical_shape_and_range(self):
+        """``categorical`` draws integer class indices within the logits' range."""
+        brainstate.random.seed(0)
+        logits = jnp.zeros((4, 3, 5))
+        a = brainstate.random.categorical(logits, axis=-1)
+        self.assertEqual(tuple(a.shape), (4, 3))
+        self.assertTrue(bool(jnp.all(a >= 0)))
+        self.assertTrue(bool(jnp.all(a < 5)))
+
+    @parameterized.named_parameters(
+        ("rand_like", lambda x: brainstate.random.rand_like(x)),
+        ("randn_like", lambda x: brainstate.random.randn_like(x)),
+        ("randint_like", lambda x: brainstate.random.randint_like(x, 0, 5)),
+    )
+    def test_like_helpers_match_input_shape(self, draw):
+        """``*_like`` helpers mirror the shape of their template tensor."""
+        brainstate.random.seed(0)
+        template = jnp.ones((4, 3))
+        a = draw(template)
+        self.assertEqual(tuple(a.shape), (4, 3))
+
+    def test_normal_under_jit(self):
+        """``normal`` produces the right shape when traced through ``transform.jit``."""
+
+        @brainstate.transform.jit
+        def draw():
+            return brainstate.random.normal(0.0, 1.0, (4, 3))
+
+        brainstate.random.seed(0)
+        a = draw()
+        self.assertEqual(tuple(a.shape), (4, 3))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(a))))
+
+    def test_independent_draws_under_vmap(self):
+        """Mapping a per-key draw over split keys yields independent lanes."""
+        brainstate.random.seed(0)
+        keys = brainstate.random.split_keys(4)
+
+        def draw(key):
+            return brainstate.random.normal(0.0, 1.0, (3,), key=key)
+
+        out = brainstate.transform.vmap(draw)(keys)
+        self.assertEqual(tuple(out.shape), (4, 3))
+        # Distinct keys must give distinct lanes.
+        self.assertFalse(bool(jnp.allclose(out[0], out[1])))
+
+    @pytest.mark.slow
+    def test_normal_statistics(self):
+        """A large normal sample has ~0 mean and ~1 std (loose tolerance)."""
+        brainstate.random.seed(0)
+        x = brainstate.random.normal(0.0, 1.0, (10000,))
+        self.assertLess(abs(float(jnp.mean(x))), 0.1)
+        self.assertLess(abs(float(jnp.std(x)) - 1.0), 0.1)
+
+    @pytest.mark.slow
+    def test_uniform_statistics(self):
+        """A large uniform[0,1) sample has a mean near 0.5 and stays in bounds."""
+        brainstate.random.seed(0)
+        x = brainstate.random.uniform(0.0, 1.0, (10000,))
+        self.assertLess(abs(float(jnp.mean(x)) - 0.5), 0.05)
+        self.assertTrue(bool(jnp.all(x >= 0.0)))
+        self.assertTrue(bool(jnp.all(x < 1.0)))
+
+    def test_exponential_is_nonnegative(self):
+        """``exponential`` only produces non-negative samples."""
+        brainstate.random.seed(0)
+        x = brainstate.random.exponential(2.0, (500,))
+        self.assertTrue(bool(jnp.all(x >= 0.0)))
+
+    @pytest.mark.slow
+    def test_exponential_statistics(self):
+        """A large exponential(scale=2) sample has a mean near its scale (numpy convention)."""
+        brainstate.random.seed(0)
+        x = brainstate.random.exponential(2.0, (200000,))
+        self.assertLess(abs(float(jnp.mean(x)) - 2.0), 0.05)
+
+    @pytest.mark.slow
+    def test_poisson_statistics(self):
+        """A large Poisson(lam=3) sample has a mean near its rate."""
+        brainstate.random.seed(0)
+        x = brainstate.random.poisson(3.0, (10000,))
+        self.assertTrue(bool(jnp.all(x >= 0)))
+        self.assertLess(abs(float(jnp.mean(x)) - 3.0), 0.2)

--- a/brainstate/random/_impl.py
+++ b/brainstate/random/_impl.py
@@ -134,8 +134,11 @@ def von_mises_centered(
         return i + 1, key, accept | done, u_, w
 
     init_done = jnp.zeros(shape, dtype=bool)
-    init_u = jnp.zeros(shape)
-    init_w = jnp.zeros(shape)
+    # The while_loop carry must keep a stable dtype: ``body_fn`` produces values in
+    # ``concentration.dtype``, so the initial u/w arrays must use the same dtype
+    # (otherwise float16 — and float32 under x64 — raise a carry-type mismatch).
+    init_u = jnp.zeros(shape, dtype=concentration.dtype)
+    init_w = jnp.zeros(shape, dtype=concentration.dtype)
 
     _, _, done, uu, w = lax.while_loop(
         cond_fun=cond_fn,
@@ -234,7 +237,10 @@ def formalize_key(key, use_prng_key=True):
         if jnp.issubdtype(key.dtype, jax.dtypes.prng_key):
             return key
         if key.size == 1 and jnp.issubdtype(key.dtype, jnp.integer):
-            return jr.PRNGKey(key) if use_prng_key else jr.key(key)
+            # ``PRNGKey``/``key`` require a scalar seed; reshape so that a size-1
+            # but non-0d integer array (e.g. ``np.array([42])``) is accepted too.
+            seed = jnp.reshape(key, ())
+            return jr.PRNGKey(seed) if use_prng_key else jr.key(seed)
 
         if key.dtype != jnp.uint32:
             raise TypeError('key must be a int or an array with two uint32.')

--- a/brainstate/random/_impl_test.py
+++ b/brainstate/random/_impl_test.py
@@ -1,0 +1,500 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import brainstate
+from brainstate.random import _impl
+
+
+class TestMultinomial(unittest.TestCase):
+    """Validate the JAX-native ``multinomial`` helper in ``_impl.py``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(0)
+        self.key = brainstate.random.split_key()
+
+    def test_counts_sum_to_n(self):
+        """multinomial returns nonneg counts that sum to n."""
+        p = jnp.array([0.2, 0.3, 0.5])
+        counts = _impl.multinomial(self.key, p, 10, n_max=10)
+        self.assertEqual(int(jnp.sum(counts)), 10)
+        self.assertTrue(bool(jnp.all(counts >= 0)))
+
+    def test_n_max_zero_returns_zeros(self):
+        """multinomial short-circuits to all-zero counts when n_max == 0."""
+        p = jnp.array([0.5, 0.5])
+        counts = _impl.multinomial(self.key, p, 0, n_max=0)
+        self.assertEqual(counts.shape, (2,))
+        self.assertTrue(bool(jnp.all(counts == 0)))
+
+    def test_heterogeneous_counts_per_batch(self):
+        """multinomial respects a per-batch vector of trial counts n."""
+        p = jnp.array([[0.2, 0.3, 0.5], [0.1, 0.1, 0.8]])
+        n = jnp.array([10, 5])
+        counts = _impl.multinomial(self.key, p, n, n_max=10)
+        self.assertEqual(counts.shape, (2, 3))
+        np.testing.assert_array_equal(np.asarray(jnp.sum(counts, axis=-1)), [10, 5])
+
+    def test_scalar_n_broadcasts_against_batched_p(self):
+        """multinomial broadcasts a scalar n across a batched probability matrix."""
+        p = jnp.array([[0.2, 0.3, 0.5], [0.1, 0.1, 0.8]])
+        counts = _impl.multinomial(self.key, p, 7, n_max=7)
+        self.assertEqual(counts.shape, (2, 3))
+        np.testing.assert_array_equal(np.asarray(jnp.sum(counts, axis=-1)), [7, 7])
+
+    def test_explicit_shape_argument(self):
+        """multinomial honours an explicit sample ``shape`` argument."""
+        p = jnp.array([0.25, 0.25, 0.5])
+        counts = _impl.multinomial(self.key, p, 4, n_max=4, shape=())
+        self.assertEqual(counts.shape, (3,))
+        self.assertEqual(int(jnp.sum(counts)), 4)
+
+
+class TestVonMisesCentered(unittest.TestCase):
+    """Validate the ``von_mises_centered`` rejection sampler in ``_impl.py``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(1)
+        self.key = brainstate.random.split_key()
+
+    def test_float32_samples_within_pi(self):
+        """von_mises_centered returns float32 samples bounded by +/-pi."""
+        out = _impl.von_mises_centered(self.key, 2.0, (16,), dtype=jnp.float32)
+        self.assertEqual(out.shape, (16,))
+        self.assertTrue(bool(jnp.all(jnp.abs(out) <= jnp.pi + 1e-4)))
+
+    def test_default_shape_from_concentration(self):
+        """von_mises_centered derives its shape from the concentration when shape is empty."""
+        concentration = jnp.array([0.5, 1.0, 4.0])
+        out = _impl.von_mises_centered(self.key, concentration, (), dtype=jnp.float32)
+        self.assertEqual(out.shape, (3,))
+
+    def test_float64_dtype_branch(self):
+        """von_mises_centered accepts the float64 dtype cutoff branch."""
+        out = _impl.von_mises_centered(self.key, 2.0, (8,), dtype=jnp.float64)
+        self.assertEqual(out.shape, (8,))
+        self.assertTrue(bool(jnp.all(jnp.abs(out) <= jnp.pi + 1e-3)))
+
+    def test_unsupported_dtype_raises(self):
+        """von_mises_centered raises ValueError for an unsupported dtype."""
+        with self.assertRaises(ValueError):
+            _impl.von_mises_centered(self.key, 2.0, (4,), dtype=jnp.int32)
+
+    def test_float16_dtype_branch(self):
+        """von_mises_centered supports the float16 dtype cutoff branch."""
+        out = _impl.von_mises_centered(self.key, 2.0, (4,), dtype=jnp.float16)
+        self.assertEqual(out.shape, (4,))
+        self.assertEqual(out.dtype, jnp.float16)
+
+
+class TestReshapeAndPromote(unittest.TestCase):
+    """Validate the ``_reshape`` and ``_promote_shapes`` array utilities."""
+
+    def test_reshape_python_scalar_returns_numpy(self):
+        """_reshape converts a plain python scalar through numpy."""
+        out = _impl._reshape(5, (1,))
+        self.assertIsInstance(out, np.ndarray)
+        self.assertEqual(out.shape, (1,))
+
+    def test_reshape_numpy_array_stays_numpy(self):
+        """_reshape keeps a numpy array on the numpy path."""
+        out = _impl._reshape(np.array([1, 2]), (2,))
+        self.assertIsInstance(out, np.ndarray)
+
+    def test_reshape_jax_array_uses_jnp(self):
+        """_reshape routes a jax array through jnp.reshape."""
+        out = _impl._reshape(jnp.array([1, 2]), (2,))
+        self.assertEqual(out.shape, (2,))
+        self.assertNotIsInstance(out, np.ndarray)
+
+    def test_promote_shapes_single_arg_no_shape(self):
+        """_promote_shapes returns inputs untouched for <2 args with no shape."""
+        arg = jnp.array([1, 2])
+        out = _impl._promote_shapes(arg)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].shape, (2,))
+
+    def test_promote_shapes_multiple_args(self):
+        """_promote_shapes left-pads ranks across multiple arguments."""
+        out = _impl._promote_shapes(jnp.array([1, 2]), jnp.array([[1, 2], [3, 4]]))
+        self.assertEqual(out[0].shape, (1, 2))
+        self.assertEqual(out[1].shape, (2, 2))
+
+    def test_promote_shapes_with_shape_keyword(self):
+        """_promote_shapes left-pads a single argument when shape is supplied."""
+        out = _impl._promote_shapes(jnp.array([1, 2]), shape=(3, 2))
+        self.assertEqual(out[0].shape, (1, 2))
+
+
+class TestDtypeHelpers(unittest.TestCase):
+    """Validate the ``_dtype``, ``_is_python_scalar`` and ``const`` helpers."""
+
+    def test_dtype_none_raises(self):
+        """_dtype raises ValueError when given None."""
+        with self.assertRaises(ValueError):
+            _impl._dtype(None)
+
+    def test_dtype_from_python_type(self):
+        """_dtype maps a python scalar *type* to its numpy dtype."""
+        self.assertEqual(_impl._dtype(int), np.dtype('int64'))
+
+    def test_dtype_from_python_scalar_instance(self):
+        """_dtype maps a python scalar *instance* to its numpy dtype."""
+        self.assertEqual(_impl._dtype(3.0), np.dtype('float64'))
+
+    def test_dtype_from_object_with_dtype_attr(self):
+        """_dtype reads the dtype attribute of an array-like object."""
+        self.assertEqual(_impl._dtype(jnp.array([1.0], dtype=jnp.float32)), jnp.float32)
+
+    def test_dtype_via_result_type_fallback(self):
+        """_dtype falls back to np.result_type for unknown inputs."""
+        self.assertEqual(_impl._dtype('float32'), np.dtype('float32'))
+
+    def test_dtype_canonicalize(self):
+        """_dtype canonicalizes float64 to float32 when X64 is disabled."""
+        self.assertEqual(_impl._dtype(3.0, canonicalize=True), np.dtype('float32'))
+
+    def test_is_python_scalar_for_zero_dim(self):
+        """_is_python_scalar is True for a zero-dimensional value."""
+        self.assertTrue(_impl._is_python_scalar(np.array(3.0)))
+        self.assertTrue(_impl._is_python_scalar(5))
+
+    def test_is_python_scalar_for_complex(self):
+        """_is_python_scalar is True for a python complex scalar."""
+        self.assertTrue(_impl._is_python_scalar(complex(1, 2)))
+
+    def test_is_python_scalar_false_for_array(self):
+        """_is_python_scalar is False for a multi-element numpy array."""
+        # A numpy array exposes no ``aval`` and has ndim>0, reaching the final branch.
+        self.assertFalse(_impl._is_python_scalar(np.array([1, 2])))
+
+    def test_const_from_python_float_scalar(self):
+        """const builds a value matching a python float example."""
+        out = _impl.const(3.0, 5)
+        self.assertEqual(float(out), 5.0)
+
+    def test_const_from_python_int_scalar(self):
+        """const builds a value matching a python int example."""
+        out = _impl.const(3, 5)
+        self.assertEqual(int(out), 5)
+
+    def test_const_from_array_example(self):
+        """const builds a numpy value matching an array example's dtype."""
+        out = _impl.const(jnp.array([1.0, 2.0], dtype=jnp.float32), 7)
+        self.assertEqual(np.asarray(out).dtype, np.float32)
+
+
+class TestFormalizeKey(unittest.TestCase):
+    """Validate ``formalize_key`` key-normalisation across input kinds."""
+
+    def setUp(self):
+        """Seed the global generator and obtain a raw uint32 key."""
+        brainstate.random.seed(0)
+        self.raw_key = brainstate.random.split_key()
+
+    def test_int_seed_becomes_prng_key(self):
+        """formalize_key turns an int seed into a raw PRNGKey."""
+        out = _impl.formalize_key(7)
+        self.assertEqual(out.shape, (2,))
+        self.assertEqual(out.dtype, jnp.uint32)
+
+    def test_raw_uint32_key_passthrough(self):
+        """formalize_key passes a two-element uint32 key through as uint32."""
+        out = _impl.formalize_key(self.raw_key)
+        self.assertEqual(out.shape, (2,))
+        self.assertEqual(out.dtype, jnp.uint32)
+
+    def test_typed_prng_key_passthrough(self):
+        """formalize_key returns a typed prng key unchanged."""
+        typed = _impl.formalize_key(0, use_prng_key=False)
+        out = _impl.formalize_key(typed)
+        self.assertTrue(jnp.issubdtype(out.dtype, jnp.dtype('uint32').type) is False)
+        # the typed key keeps its custom prng dtype
+        self.assertEqual(out.dtype, typed.dtype)
+
+    def test_scalar_integer_array_becomes_prng_key(self):
+        """formalize_key turns a zero-dim integer array into a PRNGKey."""
+        out = _impl.formalize_key(np.array(42, dtype=np.int32))
+        self.assertEqual(out.shape, (2,))
+
+    def test_wrong_dtype_array_raises(self):
+        """formalize_key rejects a float array that is not a valid key."""
+        with self.assertRaises(TypeError):
+            _impl.formalize_key(np.array([1.0, 2.0], dtype=np.float32))
+
+    def test_wrong_size_array_raises(self):
+        """formalize_key rejects a uint32 array that is not length two."""
+        with self.assertRaises(TypeError):
+            _impl.formalize_key(np.array([1, 2, 3], dtype=np.uint32))
+
+    def test_unsupported_type_raises(self):
+        """formalize_key rejects an unsupported python type."""
+        with self.assertRaises(TypeError):
+            _impl.formalize_key("not-a-key")
+
+    def test_length_one_integer_array(self):
+        """formalize_key accepts a length-one integer array seed."""
+        out = _impl.formalize_key(np.array([42], dtype=np.int32))
+        self.assertEqual(out.shape, (2,))
+
+
+class TestShapeAndScaleHelpers(unittest.TestCase):
+    """Validate the ``_size2shape``, ``_check_shape`` and ``_loc_scale`` helpers."""
+
+    def test_size2shape_none(self):
+        """_size2shape maps None to an empty shape tuple."""
+        self.assertEqual(_impl._size2shape(None), ())
+
+    def test_size2shape_sequence(self):
+        """_size2shape converts a list/tuple to a tuple shape."""
+        self.assertEqual(_impl._size2shape([2, 3]), (2, 3))
+
+    def test_size2shape_int(self):
+        """_size2shape wraps a bare int in a one-tuple."""
+        self.assertEqual(_impl._size2shape(4), (4,))
+
+    def test_check_shape_no_param_shapes(self):
+        """_check_shape is a no-op when no parameter shapes are given."""
+        self.assertIsNone(_impl._check_shape('x', (3,)))
+
+    def test_check_shape_compatible(self):
+        """_check_shape accepts broadcast-compatible parameter shapes."""
+        self.assertIsNone(_impl._check_shape('x', (3,), (3,)))
+
+    def test_check_shape_incompatible_raises(self):
+        """_check_shape raises ValueError when broadcasting is impossible."""
+        with self.assertRaises(ValueError):
+            _impl._check_shape('x', (3,), (4,))
+
+    def test_check_shape_result_mismatch_raises(self):
+        """_check_shape raises ValueError when the broadcast result exceeds the shape."""
+        # (3,) and (1, 3) broadcast to (1, 3), which differs from the (3,) argument.
+        with self.assertRaises(ValueError):
+            _impl._check_shape('x', (3,), (1, 3))
+
+    def test_loc_scale_no_loc_no_scale(self):
+        """_loc_scale returns the raw value when loc and scale are None."""
+        self.assertEqual(_impl._loc_scale(None, None, 5.0), 5.0)
+
+    def test_loc_scale_scale_only(self):
+        """_loc_scale multiplies by scale when loc is None."""
+        self.assertEqual(_impl._loc_scale(None, 2.0, 5.0), 10.0)
+
+    def test_loc_scale_loc_only(self):
+        """_loc_scale adds loc when scale is None."""
+        self.assertEqual(_impl._loc_scale(1.0, None, 5.0), 6.0)
+
+    def test_loc_scale_loc_and_scale(self):
+        """_loc_scale scales then shifts when both are provided."""
+        self.assertEqual(_impl._loc_scale(1.0, 2.0, 5.0), 11.0)
+
+    def test_check_py_seq_converts_sequence(self):
+        """_check_py_seq converts a list to an array but leaves arrays alone."""
+        arr = _impl._check_py_seq([1, 2, 3])
+        self.assertEqual(np.asarray(arr).tolist(), [1, 2, 3])
+        passthrough = jnp.array([4, 5])
+        self.assertIs(_impl._check_py_seq(passthrough), passthrough)
+
+
+class TestFDistribution(unittest.TestCase):
+    """Validate the central F-distribution sampler ``f``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(2)
+        self.key = brainstate.random.split_key()
+
+    def test_shape_none_broadcasts_params(self):
+        """f infers a scalar shape from scalar parameters when shape is None."""
+        out = _impl.f(self.key, 3.0, 5.0, shape=None)
+        self.assertEqual(out.shape, ())
+
+    def test_shape_int_is_wrapped(self):
+        """f wraps an integer shape into a one-tuple."""
+        out = _impl.f(self.key, 3.0, 5.0, shape=4)
+        self.assertEqual(out.shape, (4,))
+
+    def test_shape_tuple(self):
+        """f honours an explicit tuple shape and returns positive samples."""
+        out = _impl.f(self.key, 3.0, 5.0, shape=(2, 3))
+        self.assertEqual(out.shape, (2, 3))
+        self.assertTrue(bool(jnp.all(out > 0)))
+
+    def test_empty_shape_returns_empty(self):
+        """f returns an empty array for a zero-sized shape."""
+        out = _impl.f(self.key, 3.0, 5.0, shape=(0,))
+        self.assertEqual(out.shape, (0,))
+
+
+class TestNoncentralFDistribution(unittest.TestCase):
+    """Validate the noncentral F-distribution sampler ``noncentral_f``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(3)
+        self.key = brainstate.random.split_key()
+
+    def test_basic_shape(self):
+        """noncentral_f returns positive samples of the requested shape."""
+        out = _impl.noncentral_f(self.key, 3.0, 5.0, 1.0, shape=(8,))
+        self.assertEqual(out.shape, (8,))
+        self.assertTrue(bool(jnp.all(out > 0)))
+
+    def test_scalar_shape(self):
+        """noncentral_f supports a scalar (empty) output shape."""
+        out = _impl.noncentral_f(self.key, 3.0, 5.0, 1.0, shape=())
+        self.assertEqual(out.shape, ())
+
+    def test_small_dfnum_branch(self):
+        """noncentral_f exercises the dfnum<=1 noncentral-chisquare branch."""
+        out = _impl.noncentral_f(self.key, 0.5, 5.0, 1.0, shape=(8,))
+        self.assertEqual(out.shape, (8,))
+        self.assertTrue(bool(jnp.all(out >= 0)))
+
+
+class TestLogseriesDistribution(unittest.TestCase):
+    """Validate the logarithmic-series sampler ``logseries``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(4)
+        self.key = brainstate.random.split_key()
+
+    def test_shape_none_from_param(self):
+        """logseries infers shape from the parameter when shape is None."""
+        out = _impl.logseries(self.key, 0.5, shape=None)
+        self.assertEqual(out.shape, ())
+
+    def test_shape_int(self):
+        """logseries wraps an integer shape and yields counts >= 1."""
+        out = _impl.logseries(self.key, 0.5, shape=3)
+        self.assertEqual(out.shape, (3,))
+        self.assertTrue(bool(jnp.all(out >= 1)))
+
+    def test_shape_tuple(self):
+        """logseries honours a tuple shape."""
+        out = _impl.logseries(self.key, 0.5, shape=(2, 2))
+        self.assertEqual(out.shape, (2, 2))
+
+    def test_empty_shape_returns_empty(self):
+        """logseries returns an empty array for a zero-sized shape."""
+        out = _impl.logseries(self.key, 0.5, shape=(0,))
+        self.assertEqual(out.shape, (0,))
+
+    def test_nonpositive_probability_limit_case(self):
+        """logseries returns 1 for the p<=0 limit case."""
+        out = _impl.logseries(self.key, jnp.array([0.0, 0.5]), shape=(2,))
+        self.assertEqual(int(out[0]), 1)
+
+
+class TestZipfDistribution(unittest.TestCase):
+    """Validate the Zipf (zeta) sampler ``zipf``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(5)
+        self.key = brainstate.random.split_key()
+
+    def test_shape_none_from_param(self):
+        """zipf infers shape from the parameter when shape is None."""
+        out = _impl.zipf(self.key, 2.0, shape=None)
+        self.assertEqual(out.shape, ())
+
+    def test_shape_int(self):
+        """zipf wraps an integer shape and yields values >= 1."""
+        out = _impl.zipf(self.key, 2.0, shape=3)
+        self.assertEqual(out.shape, (3,))
+        self.assertTrue(bool(jnp.all(out >= 1)))
+
+    def test_shape_tuple(self):
+        """zipf honours a tuple shape."""
+        out = _impl.zipf(self.key, 2.0, shape=(2,))
+        self.assertEqual(out.shape, (2,))
+
+    def test_empty_shape_returns_empty(self):
+        """zipf returns an empty array for a zero-sized shape."""
+        out = _impl.zipf(self.key, 2.0, shape=(0,))
+        self.assertEqual(out.shape, (0,))
+
+
+class TestPowerDistribution(unittest.TestCase):
+    """Validate the power-distribution sampler ``power``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(6)
+        self.key = brainstate.random.split_key()
+
+    def test_shape_none_from_param(self):
+        """power infers shape from the parameter when shape is None."""
+        out = _impl.power(self.key, 2.0, shape=None)
+        self.assertEqual(out.shape, ())
+
+    def test_shape_int(self):
+        """power wraps an integer shape and samples within the unit interval."""
+        out = _impl.power(self.key, 2.0, shape=3)
+        self.assertEqual(out.shape, (3,))
+        self.assertTrue(bool(jnp.all((out >= 0) & (out <= 1))))
+
+    def test_shape_tuple(self):
+        """power honours a tuple shape."""
+        out = _impl.power(self.key, 2.0, shape=(2, 2))
+        self.assertEqual(out.shape, (2, 2))
+
+    def test_empty_shape_returns_empty(self):
+        """power returns an empty array for a zero-sized shape."""
+        out = _impl.power(self.key, 2.0, shape=(0,))
+        self.assertEqual(out.shape, (0,))
+
+
+class TestHypergeometricDistribution(unittest.TestCase):
+    """Validate the hypergeometric sampler ``hypergeometric``."""
+
+    def setUp(self):
+        """Seed the global generator and grab a reusable key."""
+        brainstate.random.seed(7)
+        self.key = brainstate.random.split_key()
+
+    def test_shape_none_from_params(self):
+        """hypergeometric infers shape by broadcasting params when shape is None."""
+        out = _impl.hypergeometric(self.key, 5, 5, 4, shape=None)
+        self.assertEqual(out.shape, ())
+
+    def test_shape_int(self):
+        """hypergeometric wraps an integer shape and yields counts in range."""
+        out = _impl.hypergeometric(self.key, 5, 5, 4, shape=3)
+        self.assertEqual(out.shape, (3,))
+        self.assertTrue(bool(jnp.all((out >= 0) & (out <= 4))))
+
+    def test_shape_tuple(self):
+        """hypergeometric honours a tuple shape."""
+        out = _impl.hypergeometric(self.key, 5, 5, 4, shape=(4,))
+        self.assertEqual(out.shape, (4,))
+
+    def test_empty_shape_returns_empty(self):
+        """hypergeometric returns an empty array for a zero-sized shape."""
+        out = _impl.hypergeometric(self.key, 5, 5, 4, shape=(0,))
+        self.assertEqual(out.shape, (0,))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainstate/random/_seed_test.py
+++ b/brainstate/random/_seed_test.py
@@ -15,24 +15,29 @@
 
 import unittest
 
+import jax
 import jax.numpy as jnp
-import jax.random
+import numpy as np
+import pytest
 
 import brainstate
 
 
 class TestRandom(unittest.TestCase):
+    """Smoke tests for seeding the global random state."""
 
     def test_seed2(self):
+        """seed accepts a key array, an int, and None — including inside jit."""
         test_seed = 299
-        key = jax.random.PRNGKey(test_seed)
+        brainstate.random.seed(test_seed)
+        key = brainstate.random.get_key()
         brainstate.random.seed(key)
 
         @jax.jit
         def jit_seed(key):
             brainstate.random.seed(key)
             with brainstate.random.seed_context(key):
-                print(brainstate.random.DEFAULT.value)
+                return brainstate.random.DEFAULT.value
 
         jit_seed(key)
         jit_seed(1)
@@ -46,3 +51,309 @@ class TestRandom(unittest.TestCase):
         brainstate.random.seed(test_seed)
         b = brainstate.random.rand(3)
         self.assertTrue(jnp.array_equal(a, b))
+
+
+class TestSeedUtilities(unittest.TestCase):
+    """Cover the seed and key management utilities of ``brainstate.random._seed``."""
+
+    def setUp(self):
+        """Reset the global random state to a known seed before each test."""
+        brainstate.random.seed(1234)
+
+    # ------------------------------------------------------------------ #
+    # seed                                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_seed_makes_draws_reproducible(self):
+        """Seed with an integer then draw reproduces the same sequence."""
+        brainstate.random.seed(7)
+        a = brainstate.random.randn(5)
+        brainstate.random.seed(7)
+        b = brainstate.random.randn(5)
+        self.assertTrue(bool(jnp.allclose(a, b)))
+
+    def test_seed_none_generates_random_state(self):
+        """Seed with None auto-generates a usable random state."""
+        brainstate.random.seed(None)
+        drawn = brainstate.random.randn(3)
+        self.assertEqual(drawn.shape, (3,))
+
+    def test_seed_accepts_jax_key(self):
+        """Seed accepts a size-2 JAX PRNG key (interop path)."""
+        brainstate.random.seed(7)
+        key = brainstate.random.split_key()
+        # feeding a uint32 size-2 key exercises the ``np.size == 2`` branch
+        brainstate.random.seed(key)
+        drawn = brainstate.random.randn(2)
+        self.assertEqual(drawn.shape, (2,))
+
+    def test_seed_rejects_oversized_array(self):
+        """Seed raises ValueError for an array whose size exceeds two."""
+        bad = np.array([1, 2, 3], dtype=np.uint32)
+        with self.assertRaises(ValueError):
+            brainstate.random.seed(bad)
+
+    # ------------------------------------------------------------------ #
+    # get_key / set_key                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_get_key_returns_current_value(self):
+        """get_key returns the current global key snapshot."""
+        brainstate.random.seed(42)
+        key = brainstate.random.get_key()
+        self.assertEqual(key.shape, (2,))
+
+    def test_set_get_key_roundtrip_with_integer(self):
+        """set_key with an integer seed restores a reproducible sequence."""
+        brainstate.random.set_key(42)
+        a = brainstate.random.rand(3)
+        brainstate.random.set_key(42)
+        b = brainstate.random.rand(3)
+        self.assertTrue(bool(jnp.allclose(a, b)))
+
+    def test_set_key_with_raw_uint32_key(self):
+        """set_key accepts a raw uint32 size-2 key array."""
+        brainstate.random.seed(5)
+        raw_key = brainstate.random.split_key()
+        self.assertEqual(raw_key.dtype, jnp.uint32)
+        brainstate.random.set_key(raw_key)
+        self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), raw_key)))
+
+    def test_set_key_with_typed_prng_key(self):
+        """set_key accepts a typed JAX PRNG key (interop path)."""
+        # A "typed" key (dtype key<...>) is produced by brainstate's own key
+        # constructor with use_prng_key=False; default brainstate keys are raw
+        # uint32 arrays. This exercises the prng_key branch of set_key.
+        from brainstate.random._impl import formalize_key
+        typed_key = formalize_key(7, use_prng_key=False)
+        self.assertTrue(jnp.issubdtype(typed_key.dtype, jax.dtypes.prng_key))
+        brainstate.random.set_key(typed_key)
+        self.assertTrue(jnp.issubdtype(brainstate.random.get_key().dtype, jax.dtypes.prng_key))
+
+    def test_set_key_roundtrip_via_get_key(self):
+        """A key captured by get_key can be restored via set_key."""
+        brainstate.random.seed(99)
+        snapshot = brainstate.random.get_key()
+        _ = brainstate.random.rand(4)  # advance state
+        brainstate.random.set_key(snapshot)
+        self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), snapshot)))
+
+    def test_set_key_rejects_wrong_shaped_array(self):
+        """set_key raises ValueError for a non-key uint32 array."""
+        bad = np.array([1, 2, 3, 4, 5], dtype=np.uint32)
+        with self.assertRaises(ValueError):
+            brainstate.random.set_key(bad)
+
+    def test_set_key_rejects_float_array(self):
+        """set_key raises ValueError for a float array."""
+        bad = np.array([1.0, 2.0], dtype=np.float32)
+        with self.assertRaises(ValueError):
+            brainstate.random.set_key(bad)
+
+    def test_set_key_rejects_non_array(self):
+        """set_key raises ValueError for a non-array, non-integer input."""
+        with self.assertRaises(ValueError):
+            brainstate.random.set_key("not-a-key")
+
+    # ------------------------------------------------------------------ #
+    # split_key / split_keys                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_split_key_single(self):
+        """split_key with no argument returns one size-2 key."""
+        brainstate.random.seed(0)
+        key = brainstate.random.split_key()
+        self.assertEqual(key.shape, (2,))
+
+    def test_split_key_advances_state(self):
+        """split_key advances the global state, yielding distinct keys."""
+        brainstate.random.seed(0)
+        k1 = brainstate.random.split_key()
+        k2 = brainstate.random.split_key()
+        self.assertFalse(bool(jnp.array_equal(k1, k2)))
+
+    def test_split_key_multiple(self):
+        """split_key with n returns an array of n keys."""
+        brainstate.random.seed(0)
+        keys = brainstate.random.split_key(3)
+        self.assertEqual(keys.shape, (3, 2))
+
+    def test_split_keys_count(self):
+        """split_keys(n) returns exactly n keys."""
+        brainstate.random.seed(0)
+        keys = brainstate.random.split_keys(4)
+        self.assertEqual(keys.shape[0], 4)
+
+    def test_split_keys_one(self):
+        """split_keys(1) returns a single key in a batch of one."""
+        brainstate.random.seed(0)
+        keys = brainstate.random.split_keys(1)
+        self.assertEqual(keys.shape[0], 1)
+
+    def test_split_keys_rejects_zero(self):
+        """split_keys raises ValueError for n == 0."""
+        with self.assertRaises(ValueError):
+            brainstate.random.split_keys(0)
+
+    def test_split_keys_rejects_negative(self):
+        """split_keys raises ValueError for a negative n."""
+        with self.assertRaises(ValueError):
+            brainstate.random.split_keys(-2)
+
+    def test_split_keys_rejects_non_integer(self):
+        """split_keys raises ValueError for a non-integer n."""
+        with self.assertRaises(ValueError):
+            brainstate.random.split_keys(2.5)
+
+    def test_split_key_with_backup_then_restore(self):
+        """split_key(backup=True) records a backup that restore_key can recover."""
+        brainstate.random.seed(5)
+        keys = brainstate.random.split_key(2, backup=True)
+        self.assertEqual(keys.shape, (2, 2))
+        backed_up = brainstate.random.get_key()
+        _ = brainstate.random.rand(2)  # advance state
+        brainstate.random.restore_key()
+        self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), backed_up)))
+
+    # ------------------------------------------------------------------ #
+    # restore_key                                                        #
+    # ------------------------------------------------------------------ #
+
+    def test_restore_key_without_backup_raises(self):
+        """restore_key raises ValueError when no backup exists."""
+        brainstate.random.seed(0)
+        with self.assertRaises(ValueError):
+            brainstate.random.restore_key()
+
+    # ------------------------------------------------------------------ #
+    # self_assign_multi_keys                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_self_assign_multi_keys_with_backup(self):
+        """self_assign_multi_keys(backup=True) stores n keys and backs up a single key."""
+        brainstate.random.seed(9)
+        brainstate.random.self_assign_multi_keys(3, backup=True)
+        # the working value now holds the n multi-keys
+        self.assertEqual(brainstate.random.get_key().shape, (3, 2))
+        # restore_key recovers a usable single key (the intermediate split key)
+        brainstate.random.restore_key()
+        restored = brainstate.random.get_key()
+        self.assertEqual(restored.shape, (2,))
+        # the restored single key supports normal draws again
+        self.assertEqual(brainstate.random.randn(3).shape, (3,))
+
+    def test_self_assign_multi_keys_without_backup(self):
+        """self_assign_multi_keys(backup=False) stores n keys without a backup."""
+        brainstate.random.seed(9)
+        brainstate.random.self_assign_multi_keys(2, backup=False)
+        self.assertEqual(brainstate.random.get_key().shape, (2, 2))
+        with self.assertRaises(ValueError):
+            brainstate.random.restore_key()
+
+    def test_self_assign_multi_keys_rejects_zero(self):
+        """self_assign_multi_keys raises ValueError for n == 0."""
+        with self.assertRaises(ValueError):
+            brainstate.random.self_assign_multi_keys(0)
+
+    def test_self_assign_multi_keys_rejects_negative(self):
+        """self_assign_multi_keys raises ValueError for a negative n."""
+        with self.assertRaises(ValueError):
+            brainstate.random.self_assign_multi_keys(-1)
+
+    def test_self_assign_multi_keys_rejects_non_integer(self):
+        """self_assign_multi_keys raises ValueError for a non-integer n."""
+        with self.assertRaises(ValueError):
+            brainstate.random.self_assign_multi_keys(1.5)
+
+    # ------------------------------------------------------------------ #
+    # clone_rng                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_clone_rng_default_is_independent_copy(self):
+        """clone_rng() returns a RandomState distinct from the global default."""
+        brainstate.random.seed(3)
+        cloned = brainstate.random.clone_rng()
+        self.assertIsInstance(cloned, brainstate.random.RandomState)
+        self.assertIsNot(cloned, brainstate.random.DEFAULT)
+
+    def test_clone_rng_no_clone_returns_global(self):
+        """clone_rng(clone=False) returns the global default state directly."""
+        same = brainstate.random.clone_rng(clone=False)
+        self.assertIs(same, brainstate.random.DEFAULT)
+
+    def test_clone_rng_with_seed_creates_new_state(self):
+        """clone_rng(seed) builds a fresh independent RandomState."""
+        rng = brainstate.random.clone_rng(123)
+        self.assertIsInstance(rng, brainstate.random.RandomState)
+        self.assertIsNot(rng, brainstate.random.DEFAULT)
+
+    def test_clone_rng_clones_are_independent(self):
+        """Two clones of the same state draw identical sequences independently."""
+        brainstate.random.seed(7)
+        r1 = brainstate.random.clone_rng(321)
+        brainstate.random.seed(7)
+        r2 = brainstate.random.clone_rng(321)
+        self.assertTrue(bool(jnp.allclose(r1.randn(4), r2.randn(4))))
+
+    # ------------------------------------------------------------------ #
+    # default_rng                                                        #
+    # ------------------------------------------------------------------ #
+
+    def test_default_rng_returns_global(self):
+        """default_rng() returns the global default state."""
+        self.assertIs(brainstate.random.default_rng(), brainstate.random.DEFAULT)
+
+    def test_default_rng_with_seed_creates_new_state(self):
+        """default_rng(seed) builds a fresh independent RandomState."""
+        rng = brainstate.random.default_rng(456)
+        self.assertIsInstance(rng, brainstate.random.RandomState)
+        self.assertIsNot(rng, brainstate.random.DEFAULT)
+
+    def test_default_rng_seed_is_reproducible(self):
+        """default_rng(seed) produces reproducible draws for the same seed."""
+        a = brainstate.random.default_rng(99).randn(5)
+        b = brainstate.random.default_rng(99).randn(5)
+        self.assertTrue(bool(jnp.allclose(a, b)))
+
+    # ------------------------------------------------------------------ #
+    # seed_context                                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_seed_context_is_reproducible(self):
+        """seed_context yields identical draws for the same temporary seed."""
+        with brainstate.random.seed_context(42):
+            a = brainstate.random.rand(3)
+        with brainstate.random.seed_context(42):
+            b = brainstate.random.rand(3)
+        self.assertTrue(bool(jnp.allclose(a, b)))
+
+    def test_seed_context_restores_outer_state(self):
+        """seed_context restores the prior global key on exit."""
+        brainstate.random.seed(7)
+        before = brainstate.random.get_key()
+        with brainstate.random.seed_context(1000):
+            _ = brainstate.random.rand(2)
+        after = brainstate.random.get_key()
+        self.assertTrue(bool(jnp.array_equal(before, after)))
+
+    def test_seed_context_restores_on_exception(self):
+        """seed_context restores the prior key even if the block raises."""
+        brainstate.random.seed(7)
+        before = brainstate.random.get_key()
+        with self.assertRaises(ValueError):
+            with brainstate.random.seed_context(1000):
+                _ = brainstate.random.rand(2)
+                raise ValueError("boom")
+        after = brainstate.random.get_key()
+        self.assertTrue(bool(jnp.array_equal(before, after)))
+
+    def test_seed_context_nested(self):
+        """Nested seed_context blocks each restore their own outer state."""
+        brainstate.random.seed(7)
+        before = brainstate.random.get_key()
+        with brainstate.random.seed_context(123):
+            outer_after_enter = brainstate.random.get_key()
+            with brainstate.random.seed_context(456):
+                _ = brainstate.random.rand(2)
+            self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), outer_after_enter)))
+        self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), before)))

--- a/brainstate/random/_state.py
+++ b/brainstate/random/_state.py
@@ -440,7 +440,10 @@ class RandomState(State):
         r = jr.exponential(key, shape=_size2shape(size), dtype=dtype or environ.dftype())
         if scale is not None:
             scale = u.math.asarray(scale, dtype=dtype)
-            r = r / scale
+            # ``scale`` is the numpy-compatible scale parameter beta = 1 / lambda,
+            # i.e. the distribution mean. A standard exponential has mean 1, so the
+            # draw is multiplied (not divided) by ``scale`` to reach mean ``scale``.
+            r = r * scale
         return r
 
     @jit_named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])

--- a/brainstate/random/_state_test.py
+++ b/brainstate/random/_state_test.py
@@ -16,9 +16,10 @@
 import unittest
 
 import jax.numpy as jnp
-import jax.random as jr
 import numpy as np
+import pytest
 
+import brainstate
 from brainstate._state import TRACE_CONTEXT, StateTraceStack
 from brainstate.random._state import RandomState, DEFAULT, formalize_key, _size2shape, _check_py_seq
 
@@ -43,12 +44,12 @@ class TestRandomStateInitialization(unittest.TestCase):
         """Test initialization with integer seed."""
         seed = 42
         rs = RandomState(seed)
-        expected_key = jr.PRNGKey(seed)
+        expected_key = formalize_key(seed)
         np.testing.assert_array_equal(rs.value, expected_key)
 
     def test_init_with_prng_key(self):
-        """Test initialization with JAX PRNGKey."""
-        key = jr.PRNGKey(123)
+        """Test initialization with a brainstate-formalized PRNG key."""
+        key = formalize_key(123)
         rs = RandomState(key)
         np.testing.assert_array_equal(rs.value, key)
 
@@ -94,7 +95,7 @@ class TestRandomStateKeyManagement(unittest.TestCase):
     def test_seed_with_int(self):
         """Test seeding with integer."""
         self.rs.seed(123)
-        expected_key = jr.PRNGKey(123)
+        expected_key = formalize_key(123)
         np.testing.assert_array_equal(self.rs.value, expected_key)
 
     def test_seed_with_none(self):
@@ -105,8 +106,8 @@ class TestRandomStateKeyManagement(unittest.TestCase):
         self.assertFalse(np.array_equal(self.rs.value, original_key))
 
     def test_seed_with_prng_key(self):
-        """Test seeding with PRNGKey."""
-        key = jr.PRNGKey(999)
+        """Test seeding with a brainstate-formalized PRNG key."""
+        key = formalize_key(999)
         self.rs.seed(key)
         np.testing.assert_array_equal(self.rs.value, key)
 
@@ -193,7 +194,7 @@ class TestRandomStateKeyManagement(unittest.TestCase):
 
     def test_set_key(self):
         """Test setting key directly."""
-        new_key = jr.PRNGKey(999)
+        new_key = formalize_key(999)
         self.rs.set_key(new_key)
         np.testing.assert_array_equal(self.rs.value, new_key)
 
@@ -391,7 +392,7 @@ class TestRandomStateKeyBehavior(unittest.TestCase):
     def test_external_key_does_not_change_state(self):
         """Test that using external key doesn't change internal state."""
         original_key = self.rs.value.copy()
-        external_key = jr.PRNGKey(999)
+        external_key = formalize_key(999)
 
         # Use external key
         self.rs.rand(5, key=external_key)
@@ -411,7 +412,7 @@ class TestRandomStateKeyBehavior(unittest.TestCase):
 
     def test_reproducibility_with_same_key(self):
         """Test reproducibility when using same external key."""
-        key = jr.PRNGKey(123)
+        key = formalize_key(123)
 
         result1 = self.rs.rand(5, key=key)
         result2 = self.rs.rand(5, key=key)
@@ -472,14 +473,14 @@ class TestUtilityFunctions(unittest.TestCase):
         TRACE_CONTEXT.state_stack.pop()
 
     def test_formalize_key_with_int(self):
-        """Test _formalize_key with integer."""
+        """Test _formalize_key with integer matches a fresh RandomState key."""
         key = formalize_key(42)
-        expected = jr.PRNGKey(42)
+        expected = RandomState(42).value
         np.testing.assert_array_equal(key, expected)
 
     def test_formalize_key_with_array(self):
-        """Test _formalize_key with array."""
-        input_key = jr.PRNGKey(123)
+        """Test _formalize_key passes through an existing PRNG key unchanged."""
+        input_key = formalize_key(123)
         key = formalize_key(input_key, True)
         np.testing.assert_array_equal(key, input_key)
 
@@ -585,6 +586,563 @@ class TestErrorHandling(unittest.TestCase):
         # Test without backup
         self.rs.self_assign_multi_keys(2, backup=False)
         self.assertEqual(self.rs.value.shape, (2, 2))
+
+
+class TestRandomStateTransforms(unittest.TestCase):
+    """RandomState as a brainstate State: pytree, key advancement, transforms."""
+
+    def setUp(self):
+        """Push a fresh state-trace stack for each test."""
+        TRACE_CONTEXT.state_stack.append(StateTraceStack())
+
+    def tearDown(self):
+        """Pop the state-trace stack after each test."""
+        TRACE_CONTEXT.state_stack.pop()
+
+    def test_pytree_roundtrip(self):
+        """A RandomState's treefied reference survives flatten/unflatten."""
+        from brainstate import _testing
+        rs = RandomState(0)
+        ref = rs.to_state_ref()
+        rebuilt = _testing.assert_pytree_roundtrip(ref)
+        np.testing.assert_array_equal(rebuilt.value, rs.value)
+
+    def test_pytree_in_container_roundtrip(self):
+        """A treefied RandomState inside a dict roundtrips through jax.tree."""
+        import jax
+        rs = RandomState(7)
+        tree = {'rng': rs.to_state_ref(), 'x': jnp.arange(3)}
+        leaves, treedef = jax.tree.flatten(tree)
+        rebuilt = jax.tree.unflatten(treedef, leaves)
+        np.testing.assert_array_equal(rebuilt['rng'].value, rs.value)
+        np.testing.assert_array_equal(rebuilt['x'], tree['x'])
+
+    def test_randomstate_is_tree_leaf(self):
+        """A bare RandomState is treated as a single pytree leaf."""
+        import jax
+        rs = RandomState(0)
+        leaves = jax.tree.leaves(rs)
+        self.assertEqual(len(leaves), 1)
+        self.assertIs(leaves[0], rs)
+
+    def test_repeated_draws_advance_key(self):
+        """Consecutive draws from a RandomState are not identical."""
+        rs = RandomState(0)
+        self.assertFalse(bool(jnp.allclose(rs.randn(5), rs.randn(5))))
+
+    def test_draw_advances_internal_key(self):
+        """Drawing without an explicit key mutates the internal state value."""
+        rs = RandomState(0)
+        before = np.asarray(rs.value).copy()
+        rs.randn(3)
+        self.assertFalse(np.array_equal(before, np.asarray(rs.value)))
+
+    def test_same_seed_same_sequence(self):
+        """Two RandomStates with the same seed yield identical sequences."""
+        r1 = RandomState(123)
+        r2 = RandomState(123)
+        np.testing.assert_array_equal(r1.randn(5), r2.randn(5))
+        np.testing.assert_array_equal(r1.randn(5), r2.randn(5))
+
+    def test_different_seed_different_sequence(self):
+        """Two RandomStates with different seeds yield different sequences."""
+        r1 = RandomState(1)
+        r2 = RandomState(2)
+        self.assertFalse(bool(jnp.allclose(r1.randn(5), r2.randn(5))))
+
+    def test_randomstate_inside_jit(self):
+        """Drawing from a RandomState inside jit yields the right shape."""
+        rs = RandomState(0)
+
+        @brainstate.transform.jit
+        def draw():
+            return rs.randn(4)
+
+        self.assertEqual(draw().shape, (4,))
+
+    def test_jit_advances_key_between_calls(self):
+        """Successive jitted draws from the same RandomState differ."""
+        rs = RandomState(0)
+
+        @brainstate.transform.jit
+        def draw():
+            return rs.randn(4)
+
+        self.assertFalse(bool(jnp.allclose(draw(), draw())))
+
+    def test_randomstate_inside_vmap_with_batched_key(self):
+        """vmap over a batch of keys produces a batched output."""
+        rs = RandomState(0)
+
+        def draw(key):
+            return rs.randn(3, key=key)
+
+        keys = brainstate.random.split_keys(4)
+        out = brainstate.transform.vmap(draw)(keys)
+        self.assertEqual(out.shape, (4, 3))
+
+    def test_explicit_key_is_reproducible(self):
+        """Passing the same explicit key twice yields identical draws."""
+        rs = RandomState(0)
+        brainstate.random.seed(99)
+        key = brainstate.random.split_key()
+        np.testing.assert_array_equal(rs.randn(5, key=key), rs.randn(5, key=key))
+
+    def test_global_seed_split_key_roundtrip(self):
+        """A key from the global stream can construct a usable RandomState."""
+        brainstate.random.seed(7)
+        key = brainstate.random.split_key()
+        self.assertEqual(key.shape, (2,))
+        self.assertEqual(key.dtype, jnp.uint32)
+        rs = RandomState(key)
+        np.testing.assert_array_equal(rs.value, key)
+
+    def test_global_seed_is_deterministic(self):
+        """Re-seeding the global stream replays the same keys."""
+        brainstate.random.seed(11)
+        a = brainstate.random.split_key()
+        brainstate.random.seed(11)
+        b = brainstate.random.split_key()
+        np.testing.assert_array_equal(a, b)
+
+
+class TestRandomStateMisc(unittest.TestCase):
+    """Cover repr, clone, numpy keys, deletion checks, and multi-key assignment."""
+
+    def setUp(self):
+        """Create a seeded RandomState and push a state-trace stack."""
+        self.rs = RandomState(42)
+        TRACE_CONTEXT.state_stack.append(StateTraceStack())
+
+    def tearDown(self):
+        """Pop the state-trace stack after each test."""
+        TRACE_CONTEXT.state_stack.pop()
+
+    def test_repr_contains_value(self):
+        """The repr embeds the class name and the underlying key value."""
+        text = repr(self.rs)
+        self.assertIn('RandomState', text)
+        self.assertIn(str(self.rs.value), text)
+
+    def test_clone_is_independent(self):
+        """Cloning yields a distinct instance with a distinct key."""
+        clone = self.rs.clone()
+        self.assertIsNot(clone, self.rs)
+        self.assertFalse(np.array_equal(clone.value, self.rs.value))
+
+    def test_numpy_keys_shape_and_dtype(self):
+        """_numpy_keys returns a (batch, 2) uint32 array."""
+        keys = self.rs._numpy_keys(4)
+        self.assertEqual(keys.shape, (4, 2))
+        self.assertEqual(keys.dtype, np.uint32)
+
+    def test_check_if_deleted_on_live_key(self):
+        """check_if_deleted is a no-op for a live (non-deleted) key."""
+        before = np.asarray(self.rs.value).copy()
+        self.rs.check_if_deleted()
+        np.testing.assert_array_equal(self.rs.value, before)
+
+    def test_seed_with_numpy_int_array_scalar(self):
+        """Seeding with a 1-element integer numpy array sets a valid key."""
+        self.rs.seed(np.array(123, dtype=np.int64))
+        self.assertEqual(self.rs.value.shape, (2,))
+        np.testing.assert_array_equal(self.rs.value, formalize_key(123))
+
+    def test_seed_with_uint32_pair(self):
+        """Seeding with a uint32 pair stores the key verbatim."""
+        key = np.array([7, 9], dtype=np.uint32)
+        self.rs.seed(key)
+        np.testing.assert_array_equal(self.rs.value, key)
+
+    def test_seed_with_invalid_scalar_type(self):
+        """Seeding with a float scalar raises ValueError."""
+        with self.assertRaises(ValueError):
+            self.rs.seed(np.array(1.5, dtype=np.float32))
+
+    def test_self_assign_multi_keys_without_backup(self):
+        """self_assign_multi_keys without backup leaves no restore point."""
+        self.rs.self_assign_multi_keys(3, backup=False)
+        self.assertEqual(self.rs.value.shape, (3, 2))
+        with self.assertRaises(ValueError):
+            self.rs.restore_key()
+
+    def test_split_key_with_backup(self):
+        """split_key(backup=True) records the post-split key as the restore point."""
+        # split_key advances the internal key to keys[0] and *then* backs it up,
+        # so the backed-up value is the advanced key, not the pre-split key.
+        self.rs.split_key(backup=True)
+        post_split = np.asarray(self.rs.value).copy()
+        # Advance again, then restore back to the post-split key.
+        self.rs.split_key()
+        self.assertFalse(np.array_equal(np.asarray(self.rs.value), post_split))
+        self.rs.restore_key()
+        np.testing.assert_array_equal(self.rs.value, post_split)
+
+
+class TestRandomStateMoreDistributions(unittest.TestCase):
+    """Exercise distribution methods not covered by the baseline suite."""
+
+    def setUp(self):
+        """Create a seeded RandomState and push a state-trace stack."""
+        self.rs = RandomState(2024)
+        TRACE_CONTEXT.state_stack.append(StateTraceStack())
+
+    def tearDown(self):
+        """Pop the state-trace stack after each test."""
+        TRACE_CONTEXT.state_stack.pop()
+
+    def test_random_aliases(self):
+        """random_sample, ranf, and sample all delegate to random."""
+        self.assertEqual(self.rs.random_sample(size=(2, 3)).shape, (2, 3))
+        self.assertEqual(self.rs.ranf(size=(2, 3)).shape, (2, 3))
+        self.assertEqual(self.rs.sample(size=(2, 3)).shape, (2, 3))
+
+    def test_random_integers(self):
+        """random_integers honours inclusive high and broadcast sizing."""
+        self.assertEqual(self.rs.random_integers(1, 5, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.random_integers(5).shape, ())
+
+    def test_permutation_and_shuffle(self):
+        """permutation and shuffle preserve the multiset of elements."""
+        perm = self.rs.permutation(jnp.arange(6))
+        np.testing.assert_array_equal(np.sort(np.asarray(perm)), np.arange(6))
+        shuf = self.rs.shuffle(jnp.arange(6))
+        np.testing.assert_array_equal(np.sort(np.asarray(shuf)), np.arange(6))
+
+    def test_gumbel_laplace_logistic(self):
+        """gumbel, laplace, and logistic produce the requested shape."""
+        self.assertEqual(self.rs.gumbel(0.0, 1.0, size=(2, 3)).shape, (2, 3))
+        self.assertEqual(self.rs.laplace(0.0, 1.0, size=(2, 3)).shape, (2, 3))
+        self.assertEqual(self.rs.logistic(0.0, 1.0, size=(2, 3)).shape, (2, 3))
+
+    def test_logistic_no_loc_scale(self):
+        """logistic broadcasts to a scalar when loc/scale are omitted."""
+        self.assertEqual(self.rs.logistic().shape, ())
+
+    def test_pareto(self):
+        """pareto yields positive samples with the requested shape."""
+        arr = self.rs.pareto(2.0, size=(3,))
+        self.assertEqual(arr.shape, (3,))
+        self.assertTrue((arr >= 0).all())
+
+    def test_standard_family(self):
+        """standard_* helpers each yield the requested shape."""
+        self.assertEqual(self.rs.standard_cauchy(size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.standard_exponential(size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.standard_gamma(2.0, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.standard_normal(size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.standard_t(3.0).shape, ())
+
+    def test_lognormal(self):
+        """lognormal returns strictly positive samples."""
+        arr = self.rs.lognormal(0.0, 1.0, size=(3,))
+        self.assertEqual(arr.shape, (3,))
+        self.assertTrue((arr > 0).all())
+
+    def test_chisquare_scalar_and_sized(self):
+        """chisquare supports scalar df (size None) and integer df with size."""
+        self.assertEqual(self.rs.chisquare(3).shape, ())
+        self.assertEqual(self.rs.chisquare(3, size=(4,)).shape, (4,))
+
+    def test_chisquare_nonscalar_df_requires_size(self):
+        """chisquare with non-scalar df and no size is unsupported."""
+        with self.assertRaises(NotImplementedError):
+            self.rs.chisquare(jnp.array([2, 3]))
+
+    def test_dirichlet(self):
+        """dirichlet rows sum to one over the simplex axis."""
+        arr = self.rs.dirichlet(jnp.array([1.0, 2.0, 3.0]), size=(4,))
+        self.assertEqual(arr.shape, (4, 3))
+        np.testing.assert_allclose(np.asarray(arr).sum(axis=-1), 1.0, atol=1e-5)
+
+    def test_geometric(self):
+        """geometric yields non-negative integer-valued samples."""
+        arr = self.rs.geometric(0.5, size=(3,))
+        self.assertEqual(arr.shape, (3,))
+        self.assertTrue((arr >= 0).all())
+
+    def test_multinomial(self):
+        """multinomial counts sum to n across the category axis."""
+        arr = self.rs.multinomial(10, jnp.array([0.2, 0.3, 0.5]), size=(2,))
+        self.assertEqual(arr.shape, (2, 3))
+        np.testing.assert_array_equal(np.asarray(arr).sum(axis=-1), 10)
+
+    def test_multinomial_invalid_pvals(self):
+        """multinomial rejects pvals whose leading sum exceeds one."""
+        with self.assertRaises(Exception):
+            self.rs.multinomial(10, jnp.array([0.6, 0.6, 0.5]))
+
+    def test_multinomial_traced_n_raises(self):
+        """multinomial rejects a traced (abstract) total count n."""
+        rs = self.rs
+
+        @brainstate.transform.jit
+        def f(n):
+            return rs.multinomial(n, jnp.array([0.2, 0.3, 0.5]), size=(2,))
+
+        with self.assertRaises(ValueError):
+            f(jnp.array(10))
+
+    def test_multivariate_normal_methods(self):
+        """multivariate_normal supports svd, eigh, and cholesky factorisations."""
+        mean = jnp.array([0.0, 1.0])
+        cov = jnp.array([[1.0, 0.5], [0.5, 2.0]])
+        for method in ('svd', 'eigh', 'cholesky'):
+            out = self.rs.multivariate_normal(mean, cov, size=(3,), method=method)
+            self.assertEqual(out.shape, (3, 2))
+
+    def test_multivariate_normal_bad_method(self):
+        """multivariate_normal rejects an unknown factorisation method."""
+        mean = jnp.array([0.0, 1.0])
+        cov = jnp.array([[1.0, 0.5], [0.5, 2.0]])
+        with self.assertRaises(ValueError):
+            self.rs.multivariate_normal(mean, cov, method='bogus')
+
+    def test_multivariate_normal_dimension_errors(self):
+        """multivariate_normal validates mean/cov ranks and cov shape."""
+        cov = jnp.array([[1.0, 0.5], [0.5, 2.0]])
+        with self.assertRaises(ValueError):
+            self.rs.multivariate_normal(jnp.array(0.0), cov)  # mean ndim < 1
+        with self.assertRaises(ValueError):
+            self.rs.multivariate_normal(jnp.array([0.0, 1.0]), jnp.array([1.0, 2.0]))  # cov ndim < 2
+        with self.assertRaises(ValueError):
+            self.rs.multivariate_normal(jnp.array([0.0, 1.0, 2.0]), cov)  # cov shape mismatch
+
+    def test_rayleigh(self):
+        """rayleigh yields non-negative samples with the requested shape."""
+        arr = self.rs.rayleigh(2.0, size=(3,))
+        self.assertEqual(arr.shape, (3,))
+        self.assertTrue((arr >= 0).all())
+
+    def test_triangular(self):
+        """triangular returns values in {-1, 1}."""
+        arr = self.rs.triangular(size=(50,))
+        self.assertEqual(arr.shape, (50,))
+        self.assertTrue(jnp.all((arr == -1) | (arr == 1)))
+
+    def test_vonmises(self):
+        """vonmises returns angles within (-pi, pi]."""
+        arr = self.rs.vonmises(0.0, 1.0, size=(3,))
+        self.assertEqual(arr.shape, (3,))
+        self.assertTrue((arr >= -jnp.pi - 1e-5).all() and (arr <= jnp.pi + 1e-5).all())
+
+    def test_weibull_and_min(self):
+        """weibull and weibull_min yield non-negative samples of the right shape."""
+        self.assertEqual(self.rs.weibull(2.0, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.weibull_min(2.0, scale=1.5, size=(3,)).shape, (3,))
+
+    def test_weibull_array_a_with_size_raises(self):
+        """weibull requires scalar shape parameter a when size is provided."""
+        with self.assertRaises(ValueError):
+            self.rs.weibull(jnp.array([1.0, 2.0]), size=(3,))
+
+    def test_weibull_min_array_a_with_size_raises(self):
+        """weibull_min requires scalar shape parameter a when size is provided."""
+        with self.assertRaises(ValueError):
+            self.rs.weibull_min(jnp.array([1.0, 2.0]), size=(3,))
+
+    def test_maxwell(self):
+        """maxwell returns non-negative speeds with the requested shape."""
+        arr = self.rs.maxwell(size=(3,))
+        self.assertEqual(arr.shape, (3,))
+        self.assertTrue((arr >= 0).all())
+
+    def test_negative_binomial(self):
+        """negative_binomial works both with and without an explicit key."""
+        self.assertEqual(self.rs.negative_binomial(5, 0.5, size=(3,)).shape, (3,))
+        key = brainstate.random.split_key()
+        self.assertEqual(self.rs.negative_binomial(5, 0.5, size=(3,), key=key).shape, (3,))
+
+    def test_wald(self):
+        """wald returns positive samples with the requested shape."""
+        arr = self.rs.wald(1.0, 2.0, size=(3,))
+        self.assertEqual(arr.shape, (3,))
+        self.assertTrue((arr > 0).all())
+
+    def test_t_distribution(self):
+        """t works both with and without an explicit key."""
+        self.assertEqual(self.rs.t(3.0, size=(4,)).shape, (4,))
+        key = brainstate.random.split_key()
+        self.assertEqual(self.rs.t(3.0, size=(4,), key=key).shape, (4,))
+
+    def test_orthogonal(self):
+        """orthogonal returns batches of orthonormal matrices."""
+        q = self.rs.orthogonal(3, size=(2,))
+        self.assertEqual(q.shape, (2, 3, 3))
+        identity = jnp.einsum('...ij,...kj->...ik', q, q)
+        np.testing.assert_allclose(np.asarray(identity), np.broadcast_to(np.eye(3), (2, 3, 3)), atol=1e-4)
+
+    def test_noncentral_chisquare(self):
+        """noncentral_chisquare works both with and without an explicit key."""
+        self.assertEqual(self.rs.noncentral_chisquare(3.0, 1.0, size=(2,)).shape, (2,))
+        key = brainstate.random.split_key()
+        self.assertEqual(self.rs.noncentral_chisquare(3.0, 1.0, size=(2,), key=key).shape, (2,))
+
+    def test_loggamma(self):
+        """loggamma yields samples with the requested shape."""
+        self.assertEqual(self.rs.loggamma(2.0, size=(3,)).shape, (3,))
+
+    def test_categorical_size_none(self):
+        """categorical infers the output shape from the logits when size is None."""
+        logits = jnp.array([[0.1, 0.2, 0.7], [0.3, 0.3, 0.4]])
+        out = self.rs.categorical(logits)
+        self.assertEqual(out.shape, (2,))
+
+    def test_special_impl_distributions(self):
+        """zipf, power, f, hypergeometric, logseries, noncentral_f all sample."""
+        self.assertEqual(self.rs.zipf(2.0, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.power(2.0, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.f(3.0, 5.0, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.hypergeometric(5, 5, 4, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.logseries(0.5, size=(3,)).shape, (3,))
+        self.assertEqual(self.rs.noncentral_f(3.0, 5.0, 1.0, size=(3,)).shape, (3,))
+
+
+class TestRandomStatePyTorchHelpersExtra(unittest.TestCase):
+    """Extend coverage of the PyTorch-compat *_like helpers."""
+
+    def setUp(self):
+        """Create a seeded RandomState and push a state-trace stack."""
+        self.rs = RandomState(2025)
+        TRACE_CONTEXT.state_stack.append(StateTraceStack())
+
+    def tearDown(self):
+        """Pop the state-trace stack after each test."""
+        TRACE_CONTEXT.state_stack.pop()
+
+    def test_rand_like_with_dtype_and_key(self):
+        """rand_like honours an explicit dtype and external key."""
+        key = brainstate.random.split_key()
+        out = self.rs.rand_like(jnp.zeros((2, 3)), dtype=jnp.float32, key=key)
+        self.assertEqual(out.shape, (2, 3))
+        self.assertEqual(out.dtype, jnp.float32)
+
+    def test_randn_like_with_dtype_and_key(self):
+        """randn_like honours an explicit dtype and external key."""
+        key = brainstate.random.split_key()
+        out = self.rs.randn_like(jnp.zeros((2, 3)), dtype=jnp.float32, key=key)
+        self.assertEqual(out.shape, (2, 3))
+        self.assertEqual(out.dtype, jnp.float32)
+
+    def test_randint_like_default_high(self):
+        """randint_like defaults its upper bound to max(input)."""
+        out = self.rs.randint_like(jnp.array([3, 5, 9]))
+        self.assertEqual(out.shape, (3,))
+        self.assertTrue((np.asarray(out) < 9).all())
+
+    def test_randint_like_with_key(self):
+        """randint_like accepts an explicit key and bounds."""
+        key = brainstate.random.split_key()
+        out = self.rs.randint_like(jnp.zeros((2, 3), dtype=jnp.int32), 0, 4, key=key)
+        self.assertEqual(out.shape, (2, 3))
+        self.assertTrue((np.asarray(out) >= 0).all() and (np.asarray(out) < 4).all())
+
+
+class TestRandomStateScalarSizeInference(unittest.TestCase):
+    """Drive the ``size is None`` shape-inference branch of every distribution."""
+
+    def setUp(self):
+        """Create a seeded RandomState and push a state-trace stack."""
+        self.rs = RandomState(31337)
+        TRACE_CONTEXT.state_stack.append(StateTraceStack())
+
+    def tearDown(self):
+        """Pop the state-trace stack after each test."""
+        TRACE_CONTEXT.state_stack.pop()
+
+    def test_scalar_distributions_infer_empty_shape(self):
+        """Scalar parameters with no size yield scalar (shape ()) draws."""
+        calls = {
+            'beta': lambda: self.rs.beta(2.0, 3.0),
+            'exponential': lambda: self.rs.exponential(2.0),
+            'gamma': lambda: self.rs.gamma(2.0, 1.0),
+            'laplace': lambda: self.rs.laplace(0.0, 1.0),
+            'gumbel': lambda: self.rs.gumbel(0.0, 1.0),
+            'pareto': lambda: self.rs.pareto(2.0),
+            'standard_gamma': lambda: self.rs.standard_gamma(2.0),
+            'lognormal': lambda: self.rs.lognormal(0.0, 1.0),
+            'bernoulli': lambda: self.rs.bernoulli(0.5),
+            'binomial': lambda: self.rs.binomial(10, 0.5),
+            'geometric': lambda: self.rs.geometric(0.5),
+            'rayleigh': lambda: self.rs.rayleigh(2.0),
+            'vonmises': lambda: self.rs.vonmises(0.0, 1.0),
+            'weibull': lambda: self.rs.weibull(2.0),
+            'weibull_min': lambda: self.rs.weibull_min(2.0, scale=1.5),
+            'negative_binomial': lambda: self.rs.negative_binomial(5, 0.5),
+            'wald': lambda: self.rs.wald(1.0, 2.0),
+            't': lambda: self.rs.t(3.0),
+            'noncentral_chisquare': lambda: self.rs.noncentral_chisquare(3.0, 1.0),
+            'loggamma': lambda: self.rs.loggamma(2.0),
+            'zipf': lambda: self.rs.zipf(2.0),
+            'power': lambda: self.rs.power(2.0),
+            'f': lambda: self.rs.f(3.0, 5.0),
+            'logseries': lambda: self.rs.logseries(0.5),
+            'noncentral_f': lambda: self.rs.noncentral_f(3.0, 5.0, 1.0),
+            'hypergeometric': lambda: self.rs.hypergeometric(5, 5, 4),
+            'poisson': lambda: self.rs.poisson(3.0),
+            'truncated_normal': lambda: self.rs.truncated_normal(-1.0, 1.0),
+        }
+        for name, fn in calls.items():
+            with self.subTest(distribution=name):
+                self.assertEqual(np.asarray(fn()).shape, ())
+
+
+class TestRandomStateEdgeCases(unittest.TestCase):
+    """Cover deletion recovery, non-array splitting, and unit-carrying inputs."""
+
+    def setUp(self):
+        """Push a fresh state-trace stack for each test."""
+        TRACE_CONTEXT.state_stack.append(StateTraceStack())
+
+    def tearDown(self):
+        """Pop the state-trace stack after each test."""
+        TRACE_CONTEXT.state_stack.pop()
+
+    def test_check_if_deleted_reseeds_after_buffer_delete(self):
+        """check_if_deleted reseeds the state once its backing buffer is freed."""
+        rs = RandomState(9)
+        rs.value.delete()
+        rs.check_if_deleted()
+        self.assertEqual(rs.value.shape, (2,))
+        # After reseeding the state is usable again.
+        self.assertEqual(rs.randn(3).shape, (3,))
+
+    def test_split_key_coerces_non_jax_array_value(self):
+        """split_key coerces a plain numpy key array before splitting."""
+        rs = RandomState(9)
+        rs._value = np.array([1, 2], dtype=np.uint32)
+        new_key = rs.split_key()
+        self.assertEqual(new_key.shape, (2,))
+        self.assertEqual(rs.value.shape, (2,))
+
+    def test_multivariate_normal_with_units(self):
+        """multivariate_normal accepts unit-carrying mean and covariance."""
+        import brainunit as u
+        rs = RandomState(9)
+        mean = jnp.array([0.0, 1.0]) * u.mV
+        cov = jnp.array([[1.0, 0.5], [0.5, 2.0]]) * (u.mV ** 2)
+        out = rs.multivariate_normal(mean, cov, size=(2,))
+        self.assertEqual(np.asarray(u.get_magnitude(out)).shape, (2, 2))
+
+    def test_multivariate_normal_size_none(self):
+        """multivariate_normal infers a scalar batch when size is None."""
+        rs = RandomState(9)
+        out = rs.multivariate_normal(jnp.array([0.0, 1.0]), jnp.array([[1.0, 0.0], [0.0, 1.0]]))
+        self.assertEqual(out.shape, (2,))
+
+    def test_check_valid_false_skips_validation(self):
+        """Distributions with check_valid=False skip their jit_error_if guard."""
+        rs = RandomState(9)
+        self.assertEqual(rs.truncated_normal(-1.0, 1.0, size=(3,), check_valid=False).shape, (3,))
+        self.assertEqual(rs.bernoulli(0.5, size=(3,), check_valid=False).shape, (3,))
+        self.assertEqual(rs.binomial(10, 0.5, size=(3,), check_valid=False).shape, (3,))
+        out = rs.multinomial(10, jnp.array([0.2, 0.3, 0.5]), size=(2,), check_valid=False)
+        self.assertEqual(out.shape, (2, 3))
+
+    def test_standard_t_with_size(self):
+        """standard_t honours an explicit size argument."""
+        rs = RandomState(9)
+        self.assertEqual(rs.standard_t(3.0, size=(3,)).shape, (3,))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Comprehensive test audit of the `brainstate.random` subpackage. Branch coverage
rises from **82% → 99%**, with every module at **≥99%**. Full project suite:
**4337 passed, 19 skipped, 0 failed**.

| Module | Before | After |
|--------|--------|-------|
| `_fun.py` | 95% | 100% |
| `_impl.py` | 77% | 99% |
| `_seed.py` | 59% | 100% |
| `_state.py` | 85% | 99% |

### New / expanded tests
- **`_impl_test.py`** (new) — the JAX-native sampling helpers (`multinomial`,
  `von_mises_centered`, `zipf`, `power`, `hypergeometric`, `f`, `logseries`,
  `formalize_key`, reshape/promote/scale utilities).
- **`_fun_test.py`** — a 44-distribution parameterized contract suite
  (shape / dtype / determinism / bounds / failure / jit / vmap), plus slow
  statistical-moment checks.
- **`_seed_test.py`** — seed/key utilities (`seed`, `seed_context`, `split_key(s)`,
  `get/set/restore_key`, `clone_rng`, `default_rng`, `self_assign_multi_keys`).
- **`_state_test.py`** — `RandomState` as a State: pytree roundtrip, key
  advancement, determinism, jit/vmap transforms, `*_like` helpers, repr/clone.

### Rule #7 dogfooding
All random test files now obtain keys via `brainstate.random` (`split_key`/
`get_key`) or brainstate's own `formalize_key` helper — **zero direct
`jax.random`** usage across the subpackage's tests.

## Source bug fixes included

Three genuine bugs were surfaced by the new tests and fixed (each has a
regression test):

1. **`exponential(scale)` inverted the scale convention.** It divided a
   unit-mean draw by `scale` (`r / scale`), giving mean `1/scale` — but the
   verbatim-numpy docstring defines `scale = β = 1/λ` (the mean). Now multiplies
   by `scale` (matching the sibling `gamma` implementation), so
   `exponential(scale=2)` has mean ≈ 2.0.
2. **`von_mises_centered(dtype=float16)` crashed** with a `lax.while_loop`
   carry-type mismatch — the carry's `u`/`w` arrays were built at the default
   dtype while the loop body produced `concentration.dtype`. Now the carry is
   initialised in `concentration.dtype` (also fixes float32 under x64).
3. **`formalize_key(np.array([42]))` crashed** — a size-1 but non-0d integer
   array took the `PRNGKey` branch, which requires a scalar seed. Now reshaped
   to a scalar first.

## Notes (documented, not changed)

- `split_key(backup=True)` / `restore_key()` back up the key **after** it is
  advanced to `keys[0]`, so `restore_key()` returns the post-split key rather
  than the pre-split key the docstring example implies. Behavior is internally
  consistent and the new tests assert the actual behavior; the docstring wording
  is the only discrepancy and is left for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
