### PR TITLE
test(util): comprehensive util subpackage tests (89%→97%)

### DIFF
--- a/brainstate/util/_pretty_pytree_test.py
+++ b/brainstate/util/_pretty_pytree_test.py
@@ -40,10 +40,13 @@ from brainstate.util._pretty_pytree import (
     NestedDict,
     FlattedDict,
     PrettyList,
+    NestedStateRepr,
     flat_mapping,
     nest_mapping,
     empty_node,
     _EmptyNode,
+    _default_compare,
+    _default_process,
 )
 
 
@@ -708,3 +711,386 @@ class TestGetattrProtocol(absltest.TestCase):
         """Accessing an existing key as an attribute still returns its value."""
         d = NestedDict({'a': 5})
         self.assertEqual(d.a, 5)
+
+
+class TestPrettyPytreeRoundtrips(unittest.TestCase):
+    """Verify flat/nest roundtrips and JAX pytree registration consistency."""
+
+    def test_flat_nest_roundtrip(self):
+        """Reproduce the nested structure via ``nest_mapping(flat_mapping(x))``."""
+        nested = {'a': 1, 'b': {'c': 2, 'd': {'e': 3}}}
+        self.assertEqual(nest_mapping(flat_mapping(nested)).to_dict(), nested)
+
+    def test_nesteddict_flatten_unflatten_consistent(self):
+        """Flatten and unflatten a NestedDict to an equal JAX structure."""
+        nd = NestedDict({'a': brainstate.ParamState(1), 'b': {'c': brainstate.ParamState(2)}})
+        leaves, treedef = jax.tree.flatten(nd)
+        rebuilt = jax.tree.unflatten(treedef, leaves)
+        self.assertEqual(jax.tree.structure(nd), jax.tree.structure(rebuilt))
+
+    def test_empty_nesteddict(self):
+        """Flatten an empty NestedDict to zero leaves."""
+        self.assertEqual(len(jax.tree.leaves(NestedDict({}))), 0)
+
+
+class TestFlatMappingEmptyWhole(unittest.TestCase):
+    """Exercise the whole-empty-input branch of ``flat_mapping``."""
+
+    def test_flat_mapping_whole_empty_keep_empty_nodes(self):
+        """Return an empty FlattedDict when the whole input is empty even with keep_empty_nodes."""
+        flat = flat_mapping({}, keep_empty_nodes=True)
+        self.assertIsInstance(flat, FlattedDict)
+        self.assertEqual(len(flat), 0)
+
+
+class TestDefaultIdentityHelpers(unittest.TestCase):
+    """Cover the module-level identity helper functions."""
+
+    def test_default_process_returns_id(self):
+        """Return the object identity from ``_default_process``."""
+        obj = object()
+        self.assertEqual(_default_process(obj), id(obj))
+
+    def test_default_compare_membership(self):
+        """Report membership of an object's id in a set via ``_default_compare``."""
+        obj = object()
+        self.assertTrue(_default_compare(obj, {id(obj)}))
+        self.assertFalse(_default_compare(obj, set()))
+
+
+class TestPrettyDictAbstractAndUtils(unittest.TestCase):
+    """Cover PrettyDict abstract methods, subset, and treefy_state."""
+
+    def test_split_not_implemented(self):
+        """Raise NotImplementedError from the abstract ``PrettyDict.split``."""
+        d = PrettyDict({'a': 1})
+        with self.assertRaises(NotImplementedError):
+            d.split(lambda p, v: True)
+
+    def test_filter_not_implemented(self):
+        """Raise NotImplementedError from the abstract ``PrettyDict.filter``."""
+        d = PrettyDict({'a': 1})
+        with self.assertRaises(NotImplementedError):
+            d.filter(lambda p, v: True)
+
+    def test_merge_not_implemented(self):
+        """Raise NotImplementedError from the abstract ``PrettyDict.merge``."""
+        d = PrettyDict({'a': 1})
+        with self.assertRaises(NotImplementedError):
+            d.merge(PrettyDict({'b': 2}))
+
+    def test_subset_delegates_to_filter(self):
+        """Subset a NestedDict by delegating to ``filter``."""
+        nd = NestedDict({'a': 1, 'b': 2, 'c': 3})
+        subset = nd.subset(lambda p, v: v > 1)
+        flat = subset.to_flat()
+        self.assertIn(('b',), flat)
+        self.assertIn(('c',), flat)
+        self.assertNotIn(('a',), flat)
+
+    def test_treefy_state_converts_state_objects(self):
+        """Map State objects through ``to_state_ref`` while preserving structure."""
+        d = PrettyDict({'a': brainstate.ParamState(1), 'b': 2})
+        ref_tree = d.treefy_state()
+        # The flatten/map/unflatten roundtrip preserves the dict structure and
+        # passes non-State leaves through unchanged.
+        self.assertEqual(set(ref_tree.keys()), {'a', 'b'})
+        self.assertEqual(ref_tree['b'], 2)
+        # State leaves remain State-like (their reference form).
+        self.assertEqual(ref_tree['a'].value, 1)
+
+
+class TestNestedStateReprTreescope(unittest.TestCase):
+    """Cover NestedStateRepr treescope and nested wrapping behaviour."""
+
+    def test_treescope_repr_wraps_nested_dicts(self):
+        """Render nested PrettyDict children through a subtree renderer."""
+        nsr = NestedStateRepr(NestedDict({'a': 1, 'b': NestedDict({'c': 2})}))
+        captured = {}
+
+        def renderer(children, path):
+            captured['children'] = children
+            captured['path'] = path
+            return 'rendered'
+
+        result = nsr.__treescope_repr__('PATH', renderer)
+        self.assertEqual(result, 'rendered')
+        self.assertEqual(captured['path'], 'PATH')
+        # Nested PrettyDict value should have been wrapped in NestedStateRepr.
+        self.assertIsInstance(captured['children']['b'], NestedStateRepr)
+        self.assertEqual(captured['children']['a'], 1)
+
+    def test_nested_state_repr_pretty_output(self):
+        """Produce a compact brace-delimited repr for a wrapped NestedDict."""
+        from brainstate.util._pretty_repr import pretty_repr_object
+        nsr = NestedStateRepr(NestedDict({'a': 1, 'b': NestedDict({'c': 2})}))
+        out = pretty_repr_object(nsr)
+        self.assertIn('a', out)
+        self.assertIn('c', out)
+
+
+class TestNestedDictMergeAndOps(unittest.TestCase):
+    """Cover NestedDict merge variants and empty-operand operators."""
+
+    def test_or_with_empty_other_returns_self(self):
+        """Return self unchanged when OR-ing with an empty NestedDict."""
+        d1 = NestedDict({'a': 1})
+        result = d1 | NestedDict({})
+        self.assertIs(result, d1)
+
+    def test_sub_with_empty_other_returns_self(self):
+        """Return self unchanged when subtracting an empty NestedDict."""
+        d1 = NestedDict({'a': 1})
+        result = d1 - NestedDict({})
+        self.assertIs(result, d1)
+
+    def test_merge_accepts_flatted_dict(self):
+        """Merge a FlattedDict argument into a NestedDict result."""
+        nd = NestedDict({'a': 1})
+        fd = FlattedDict({('b',): 2})
+        merged = NestedDict.merge(nd, fd)
+        self.assertEqual(merged['a'], 1)
+        self.assertEqual(merged['b'], 2)
+
+    def test_merge_rejects_invalid_type(self):
+        """Raise TypeError when merging a non-mapping into a NestedDict."""
+        with self.assertRaises(TypeError):
+            NestedDict.merge(NestedDict({'a': 1}), [('b', 2)])
+
+    def test_filter_single_filter_returns_single(self):
+        """Return a single NestedDict when ``filter`` is given one filter."""
+        nd = NestedDict({'a': 1, 'b': 2})
+        result = nd.filter(lambda p, v: v > 1)
+        self.assertIsInstance(result, NestedDict)
+        self.assertIn(('b',), result.to_flat())
+
+    def test_split_single_filter_returns_single(self):
+        """Return a single NestedDict when ``split`` resolves to one state."""
+        nd = NestedDict({'a': 1, 'b': 2})
+        result = nd.split(...)
+        self.assertIsInstance(result, NestedDict)
+        self.assertEqual(len(result.to_flat()), 2)
+
+    def test_filter_multiple_filters_returns_tuple(self):
+        """Return a tuple of NestedDicts when filtering with two filters."""
+        nd = NestedDict({'a': 1, 'b': 2, 'c': 3})
+        evens, odds = nd.filter(lambda p, v: v % 2 == 0, lambda p, v: v % 2 == 1)
+        self.assertIn(('b',), evens.to_flat())
+        self.assertIn(('a',), odds.to_flat())
+        self.assertIn(('c',), odds.to_flat())
+
+
+class TestNestedDictReplaceByPureDict(unittest.TestCase):
+    """Cover NestedDict.replace_by_pure_dict for State and plain values."""
+
+    def test_replace_state_values(self):
+        """Replace State values via their ``replace`` method by default."""
+        nd = NestedDict({'a': brainstate.ParamState(1), 'b': brainstate.ParamState(2)})
+        nd.replace_by_pure_dict({'a': 10, 'b': 20})
+        self.assertEqual(nd['a'].value, 10)
+        self.assertEqual(nd['b'].value, 20)
+
+    def test_replace_plain_values(self):
+        """Replace plain (non-State) values by direct assignment."""
+        nd = NestedDict({'a': 5, 'b': 6})
+        nd.replace_by_pure_dict({'a': 99, 'b': 100})
+        self.assertEqual(nd['a'], 99)
+        self.assertEqual(nd['b'], 100)
+
+    def test_replace_with_custom_replace_fn(self):
+        """Apply a custom replace function to combine old and new values."""
+        nd = NestedDict({'a': 5})
+        nd.replace_by_pure_dict({'a': 3}, replace_fn=lambda old, new: old + new)
+        self.assertEqual(nd['a'], 8)
+
+    def test_replace_missing_key_raises(self):
+        """Raise ValueError when a pure_dict key is absent from the state."""
+        nd = NestedDict({'a': 1})
+        with self.assertRaises(ValueError):
+            nd.replace_by_pure_dict({'z': 9})
+
+
+class TestFlattedDictMergeAndOps(unittest.TestCase):
+    """Cover FlattedDict merge variants, operators, and conversions."""
+
+    def test_or_with_empty_other_returns_self(self):
+        """Return self unchanged when OR-ing with an empty FlattedDict."""
+        d1 = FlattedDict({('a',): 1})
+        result = d1 | FlattedDict({})
+        self.assertIs(result, d1)
+
+    def test_sub_with_empty_other_returns_self(self):
+        """Return self unchanged when subtracting an empty FlattedDict."""
+        d1 = FlattedDict({('a',): 1})
+        result = d1 - FlattedDict({})
+        self.assertIs(result, d1)
+
+    def test_from_nest_classmethod(self):
+        """Build a FlattedDict from a nested mapping via ``from_nest``."""
+        fd = FlattedDict.from_nest({'a': 1, 'b': {'c': 2}})
+        self.assertIsInstance(fd, FlattedDict)
+        self.assertEqual(fd[('a',)], 1)
+        self.assertEqual(fd[('b', 'c')], 2)
+
+    def test_split_exhaustive(self):
+        """Split a FlattedDict exhaustively into two FlattedDicts."""
+        fd = FlattedDict({('a',): 1, ('b',): 2})
+        big, rest = fd.split(lambda p, v: v > 1, ...)
+        self.assertIn(('b',), big)
+        self.assertIn(('a',), rest)
+
+    def test_split_non_exhaustive_raises(self):
+        """Raise ValueError for non-exhaustive FlattedDict split filters."""
+        fd = FlattedDict({('a',): 1, ('b',): 2})
+        with self.assertRaises(ValueError):
+            fd.split(lambda p, v: v > 1)
+
+    def test_split_single_filter_returns_single(self):
+        """Return a single FlattedDict when split resolves to one state."""
+        fd = FlattedDict({('a',): 1, ('b',): 2})
+        result = fd.split(...)
+        self.assertIsInstance(result, FlattedDict)
+        self.assertEqual(len(result), 2)
+
+    def test_filter_single_filter_returns_single(self):
+        """Return a single FlattedDict when ``filter`` is given one filter."""
+        fd = FlattedDict({('a',): 1, ('b',): 2})
+        result = fd.filter(lambda p, v: v > 1)
+        self.assertIsInstance(result, FlattedDict)
+        self.assertIn(('b',), result)
+
+    def test_filter_multiple_filters_returns_tuple(self):
+        """Return a tuple of FlattedDicts when filtering with two filters."""
+        fd = FlattedDict({('a',): 1, ('b',): 2, ('c',): 3})
+        evens, odds = fd.filter(lambda p, v: v % 2 == 0, lambda p, v: v % 2 == 1)
+        self.assertIn(('b',), evens)
+        self.assertIn(('a',), odds)
+        self.assertIn(('c',), odds)
+
+    def test_merge_accepts_nested_dict(self):
+        """Merge a NestedDict argument into a FlattedDict result."""
+        fd = FlattedDict({('a',): 1})
+        nd = NestedDict({'b': 2})
+        merged = FlattedDict.merge(fd, nd)
+        self.assertEqual(merged[('a',)], 1)
+        self.assertEqual(merged[('b',)], 2)
+
+    def test_merge_rejects_invalid_type(self):
+        """Raise TypeError when merging a non-mapping into a FlattedDict."""
+        with self.assertRaises(TypeError):
+            FlattedDict.merge(FlattedDict({('a',): 1}), 123)
+
+
+class TestSplitErrorPaths(unittest.TestCase):
+    """Cover the ``...``/``True`` filter-position validation branches."""
+
+    def test_nested_ellipsis_then_ellipsis_no_error(self):
+        """Allow trailing ``...`` filters after an earlier ``...`` in NestedDict.split."""
+        nd = NestedDict({'a': 1, 'b': 2})
+        first, second = nd.split(..., ...)
+        self.assertIsInstance(first, NestedDict)
+        self.assertIsInstance(second, NestedDict)
+
+    def test_nested_ellipsis_before_real_filter_raises(self):
+        """Raise ValueError when ``...`` precedes a real filter in NestedDict.split."""
+        nd = NestedDict({'a': 1, 'b': 2})
+        with self.assertRaises(ValueError):
+            nd.split(..., lambda p, v: v > 1)
+
+    def test_flatted_ellipsis_then_ellipsis_no_error(self):
+        """Allow trailing ``...`` filters after an earlier ``...`` in FlattedDict.split."""
+        fd = FlattedDict({('a',): 1, ('b',): 2})
+        first, second = fd.split(..., ...)
+        self.assertIsInstance(first, FlattedDict)
+        self.assertIsInstance(second, FlattedDict)
+
+    def test_flatted_ellipsis_before_real_filter_raises(self):
+        """Raise ValueError when ``...`` precedes a real filter in FlattedDict.split."""
+        fd = FlattedDict({('a',): 1, ('b',): 2})
+        with self.assertRaises(ValueError):
+            fd.split(..., lambda p, v: v > 1)
+
+
+class TestReprAttributeBranches(unittest.TestCase):
+    """Cover list/dict conversion and key-filtering branches in repr helpers."""
+
+    def test_pretty_dict_with_list_value_repr(self):
+        """Render a PrettyDict that holds a list value (PrettyList conversion)."""
+        d = PrettyDict({'a': [1, 2, 3], 'b': 1})
+        out = repr(d)
+        self.assertIsInstance(out, str)
+        self.assertIn('1', out)
+
+    def test_pretty_list_of_lists_repr(self):
+        """Render a PrettyList that holds nested list items."""
+        pl = PrettyList([[1, 2], [3, 4]])
+        out = repr(pl)
+        self.assertIsInstance(out, str)
+        self.assertIn('3', out)
+
+    def test_pretty_object_with_list_and_dict_attrs(self):
+        """Render a PrettyObject whose attributes are a list and a dict."""
+        class Obj(PrettyObject):
+            def __init__(self):
+                self.mylist = [1, 2, 3]
+                self.mydict = {'x': 1}
+
+        out = repr(Obj())
+        self.assertIn('mylist', out)
+        self.assertIn('mydict', out)
+
+    def test_pretty_object_item_returns_none_key_is_skipped(self):
+        """Skip an attribute when ``__pretty_repr_item__`` returns a ``None`` key."""
+        class Obj(PrettyObject):
+            def __init__(self):
+                self.keep = 'visible'
+                self.drop = 'gone'
+
+            def __pretty_repr_item__(self, k, v):
+                if k == 'drop':
+                    return None, v
+                return k, v
+
+        out = repr(Obj())
+        self.assertIn('keep', out)
+        self.assertNotIn('gone', out)
+
+    def test_pretty_object_without_item_hook(self):
+        """Render a PrettyObject lacking ``__pretty_repr_item__`` (AttributeError path)."""
+        # A bare PrettyObject still defines the hook, so use a value attribute
+        # to exercise the general attribute path with the default hook.
+        class Obj(PrettyObject):
+            def __init__(self):
+                self.value = 7
+
+        out = repr(Obj())
+        self.assertIn('value', out)
+        self.assertIn('7', out)
+
+    def test_general_repr_object_missing_item_hook(self):
+        """Exercise the AttributeError fallback when a node lacks the item hook."""
+        from brainstate.util._pretty_repr import (
+            PrettyRepr,
+            yield_unique_pretty_repr_items,
+            pretty_repr_object,
+        )
+        from brainstate.util._pretty_pytree import (
+            _repr_object_general,
+            _repr_attribute_general,
+        )
+
+        class Bare(PrettyRepr):
+            # Deliberately does NOT define ``__pretty_repr_item__`` so the
+            # ``except AttributeError`` branch in ``_repr_attribute_general`` runs.
+            def __init__(self):
+                self.x = 5
+                self.items_list = [1, 2]
+
+            def __pretty_repr__(self):
+                yield from yield_unique_pretty_repr_items(
+                    self, _repr_object_general, _repr_attribute_general
+                )
+
+        out = pretty_repr_object(Bare())
+        self.assertIn('x', out)
+        self.assertIn('items_list', out)

--- a/brainstate/util/_tracers.py
+++ b/brainstate/util/_tracers.py
@@ -26,7 +26,7 @@ __all__ = [
 
 def current_jax_trace():
     """Returns the Jax tracing state."""
-    if jax.__version_info__ <= (0, 4, 33):
+    if jax.__version_info__ <= (0, 4, 33):  # pragma: no cover
         return jax.core.thread_local_state.trace_state.trace_stack.dynamic
     return get_opaque_trace_state(convention="nnx")
 

--- a/brainstate/util/_tracers_test.py
+++ b/brainstate/util/_tracers_test.py
@@ -1,0 +1,118 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+
+from brainstate.util._tracers import StateJaxTracer, current_jax_trace
+
+
+class TestCurrentJaxTrace(unittest.TestCase):
+    """Validate the module-level ``current_jax_trace`` helper."""
+
+    def test_returns_non_none_at_top_level(self):
+        """Return a non-None tracing state when called outside any transform."""
+        self.assertIsNotNone(current_jax_trace())
+
+    def test_top_level_calls_are_equal(self):
+        """Return equal tracing states for repeated top-level calls."""
+        self.assertEqual(current_jax_trace(), current_jax_trace())
+
+
+class TestStateJaxTracer(unittest.TestCase):
+    """Validate trace capture, validity, equality, and pretty-repr."""
+
+    def test_jax_trace_property_matches_current(self):
+        """Expose the captured trace through the ``jax_trace`` property."""
+        tracer = StateJaxTracer()
+        self.assertIsNotNone(tracer.jax_trace)
+        self.assertEqual(tracer.jax_trace, current_jax_trace())
+
+    def test_top_level_tracers_are_equal_and_valid(self):
+        """Capture identical traces and report validity at the top level."""
+        a = StateJaxTracer()
+        b = StateJaxTracer()
+        self.assertEqual(a, b)
+        self.assertTrue(a.is_valid())
+        self.assertTrue(b.is_valid())
+        self.assertIsNotNone(a.jax_trace)
+
+    def test_eq_rejects_non_tracer(self):
+        """Return False from ``__eq__`` for non-tracer objects."""
+        self.assertNotEqual(StateJaxTracer(), object())
+        self.assertFalse(StateJaxTracer().__eq__(42))
+
+    def test_eq_accepts_matching_tracer(self):
+        """Return True from ``__eq__`` for another tracer with the same trace."""
+        self.assertTrue(StateJaxTracer().__eq__(StateJaxTracer()))
+
+    def test_repr_contains_class_name(self):
+        """Name the class and the captured attribute in the pretty repr."""
+        text = repr(StateJaxTracer())
+        self.assertIn("StateJaxTracer", text)
+        self.assertIn("jax_trace", text)
+
+    def test_pretty_repr_yields_type_and_attr(self):
+        """Yield a type header and a ``jax_trace`` attribute from ``__pretty_repr__``."""
+        tracer = StateJaxTracer()
+        parts = list(tracer.__pretty_repr__())
+        self.assertEqual(len(parts), 2)
+        self.assertEqual(parts[0].type, "StateJaxTracer")
+        self.assertEqual(parts[1].key, "jax_trace")
+
+    def test_tracer_captured_in_jit_is_invalid_outside(self):
+        """Invalidate a tracer captured inside a jit trace once tracing finishes."""
+        captured = []
+
+        @jax.jit
+        def f(x):
+            captured.append(StateJaxTracer())
+            return x
+
+        f(jnp.ones((3,)))
+        self.assertFalse(captured[0].is_valid())
+
+    def test_tracer_inside_jit_differs_from_top_level(self):
+        """Capture a distinct trace inside jit compared to the enclosing scope."""
+        outer = StateJaxTracer()
+        captured = []
+
+        @jax.jit
+        def f(x):
+            captured.append(StateJaxTracer())
+            return x
+
+        f(jnp.ones((3,)))
+        self.assertNotEqual(outer, captured[0])
+
+    def test_tracer_inside_jit_is_valid_during_trace(self):
+        """Report validity for a tracer while its own jit trace is still active."""
+        results = []
+
+        @jax.jit
+        def f(x):
+            tracer = StateJaxTracer()
+            results.append(tracer.is_valid())
+            return x
+
+        f(jnp.ones((3,)))
+        self.assertTrue(results[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/brainstate/util/struct_test.py
+++ b/brainstate/util/struct_test.py
@@ -3,6 +3,7 @@ Comprehensive tests for the struct module.
 """
 
 import pickle
+import unittest
 from typing import Any
 
 import jax
@@ -596,6 +597,174 @@ class TestIntegration:
         batch_x = jnp.ones((2, 3))
         result = batch_process(batch_params, batch_x)
         assert result.shape == (2, 3)
+
+
+class TestStructSemantics(unittest.TestCase):
+    """Frozen dataclass behavior and pytree_node field separation."""
+
+    def test_pytreenode_is_frozen(self):
+        """Assign to a PyTreeNode field after construction and expect a raise."""
+        class Layer(PyTreeNode):
+            weights: jax.Array
+
+        layer = Layer(weights=jnp.ones(3))
+        with self.assertRaises(Exception):
+            layer.weights = jnp.zeros(3)
+
+    def test_replace_does_not_mutate_original(self):
+        """Return a new instance from replace, leaving the original unchanged."""
+        class Layer(PyTreeNode):
+            weights: jax.Array
+
+        a = Layer(weights=jnp.ones(3))
+        b = a.replace(weights=jnp.ones(3) * 2)
+        self.assertTrue(bool(jnp.allclose(a.weights, 1.0)))
+        self.assertTrue(bool(jnp.allclose(b.weights, 2.0)))
+
+    def test_pytreenode_is_jax_pytree(self):
+        """Flatten and unflatten a PyTreeNode through jax.tree."""
+        class Layer(PyTreeNode):
+            weights: jax.Array
+
+        a = Layer(weights=jnp.arange(3.0))
+        leaves, treedef = jax.tree.flatten(a)
+        rebuilt = jax.tree.unflatten(treedef, leaves)
+        self.assertTrue(bool(jnp.allclose(rebuilt.weights, a.weights)))
+
+    def test_static_field_not_a_leaf(self):
+        """Exclude a pytree_node=False field from jax.tree leaves and survive flatten/unflatten."""
+        class Layer(PyTreeNode):
+            weights: jax.Array
+            name: str = field(pytree_node=False, default="layer")
+
+        a = Layer(weights=jnp.ones(3), name="static-name")
+        leaves = jax.tree_util.tree_leaves(a)
+        # Only the array weights should be a leaf; the static name must not appear.
+        self.assertEqual(len(leaves), 1)
+        self.assertNotIn("static-name", leaves)
+        # The static field survives a flatten/unflatten roundtrip unchanged.
+        flat, treedef = jax.tree_util.tree_flatten(a)
+        rebuilt = jax.tree_util.tree_unflatten(treedef, flat)
+        self.assertEqual(rebuilt.name, "static-name")
+        self.assertTrue(bool(jnp.allclose(rebuilt.weights, a.weights)))
+
+    def test_pytreenode_init_stub_raises(self):
+        """Raise NotImplementedError when instantiating PyTreeNode directly."""
+        with self.assertRaises(NotImplementedError):
+            PyTreeNode()
+
+    def test_pytreenode_replace_stub_raises(self):
+        """Raise NotImplementedError when calling the unbound PyTreeNode.replace stub."""
+        with self.assertRaises(NotImplementedError):
+            PyTreeNode.replace(object())
+
+    def test_register_pytree_fallback_path(self):
+        """Drive the register_pytree_with_keys fallback closures when register_dataclass is absent."""
+        import brainstate.util.struct as struct_mod
+
+        had_attr = hasattr(jax.tree_util, 'register_dataclass')
+        saved = jax.tree_util.register_dataclass if had_attr else None
+        if had_attr:
+            del jax.tree_util.register_dataclass
+        try:
+            @struct_mod.dataclass
+            class Fallback:
+                weights: jax.Array
+                name: str = field(pytree_node=False, default="fb")
+
+            obj = Fallback(weights=jnp.ones(2))
+
+            # tree_flatten / tree_unflatten exercise flatten_fn and unflatten_fn.
+            leaves, treedef = jax.tree_util.tree_flatten(obj)
+            self.assertEqual(len(leaves), 1)
+            rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+            self.assertEqual(rebuilt.name, "fb")
+            self.assertTrue(bool(jnp.allclose(rebuilt.weights, obj.weights)))
+
+            # tree_flatten_with_path exercises flatten_with_keys_fn.
+            with_keys, _ = jax.tree_util.tree_flatten_with_path(obj)
+            self.assertEqual(len(with_keys), 1)
+        finally:
+            if had_attr:
+                jax.tree_util.register_dataclass = saved
+
+
+class TestFrozenDictCoverage(unittest.TestCase):
+    """Cover FrozenDict helpers, hashing, repr, and pretty-print edge cases."""
+
+    def test_frozendict_immutable_and_roundtrip(self):
+        """Reject mutation and support a freeze/unfreeze roundtrip."""
+        fd = freeze({'a': 1, 'b': 2})
+        self.assertIsInstance(fd, FrozenDict)
+        with self.assertRaises(Exception):
+            fd['a'] = 99
+        self.assertEqual(unfreeze(fd), {'a': 1, 'b': 2})
+
+    def test_deep_freeze_unwraps_nested_frozendict(self):
+        """Unwrap a nested FrozenDict value to its underlying data during construction."""
+        inner = FrozenDict({'x': 1})
+        # A FrozenDict held as a value drives _deep_freeze's FrozenDict branch.
+        outer = FrozenDict({'a': inner})
+        self.assertEqual(outer['a']['x'], 1)
+        # The nested value is re-frozen as plain data internally.
+        self.assertNotIsInstance(outer._data['a'], FrozenDict)
+        self.assertEqual(outer._data['a'], {'x': 1})
+
+    def test_repr_uses_pretty_repr(self):
+        """Produce a FrozenDict-prefixed string from __repr__."""
+        fd = FrozenDict({'a': 1})
+        r = repr(fd)
+        self.assertIn('FrozenDict', r)
+        self.assertIn("'a': 1", r)
+
+    def test_hash_with_nested_dict_value(self):
+        """Hash a FrozenDict whose value is a plain dict, wrapping it during hashing."""
+        # Construct with _data holding a raw dict so __hash__ hits the dict branch.
+        fd = FrozenDict({'a': {'b': 1}})
+        h1 = hash(fd)
+        # Cached hash returns the same value on a second call.
+        self.assertEqual(h1, hash(fd))
+        fd2 = FrozenDict({'a': {'b': 1}})
+        self.assertEqual(hash(fd), hash(fd2))
+
+    def test_pretty_repr_empty_frozendict(self):
+        """Render an empty FrozenDict as FrozenDict({})."""
+        fd = FrozenDict({})
+        self.assertEqual(fd.pretty_repr(), 'FrozenDict({})')
+
+    def test_pretty_repr_empty_nested_dict(self):
+        """Render a nested empty dict as {} inside FrozenDict.pretty_repr."""
+        fd = FrozenDict({'a': {}})
+        r = fd.pretty_repr()
+        self.assertIn('FrozenDict', r)
+        self.assertIn("'a': {}", r)
+
+    def test_module_pretty_repr_empty_nested_dict(self):
+        """Render a nested empty dict as {} via the module-level pretty_repr."""
+        r = pretty_repr({'a': {}})
+        self.assertIn("'a': {}", r)
+
+    def test_module_pretty_repr_empty_dict(self):
+        """Render an empty top-level dict as {} via the module-level pretty_repr."""
+        self.assertEqual(pretty_repr({}), '{}')
+
+    def test_copy_pop_items_equality(self):
+        """Cover copy, pop, items, and equality on FrozenDict."""
+        fd = FrozenDict({'a': 1, 'b': 2})
+        # copy with replacement
+        fd2 = fd.copy({'a': 10, 'c': 3})
+        self.assertEqual(fd2['a'], 10)
+        self.assertEqual(fd2['c'], 3)
+        self.assertEqual(fd['a'], 1)
+        # pop returns new dict and value
+        fd3, val = fd.pop('a')
+        self.assertEqual(val, 1)
+        self.assertNotIn('a', fd3)
+        # items view
+        self.assertEqual(dict(fd.items()), {'a': 1, 'b': 2})
+        # equality against dict and FrozenDict
+        self.assertEqual(fd, {'a': 1, 'b': 2})
+        self.assertEqual(fd, FrozenDict({'a': 1, 'b': 2}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Comprehensive test audit of the `brainstate.util` subpackage. Branch coverage
rises from **89% → 97%**, with every module now **≥92%** (all clear the ≥90%
bar). Full project suite: **4408 passed, 19 skipped, 0 failed**.

| Module | Before | After |
|--------|--------|-------|
| `_tracers.py` | 72% | 100% |
| `_pretty_pytree.py` | 80% | 100% |
| `struct.py` | 89% | 99% |
| `_others.py` | 92% | 92% |
| `filter.py` | 96% | 96% |
| `_cache.py` / `_pretty_repr.py` | 99% | 99% |

### New / expanded tests
- **`_tracers_test.py`** (new) — `StateJaxTracer` trace capture, `is_valid()`,
  `__eq__` type-guarding, pretty repr, and inside-jit invalidation.
- **`_pretty_pytree_test.py`** — flat/nest roundtrips, JAX pytree registration
  consistency, and `FlattedDict`/`PrettyList`/`PrettyObject` repr, mutation,
  merge/split, and error paths.
- **`struct_test.py`** — frozen `PyTreeNode` semantics, `replace`, static
  (`pytree_node=False`) fields, and `FrozenDict` freeze/unfreeze/hash.

### Source
No bugs were found in `brainstate.util`. The only source change is a
`# pragma: no cover` comment on the statically-unreachable `jax <= 0.4.33`
branch in `_tracers.current_jax_trace` (comment only, no logic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
