### PR TITLE
test: widen jax<0.10 pmap/empty guards to cover construction

### DIFF
--- a/brainstate/nn/_common_test.py
+++ b/brainstate/nn/_common_test.py
@@ -425,13 +425,15 @@ class TestMapPmapWrapper(unittest.TestCase):
         pmap mode (see ``test_pmap_update_is_broken``).
         """
         m = Map(_ParamModule(), init_map_size=1, behavior='pmap')
-        m.init_all_states(din=3, dout=2)
-        self.assertIn(0, m.dict_vmap_states)
         try:
+            # jax < 0.10 does not support ordered effects (carried by the RNG
+            # state) inside pmap, so the pmap path is unavailable there. The
+            # rejection happens as early as ``init_all_states``, so the whole
+            # pmap interaction is guarded.
+            m.init_all_states(din=3, dout=2)
+            self.assertIn(0, m.dict_vmap_states)
             out = m.map('update')(jnp.ones((1, 3)))
         except ValueError as e:
-            # jax < 0.10 does not support ordered effects (carried by the RNG
-            # state) inside pmap, so the pmap path is unavailable there.
             if 'Ordered effects' in str(e):
                 self.skipTest(f'pmap on this JAX version rejects ordered effects: {e}')
             raise
@@ -445,15 +447,16 @@ class TestMapPmapWrapper(unittest.TestCase):
         keeping the suite green; see report.
         """
         m = Map(_ParamModule(), init_map_size=1, behavior='pmap')
-        m.init_all_states(din=3, dout=2)
         try:
+            # ``init_all_states`` already drives the pmap path; jax < 0.10 rejects
+            # ordered effects there, before the TypeError this test documents.
+            m.init_all_states(din=3, dout=2)
             m.update(jnp.ones((1, 3)))
         except TypeError:
             return  # expected: pmap2 rejects the forwarded spmd_axis_name kwarg
         except ValueError as e:
-            # jax < 0.10 rejects ordered effects in pmap before the TypeError path.
             if 'Ordered effects' in str(e):
-                self.skipTest(f'pmap on this JAX version rejects ordered effects before the TypeError: {e}')
+                self.skipTest(f'pmap on this JAX version rejects ordered effects: {e}')
             raise
         self.fail('expected a TypeError from the invalid pmap2 kwarg, but no error was raised')
 

--- a/brainstate/nn/_event_fixedprob_test.py
+++ b/brainstate/nn/_event_fixedprob_test.py
@@ -165,13 +165,14 @@ class TestFixedNumConnConstruction:
 
     def test_no_replacement_construction_for_loop(self):
         """``allow_multi_conn=False`` with ``conn_init='for_loop'`` builds a valid module."""
-        m = FixedNumConn(20, 40, 0.2, 1.0, seed=3,
-                         allow_multi_conn=False, conn_init='for_loop')
         try:
+            # jax < 0.10 has no evaluation rule for the 'empty' primitive used by
+            # the for_loop construction path in brainevent; the error is raised as
+            # early as ``FixedNumConn`` construction, so guard both it and the call.
+            m = FixedNumConn(20, 40, 0.2, 1.0, seed=3,
+                             allow_multi_conn=False, conn_init='for_loop')
             out = m(brainstate.random.rand(20))
         except NotImplementedError as e:
-            # jax < 0.10 has no evaluation rule for the 'empty' primitive used by
-            # the for_loop construction path in brainevent.
             if 'empty' in str(e):
                 pytest.skip(f"this JAX version lacks an eval rule for the 'empty' primitive: {e}")
             raise


### PR DESCRIPTION
Follow-up to #174. Three nn tests still failed on the jax 0.6/0.7 CI runners because the version-specific errors (`Ordered effects not supported in pmap`, `Evaluation rule for 'empty' not implemented`) are raised one statement *earlier* than the call the guards originally wrapped:

- `_common_test::TestMapPmapWrapper::test_pmap_init_and_map_call` / `test_pmap_update_is_broken` — the `ValueError` originates in `Map.init_all_states` (`_common.py:533`), not the `map`/`update` call.
- `_event_fixedprob_test::TestFixedNumConnConstruction::test_no_replacement_construction_for_loop` — the `NotImplementedError` originates in the `FixedNumConn(...)` constructor, not the forward call.

Each `try/except` is widened to cover the construction/init step so the tests skip correctly on jax < 0.10. All three still run and pass on jax 0.10.1 (guards are no-ops there). Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Broaden version-specific test guards so JAX < 0.10 errors during pmap and for-loop construction are correctly skipped while keeping behavior unchanged on newer JAX versions.

Tests:
- Extend pmap-related tests to guard both initialization and call paths against JAX < 0.10 ordered-effects errors.
- Adjust FixedNumConn for-loop construction test to guard module construction and invocation against missing 'empty' primitive support on older JAX versions.