### PR TITLE
ci: add test coverage badge (Codecov)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,6 +65,12 @@ jobs:
           fi
           coverage report -m
           coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false
 
   type_check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     </a>
     <a href="https://badge.fury.io/py/brainstate"><img alt="PyPI version" src="https://badge.fury.io/py/brainstate.svg"></a>
     <a href="https://github.com/chaobrain/brainstate/actions/workflows/CI.yml"><img alt="Continuous Integration" src="https://github.com/chaobrain/brainstate/actions/workflows/CI.yml/badge.svg"></a>
+    <a href="https://codecov.io/gh/chaobrain/brainstate"><img alt="Code Coverage" src="https://codecov.io/gh/chaobrain/brainstate/branch/main/graph/badge.svg"></a>
     <a href="https://pepy.tech/projects/brainstate"><img src="https://static.pepy.tech/badge/brainstate" alt="PyPI Downloads"></a>
     <a href="https://doi.org/10.5281/zenodo.14970015"><img src="https://zenodo.org/badge/811300394.svg" alt="DOI"></a>
 </p>


### PR DESCRIPTION
## Summary
- Add a **Codecov** coverage badge to the README badge row.
- Wire CI to upload `coverage.xml` to Codecov (it was generated but never uploaded).

## Changes
- **`.github/workflows/CI.yml`** — new `codecov/codecov-action@v5` step in `test_linux`, after `coverage xml`. Runs per matrix entry (5 JAX versions); Codecov merges them. `fail_ci_if_error: false` so a Codecov outage can't break the build.
- **`README.md`** — Codecov badge after the CI badge, using the existing `<a>/<img>` HTML style, pinned to `branch/main`.

## Setup status
- `CODECOV_TOKEN` repository secret: **set**.
- The badge populates after the first upload runs on `main` (i.e. once this merges).

## Notes
- Fork PRs don't get secrets, so their coverage uploads no-op — expected, and harmless given `fail_ci_if_error: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate Codecov coverage reporting into CI and expose coverage status in the README.

Build:
- Add a Codecov upload step to the Linux test job to publish coverage.xml without failing CI on upload errors.

Documentation:
- Display a Codecov coverage badge in the README alongside existing project badges.