### PR TITLE
fix(transform): support state-only vjp + clearer argnums errors, with examples

### DIFF
--- a/brainstate/transform/_vjp_jvp.py
+++ b/brainstate/transform/_vjp_jvp.py
@@ -37,7 +37,7 @@ def vjp(
     fun: Callable,
     *primals,
     grad_states: Optional[Union[State, Sequence[State], Dict[str, State]]] = None,
-    argnums: Union[int, Sequence[int]] = 0,
+    argnums: Optional[Union[int, Sequence[int]]] = 0,
     has_aux: bool = False,
 ):
     """Compute a state-aware vector-Jacobian product (reverse-mode autodiff).
@@ -45,25 +45,54 @@ def vjp(
     Trace ``fun`` (which may read and write :class:`~brainstate.State` objects)
     into a pure function, apply :func:`jax.vjp`, re-thread any written states
     back into their ``State`` objects, and return the primal output together
-    with a pullback function.
+    with a pullback (a.k.a. *cotangent map* or *backward function*).
+
+    Calling the returned ``vjp_fn`` with a cotangent ``v`` (a tangent of the
+    output) yields ``v @ J``, where ``J`` is the Jacobian of ``fun`` evaluated
+    at ``primals``. This is the building block of reverse-mode autodiff: a
+    single forward trace amortizes arbitrarily many backward passes, so it is
+    the natural primitive for full Jacobians (one row per output) and for
+    higher-order products such as Hessian-vector products.
+
+    What ``vjp_fn`` returns depends on ``grad_states`` and ``argnums``,
+    mirroring :func:`brainstate.transform.grad`:
+
+    +----------------+--------------------------+----------------------------+
+    | ``grad_states``| ``argnums``              | ``vjp_fn(v)`` returns      |
+    +================+==========================+============================+
+    | ``None``       | ``int`` / sequence       | ``arg_cotangents``         |
+    +----------------+--------------------------+----------------------------+
+    | provided       | ``int`` / sequence       | ``(state_cts, arg_cts)``   |
+    +----------------+--------------------------+----------------------------+
+    | provided       | ``None`` (or no primals) | ``state_cotangents``       |
+    +----------------+--------------------------+----------------------------+
 
     Parameters
     ----------
     fun : callable
-        Function to be differentiated. It may read/write ``State`` objects. If
-        ``has_aux`` is ``True`` it must return ``(output, aux)``.
+        Function to be differentiated. It may read and/or write ``State``
+        objects. If ``has_aux`` is ``True`` it must return ``(output, aux)``.
     *primals
         Positional arguments at which to evaluate ``fun`` and its pullback.
+        May be omitted entirely when differentiating only with respect to
+        ``grad_states`` (e.g. a parameterized model whose inputs are closed
+        over or supplied through states).
     grad_states : State, sequence of State, or dict of State, optional
-        States to compute cotangents for. When given, the pullback returns
-        ``(state_cotangents, arg_cotangents)``.
-    argnums : int or sequence of int, default 0
+        States to compute cotangents for. The returned state cotangents follow
+        the structure of ``grad_states`` (an unwrapped array for a single
+        ``State``, a list for a sequence, a matching ``dict`` for a mapping).
+        When given, the pullback also returns argument cotangents unless
+        ``argnums`` is ``None`` or no positional ``primals`` are supplied.
+    argnums : int, sequence of int, or None, default 0
         Positional argument(s) to differentiate with respect to. A single
         ``int`` yields an unwrapped argument cotangent; a sequence yields a
-        tuple.
+        tuple, one entry per index. ``None`` disables argument differentiation
+        so the pullback returns only state cotangents (requires
+        ``grad_states``). If ``fun`` is called with no positional ``primals``,
+        argument differentiation is disabled automatically.
     has_aux : bool, default False
         Whether ``fun`` returns ``(output, aux)``. The auxiliary data is not
-        differentiated.
+        differentiated but is returned to the caller.
 
     Returns
     -------
@@ -71,34 +100,170 @@ def vjp(
         The value ``fun(*primals)`` (the first element if ``has_aux``).
     vjp_fn : callable
         Pullback mapping a cotangent of ``primal_out`` to input cotangents.
-        Returns ``arg_cotangents`` when ``grad_states`` is ``None``, else
-        ``(state_cotangents, arg_cotangents)``.
+        The cotangent passed to ``vjp_fn`` must have the same pytree structure,
+        shape, and dtype as ``primal_out``. See the table above for the return
+        structure.
     aux : PyTree
         Returned only when ``has_aux`` is ``True``.
+
+    Raises
+    ------
+    TypeError
+        If any entry of ``grad_states`` is not a :class:`~brainstate.State`.
+    ValueError
+        If a ``grad_state`` is never read by ``fun`` (so its cotangent is
+        undefined), if ``argnums`` is out of range for the given ``primals``,
+        or if there is nothing to differentiate (no ``primals`` and no
+        ``grad_states``).
 
     See Also
     --------
     jvp, grad, jacrev
 
+    Notes
+    -----
+    States that ``fun`` *writes* are re-threaded back into their ``State``
+    objects after the forward trace (the same side effects ``fun`` would have
+    produced if called directly). Differentiation is always taken with respect
+    to the *input* value a state held on entry, so reading-then-writing a
+    ``grad_state`` is well defined.
+
+    Because ``vjp`` traces ``fun`` once and returns a reusable pullback, it is
+    strictly more flexible than :func:`grad` when you need (a) multiple
+    backward passes, (b) a non-scalar output, or (c) a custom cotangent ``v``.
+    Evaluating ``vjp_fn(1.0)`` on a scalar-output ``fun`` reproduces
+    :func:`grad` exactly.
+
     Examples
     --------
+    **Plain reverse-mode autodiff (no states).** ``vjp`` matches
+    :func:`jax.vjp` on a pure function; with a scalar ``int`` ``argnums`` the
+    argument cotangent is returned unwrapped.
+
     .. code-block:: python
 
         >>> import brainstate
         >>> import jax.numpy as jnp
-        >>> w = brainstate.State(jnp.array([2.0, 3.0]))
         >>> def f(x):
-        ...     return jnp.sum(w.value * x)
-        >>> out, vjp_fn = brainstate.transform.vjp(f, jnp.array([5.0, 7.0]), grad_states=w)
-        >>> state_ct, arg_ct = vjp_fn(1.0)
-    """
-    single_arg = isinstance(argnums, int)
-    argnums_t = (argnums,) if single_arg else tuple(argnums)
+        ...     return jnp.sum(x ** 2)
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> out, vjp_fn = brainstate.transform.vjp(f, x)
+        >>> out
+        Array(14., dtype=float32)
+        >>> vjp_fn(1.0)            # d/dx sum(x**2) = 2x
+        Array([2., 4., 6.], dtype=float32)
 
+    **Gradients with respect to states.** Pass ``grad_states`` to also obtain
+    state cotangents. The pullback then returns ``(state_cts, arg_cts)``.
+
+    .. code-block:: python
+
+        >>> w = brainstate.State(jnp.array([2.0, 3.0]))
+        >>> def loss(x):
+        ...     return jnp.sum(w.value * x)
+        >>> x = jnp.array([5.0, 7.0])
+        >>> out, vjp_fn = brainstate.transform.vjp(loss, x, grad_states=w)
+        >>> state_ct, arg_ct = vjp_fn(1.0)
+        >>> state_ct              # d/dw sum(w*x) = x
+        Array([5., 7.], dtype=float32)
+        >>> arg_ct                # d/dx sum(w*x) = w
+        Array([2., 3.], dtype=float32)
+
+    **State-only gradients (no differentiable argument).** This is the typical
+    neural-network case: the loss closes over the trainable parameters, so the
+    pullback returns just the state cotangents.
+
+    .. code-block:: python
+
+        >>> weight = brainstate.State(jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+        >>> bias = brainstate.State(jnp.array([0.0, 0.0]))
+        >>> x = jnp.array([1.0, 1.0])
+        >>> def predict_loss():
+        ...     y = x @ weight.value + bias.value
+        ...     return jnp.sum(y ** 2)
+        >>> out, vjp_fn = brainstate.transform.vjp(predict_loss, grad_states=[weight, bias])
+        >>> grads = vjp_fn(1.0)           # list of state cotangents, no arg cotangent
+        >>> [g.shape for g in grads]
+        [(2, 2), (2,)]
+
+    **Auxiliary data and state write-back.** ``has_aux=True`` returns the side
+    output untouched; states written inside ``fun`` keep their new values.
+
+    .. code-block:: python
+
+        >>> counter = brainstate.State(jnp.array(0.0))
+        >>> def f(x):
+        ...     counter.value = counter.value + 1.0
+        ...     return jnp.sum(x ** 2), {'mean': jnp.mean(x)}
+        >>> x = jnp.array([1.0, 2.0])
+        >>> out, vjp_fn, aux = brainstate.transform.vjp(f, x, has_aux=True)
+        >>> aux['mean']
+        Array(1.5, dtype=float32)
+        >>> vjp_fn(1.0)
+        Array([2., 4.], dtype=float32)
+        >>> float(counter.value)  # write re-threaded back into the State
+        1.0
+
+    **Full Jacobian by reusing the pullback.** One trace, many backward passes:
+    map the pullback over the rows of the identity to build the Jacobian.
+
+    .. code-block:: python
+
+        >>> import jax
+        >>> def f(x):
+        ...     return jnp.array([jnp.sum(x), jnp.sum(x ** 2)])
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> out, vjp_fn = brainstate.transform.vjp(f, x)
+        >>> jac = jax.vmap(vjp_fn)(jnp.eye(2))
+        >>> jac                   # rows are gradients of each output
+        Array([[1., 1., 1.],
+               [2., 4., 6.]], dtype=float32)
+
+    **Multiple arguments.** A sequence ``argnums`` returns a tuple of
+    cotangents, one per requested argument.
+
+    .. code-block:: python
+
+        >>> def f(x, y):
+        ...     return jnp.sum(x * y)
+        >>> x = jnp.array([1.0, 2.0])
+        >>> y = jnp.array([3.0, 4.0])
+        >>> out, vjp_fn = brainstate.transform.vjp(f, x, y, argnums=(0, 1))
+        >>> gx, gy = vjp_fn(1.0)
+        >>> gx, gy                # (d/dx, d/dy) sum(x*y) = (y, x)
+        (Array([3., 4.], dtype=float32), Array([1., 2.], dtype=float32))
+    """
     grad_state_list, grad_tree = _flatten_grad_states(grad_states)
     grad_ids = [id(s) for s in grad_state_list]
     grad_id_set = set(grad_ids)
     has_states = len(grad_state_list) > 0
+
+    # Resolve which positional arguments (if any) to differentiate. Mirrors the
+    # semantics of ``brainstate.transform.grad``:
+    #   * ``argnums=None``      -> differentiate states only (no arg cotangent).
+    #   * no positional primals -> differentiate states only (nothing else).
+    #   * otherwise             -> differentiate the selected positional args.
+    if argnums is None or len(primals) == 0:
+        diff_args = False
+        single_arg = False
+        argnums_t: tuple = ()
+    else:
+        single_arg = isinstance(argnums, int)
+        argnums_t = (argnums,) if single_arg else tuple(argnums)
+        n_primals = len(primals)
+        for i in argnums_t:
+            if not -n_primals <= i < n_primals:
+                raise ValueError(
+                    f"argnums {i} is out of range for a function called with "
+                    f"{n_primals} positional argument(s)."
+                )
+        diff_args = True
+
+    if not diff_args and not has_states:
+        raise ValueError(
+            "vjp has nothing to differentiate: supply positional arguments to "
+            "differentiate (controlled by `argnums`) and/or `grad_states`."
+        )
 
     sf = StatefulFunction(fun, name='vjp', return_only_write=True)
     sf.make_jaxpr(*primals)
@@ -127,10 +292,10 @@ def vjp(
         return [gvals[id(st)] if id(st) in gvals else other_vals[id(st)]
                 for st in state_trace.states]
 
-    def _pure(gvals, diff_args):
+    def _pure(gvals, diff_arg_vals):
         full = list(primals)
         for pos, i in enumerate(argnums_t):
-            full[i] = diff_args[pos]
+            full[i] = diff_arg_vals[pos]
         write_state_vals, raw_out = sf.jaxpr_call(_merge(gvals), *full)
         if has_aux:
             primal_out, aux = raw_out
@@ -147,11 +312,13 @@ def vjp(
 
     def vjp_fn(cotangent):
         gval_ct, diff_arg_ct = pull(cotangent)
-        arg_ct = diff_arg_ct[0] if single_arg else diff_arg_ct
         if has_states:
             state_ct = grad_tree.unflatten([gval_ct[i] for i in grad_ids])
-            return state_ct, arg_ct
-        return arg_ct
+            if diff_args:
+                arg_ct = diff_arg_ct[0] if single_arg else diff_arg_ct
+                return state_ct, arg_ct
+            return state_ct
+        return diff_arg_ct[0] if single_arg else diff_arg_ct
 
     if has_aux:
         return primal_out, vjp_fn, aux

--- a/brainstate/transform/_vjp_jvp_test.py
+++ b/brainstate/transform/_vjp_jvp_test.py
@@ -222,5 +222,259 @@ class TestJvpErrors(unittest.TestCase):
             brainstate.transform.jvp(lambda x: x, (jnp.array(1.0),), 1.0)
 
 
+class TestVjpStateOnly(unittest.TestCase):
+    """State-only differentiation (no differentiable positional argument).
+
+    Regression tests for the bug where ``vjp(loss, grad_states=...)`` with no
+    positional primals crashed with ``IndexError`` because ``argnums`` defaulted
+    to ``0`` and unconditionally indexed ``primals[0]``.
+    """
+
+    def test_no_primals_single_state(self):
+        # The canonical neural-network pattern: loss closes over a parameter.
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        def loss():
+            return jnp.sum(w.value ** 2)
+
+        out, vjp_fn = brainstate.transform.vjp(loss, grad_states=w)
+        state_ct = vjp_fn(1.0)
+        # Pullback returns ONLY the state cotangent (no arg cotangent).
+        self.assertTrue(jnp.allclose(out, jnp.sum(w.value ** 2)))
+        self.assertTrue(jnp.allclose(state_ct, 2.0 * w.value))
+
+    def test_no_primals_matches_grad(self):
+        # State-only vjp pullback at 1.0 must equal brainstate.transform.grad.
+        weight = brainstate.State(jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+        bias = brainstate.State(jnp.array([0.5, -0.5]))
+        x = jnp.array([1.0, 1.0])
+
+        def loss():
+            return jnp.sum((x @ weight.value + bias.value) ** 2)
+
+        out, vjp_fn = brainstate.transform.vjp(loss, grad_states=[weight, bias])
+        gw, gb = vjp_fn(1.0)
+
+        ref = brainstate.transform.grad(loss, grad_states=[weight, bias])
+        ref_gw, ref_gb = ref()
+        self.assertTrue(jnp.allclose(gw, ref_gw))
+        self.assertTrue(jnp.allclose(gb, ref_gb))
+
+    def test_argnums_none_with_primals_present(self):
+        # argnums=None disables arg differentiation even if primals are given.
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        def f(x):
+            return jnp.sum(w.value * x)
+
+        x = jnp.array([5.0, 7.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x, grad_states=w, argnums=None)
+        state_ct = vjp_fn(1.0)
+        # Only state cotangent, returned unwrapped (single State).
+        self.assertTrue(jnp.allclose(state_ct, x))
+        self.assertNotIsInstance(state_ct, tuple)
+
+    def test_no_primals_dict_states(self):
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        def loss():
+            return jnp.sum(w.value ** 2)
+
+        out, vjp_fn = brainstate.transform.vjp(loss, grad_states={'w': w})
+        state_ct = vjp_fn(1.0)
+        self.assertIn('w', state_ct)
+        self.assertTrue(jnp.allclose(state_ct['w'], 2.0 * w.value))
+
+
+class TestVjpArgnumsSemantics(unittest.TestCase):
+    """argnums validation and the three return-structure regimes."""
+
+    def test_out_of_range_argnums_raises_value_error(self):
+        with self.assertRaises(ValueError) as cm:
+            brainstate.transform.vjp(lambda x: jnp.sum(x), jnp.array([1.0]), argnums=5)
+        self.assertIn('out of range', str(cm.exception))
+
+    def test_negative_out_of_range_argnums_raises(self):
+        with self.assertRaises(ValueError):
+            brainstate.transform.vjp(lambda x: jnp.sum(x), jnp.array([1.0]), argnums=-3)
+
+    def test_nothing_to_differentiate_raises(self):
+        # No positional primals and no grad_states -> nothing to differentiate.
+        with self.assertRaises(ValueError) as cm:
+            brainstate.transform.vjp(lambda: jnp.array(5.0))
+        self.assertIn('nothing to differentiate', str(cm.exception))
+
+    def test_negative_argnums(self):
+        def f(x, y):
+            return jnp.sum(x * y ** 2)
+
+        x, y = jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x, y, argnums=-1)
+        g = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(g, 2.0 * x * y))   # d/dy sum(x*y**2)
+
+
+class TestVjpComprehensive(unittest.TestCase):
+    """Cover the documented use cases end to end."""
+
+    def test_vector_output_matches_jax(self):
+        def f(x):
+            return x ** 2
+
+        x = jnp.array([1.0, 2.0, 3.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x)
+        jout, jvjp = jax.vjp(f, x)
+        ct = jnp.array([1.0, 1.0, 1.0])
+        self.assertTrue(jnp.allclose(out, jout))
+        self.assertTrue(jnp.allclose(vjp_fn(ct), jvjp(ct)[0]))
+
+    def test_pytree_output_matches_jax(self):
+        def f(x):
+            return {'a': jnp.sum(x), 'b': jnp.sum(x ** 2)}
+
+        x = jnp.array([1.0, 2.0, 3.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x)
+        jout, jvjp = jax.vjp(f, x)
+        ct = {'a': 1.0, 'b': 1.0}
+        self.assertTrue(jnp.allclose(vjp_fn(ct), jvjp(ct)[0]))
+
+    def test_pytree_input(self):
+        def f(d):
+            return jnp.sum(d['a'] ** 2) + jnp.sum(d['b'])
+
+        d = {'a': jnp.array([1.0, 2.0]), 'b': jnp.array([3.0, 4.0])}
+        out, vjp_fn = brainstate.transform.vjp(f, d)
+        r = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(r['a'], 2.0 * d['a']))
+        self.assertTrue(jnp.allclose(r['b'], jnp.ones_like(d['b'])))
+
+    def test_full_jacobian_via_vmap_pullback(self):
+        def f(x):
+            return jnp.array([jnp.sum(x), jnp.sum(x ** 2), jnp.prod(x)])
+
+        x = jnp.array([1.0, 2.0, 3.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x)
+        jac = jax.vmap(vjp_fn)(jnp.eye(3))
+        self.assertTrue(jnp.allclose(jac, jax.jacrev(f)(x)))
+
+    def test_pullback_reusable_and_linear(self):
+        def f(x):
+            return x ** 2
+
+        x = jnp.array([1.0, 2.0, 3.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x)
+        r1 = vjp_fn(jnp.ones(3))
+        r2 = vjp_fn(2.0 * jnp.ones(3))
+        self.assertTrue(jnp.allclose(r2, 2.0 * r1))   # pullback is linear
+
+    def test_hessian_vector_product_via_nested_vjp(self):
+        def f(x):
+            return jnp.sum(x ** 3)
+
+        x = jnp.array([1.0, 2.0, 3.0])
+        v = jnp.array([1.0, 1.0, 1.0])
+
+        def grad_f(x):
+            _, vjp_fn = brainstate.transform.vjp(f, x)
+            return vjp_fn(1.0)
+
+        _, hvp_fn = brainstate.transform.vjp(grad_f, x)
+        hvp = hvp_fn(v)
+        # Hessian of sum(x**3) is diag(6x); H @ v = 6x.
+        self.assertTrue(jnp.allclose(hvp, 6.0 * x))
+
+    def test_multiple_states_and_args(self):
+        w1 = brainstate.State(jnp.array([2.0, 3.0]))
+        w2 = brainstate.State(jnp.array([0.5, 1.5]))
+
+        def f(x, y):
+            return jnp.sum(w1.value * x ** 2 + w2.value * y)
+
+        x, y = jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0])
+        out, vjp_fn = brainstate.transform.vjp(
+            f, x, y, grad_states=[w1, w2], argnums=(0, 1)
+        )
+        state_ct, arg_ct = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(state_ct[0], x ** 2))           # d/dw1
+        self.assertTrue(jnp.allclose(state_ct[1], y))                # d/dw2
+        self.assertTrue(jnp.allclose(arg_ct[0], 2.0 * w1.value * x)) # d/dx
+        self.assertTrue(jnp.allclose(arg_ct[1], w2.value))           # d/dy
+
+    def test_nested_dict_grad_states_structure(self):
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+        b = brainstate.State(jnp.array([1.0]))
+
+        def f(x):
+            return jnp.sum(w.value * x) + jnp.sum(b.value)
+
+        x = jnp.array([5.0, 7.0])
+        out, vjp_fn = brainstate.transform.vjp(
+            f, x, grad_states={'layer': {'w': w, 'b': b}}
+        )
+        state_ct, arg_ct = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(state_ct['layer']['w'], x))
+        self.assertTrue(jnp.allclose(state_ct['layer']['b'], jnp.array([1.0])))
+
+    def test_readonly_nongrad_state_is_constant(self):
+        const = brainstate.State(jnp.array([10.0, 20.0]))
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        def f(x):
+            return jnp.sum(const.value * w.value * x)
+
+        x = jnp.array([1.0, 1.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x, grad_states=w)
+        state_ct, arg_ct = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(state_ct, const.value * x))
+        self.assertTrue(jnp.allclose(arg_ct, const.value * w.value))
+        # The non-grad read-only state is unchanged.
+        self.assertTrue(jnp.allclose(const.value, jnp.array([10.0, 20.0])))
+
+    def test_grad_state_read_then_written(self):
+        # A grad_state that is read (for the output) and also written.
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        def f(x):
+            old = w.value
+            w.value = w.value + 1.0          # written
+            return jnp.sum(old * x)          # output depends on the OLD value
+
+        x = jnp.array([5.0, 7.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x, grad_states=w)
+        state_ct, arg_ct = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(state_ct, x))                 # d/dw_in
+        self.assertTrue(jnp.allclose(arg_ct, jnp.array([2.0, 3.0])))  # d/dx = w_in
+        self.assertTrue(jnp.allclose(w.value, jnp.array([3.0, 4.0])))  # write-back
+
+    def test_has_aux_with_grad_states(self):
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        def f(x):
+            return jnp.sum(w.value * x), {'norm': jnp.sum(x ** 2)}
+
+        x = jnp.array([5.0, 7.0])
+        out, vjp_fn, aux = brainstate.transform.vjp(
+            f, x, grad_states=w, has_aux=True
+        )
+        state_ct, arg_ct = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(out, jnp.sum(w.value * x)))
+        self.assertTrue(jnp.allclose(aux['norm'], jnp.sum(x ** 2)))
+        self.assertTrue(jnp.allclose(state_ct, x))
+        self.assertTrue(jnp.allclose(arg_ct, w.value))
+
+    def test_state_only_vjp_under_jit(self):
+        w = brainstate.State(jnp.array([2.0, 3.0]))
+
+        @jax.jit
+        def run():
+            out, vjp_fn = brainstate.transform.vjp(
+                lambda: jnp.sum(w.value ** 2), grad_states=w
+            )
+            return out, vjp_fn(1.0)
+
+        out, state_ct = run()
+        self.assertTrue(jnp.allclose(state_ct, 2.0 * w.value))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,12 @@
 - **Typing correctness gate**: a `mypy` configuration with a per-module "ratchet" enforces type correctness in CI, starting with `brainstate.typing`. Coverage expands module-by-module over time.
 - All annotations are evaluated lazily (`from __future__ import annotations`), so they impose no import-time or runtime cost.
 
+### Bug Fixes
+
+- **`brainstate.transform.vjp` now supports state-only differentiation**: calling `vjp(fun, grad_states=...)` with no differentiable positional argument (e.g. a loss that closes over trainable parameters) previously raised `IndexError`. It now returns a pullback yielding just the state cotangents, matching `brainstate.transform.grad` semantics.
+- **`brainstate.transform.vjp` accepts `argnums=None`**: like `grad`, `argnums=None` disables positional-argument differentiation so the pullback returns only state cotangents.
+- **Clearer `vjp` errors**: out-of-range `argnums` now raises a descriptive `ValueError` instead of a bare `IndexError`, and supplying neither positional primals nor `grad_states` raises an explanatory `ValueError`.
+
 
 ## Version 0.3.0
 


### PR DESCRIPTION
`brainstate.transform.vjp` previously crashed with `IndexError` when called
with `grad_states` but no differentiable positional argument (the canonical
neural-network case, e.g. a loss that closes over trainable parameters),
because `argnums` defaulted to 0 and unconditionally indexed `primals[0]`.

Changes:
- Support state-only differentiation: with no positional primals (or
  `argnums=None`) the pullback now returns just the state cotangents,
  matching `brainstate.transform.grad` semantics.
- Accept `argnums=None` to disable positional-argument differentiation.
- Raise descriptive `ValueError` for out-of-range `argnums` and for the
  "nothing to differentiate" case, instead of a bare `IndexError`.
- Rewrite the `vjp` docstring with comprehensive, runnable NumPy-doc
  examples (plain autodiff, state grads, state-only grads, has_aux +
  write-back, full Jacobian via vmap, multiple args).
- Add 20 tests covering the bug fixes and documented use cases.

Existing behavior is preserved: `vjp(f, x, grad_states=w)` still returns
`(state_ct, arg_ct)`.
