### PR TITLE
fix(transform): trace collectives during shard_map state discovery

### DIFF
--- a/brainstate/transform/_shard_map.py
+++ b/brainstate/transform/_shard_map.py
@@ -130,6 +130,73 @@ def shard_map(
         ...     return data * w.value
         >>> f = brainstate.transform.shard_map(fun, mesh, in_specs=(P('x'),), out_specs=P('x'))
         >>> f(jnp.arange(jax.device_count() * 2, dtype=jnp.float32))  # doctest: +SKIP
+
+    Keep a per-shard buffer by giving a state an explicit partition through
+    ``state_in_specs`` / ``state_out_specs``; the buffer is read and written
+    in place on each device:
+
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax, jax.numpy as jnp
+        >>> from jax.sharding import PartitionSpec as P
+        >>> mesh = jax.make_mesh((jax.device_count(),), ('x',))
+        >>> buffer = brainstate.State(jnp.zeros(jax.device_count() * 2))
+        >>> def accumulate(data):
+        ...     buffer.value = buffer.value + data
+        ...     return data
+        >>> f = brainstate.transform.shard_map(
+        ...     accumulate, mesh, in_specs=(P('x'),), out_specs=P('x'),
+        ...     state_in_specs={buffer: P('x')}, state_out_specs={buffer: P('x')})
+        >>> _ = f(jnp.ones(jax.device_count() * 2))  # doctest: +SKIP
+        >>> buffer.value  # doctest: +SKIP
+
+    Communicate across shards with collectives such as :func:`jax.lax.psum`,
+    referring to the mesh axis by name. Here each device contributes a partial
+    sum and ``psum`` reduces them to the global total (replicated back):
+
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax, jax.numpy as jnp
+        >>> from jax.sharding import PartitionSpec as P
+        >>> mesh = jax.make_mesh((jax.device_count(),), ('x',))
+        >>> def global_sum(data):
+        ...     return jax.lax.psum(jnp.sum(data, keepdims=True), axis_name='x')
+        >>> f = brainstate.transform.shard_map(
+        ...     global_sum, mesh, in_specs=(P('x'),), out_specs=P())
+        >>> f(jnp.arange(jax.device_count() * 2, dtype=jnp.float32))  # doctest: +SKIP
+
+    ``shard_map`` re-traces ``fun`` on each call to discover its state usage;
+    wrap it in :func:`jax.jit` to amortise that on the hot path:
+
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax, jax.numpy as jnp
+        >>> from jax.sharding import PartitionSpec as P
+        >>> mesh = jax.make_mesh((jax.device_count(),), ('x',))
+        >>> bias = brainstate.State(jnp.array(5.0))
+        >>> f = brainstate.transform.shard_map(
+        ...     lambda data: data + bias.value, mesh,
+        ...     in_specs=(P('x'),), out_specs=P('x'))
+        >>> jit_f = jax.jit(f)
+        >>> jit_f(jnp.arange(jax.device_count() * 2, dtype=jnp.float32))  # doctest: +SKIP
+
+    Multi-axis meshes express combined data- and model-parallel shardings by
+    naming each axis in the :class:`~jax.sharding.PartitionSpec`:
+
+    .. code-block:: python
+
+        >>> import jax, jax.numpy as jnp
+        >>> import brainstate
+        >>> from jax.sharding import PartitionSpec as P
+        >>> n = jax.device_count()
+        >>> mesh2d = jax.make_mesh((n // 2, 2), ('data', 'model'))  # needs n >= 2
+        >>> f = brainstate.transform.shard_map(
+        ...     lambda data: data + 1.0, mesh2d,
+        ...     in_specs=(P('data', 'model'),), out_specs=P('data', 'model'))
+        >>> f(jnp.ones((n // 2, 2)))  # doctest: +SKIP
     """
     arg_specs = tuple(in_specs) if isinstance(in_specs, (tuple, list)) else None
     sin = _prep_spec_table(state_in_specs)
@@ -138,7 +205,10 @@ def shard_map(
     @wraps(fun)
     def wrapped(*args, **kwargs):
         # 1. Discover the states the function touches (shape-independent).
-        sf = StatefulFunction(fun, name='shard_map')
+        #    Pass the mesh axis environment so collectives such as
+        #    ``jax.lax.psum`` inside ``fun`` can be traced during state
+        #    discovery without raising an "unbound axis name" error.
+        sf = StatefulFunction(fun, name='shard_map', axis_env=tuple(mesh.shape.items()))
         sf.make_jaxpr(*args, **kwargs)
         cache = sf.get_arg_cache_key(*args, **kwargs)
         trace = sf.get_state_trace_by_cache(cache)

--- a/brainstate/transform/_shard_map_test.py
+++ b/brainstate/transform/_shard_map_test.py
@@ -223,5 +223,108 @@ class TestSingleInSpec(unittest.TestCase):
         self.assertTrue(jnp.allclose(out, a + b))
 
 
+class TestShardMapUseCases(unittest.TestCase):
+    """Comprehensive use-case coverage mirroring the ``shard_map`` docstring."""
+
+    def setUp(self):
+        self.n = jax.device_count()
+        self.mesh = jax.make_mesh((self.n,), ('x',))
+
+    def test_basic_data_parallel_no_state(self):
+        f = brainstate.transform.shard_map(
+            lambda x: x * 2.0, self.mesh, in_specs=(P('x'),), out_specs=P('x'))
+        x = jnp.arange(self.n * 2, dtype=jnp.float32)
+        out = f(x)
+        self.assertEqual(out.shape, (self.n * 2,))
+        self.assertTrue(jnp.allclose(out, x * 2.0))
+
+    def test_readonly_replicated_param_preserved(self):
+        # A scalar state read but never written is replicated and must keep its
+        # value after the call (write/read restore must not clobber read states).
+        w = brainstate.ParamState(jnp.array(3.0))
+        before = w.value
+        def scale(x):
+            return x * w.value
+        f = brainstate.transform.shard_map(
+            scale, self.mesh, in_specs=(P('x'),), out_specs=P('x'))
+        x = jnp.arange(self.n * 2, dtype=jnp.float32)
+        out = f(x)
+        self.assertTrue(jnp.allclose(out, x * 3.0))
+        self.assertIsNotNone(w.value)
+        self.assertTrue(jnp.allclose(w.value, before))
+
+    def test_readonly_state_repeated_calls(self):
+        w = brainstate.ParamState(jnp.array(2.0))
+        def scale(x):
+            return x * w.value
+        f = brainstate.transform.shard_map(
+            scale, self.mesh, in_specs=(P('x'),), out_specs=P('x'))
+        x = jnp.ones(self.n * 2, dtype=jnp.float32)
+        for _ in range(3):
+            out = f(x)
+            self.assertTrue(jnp.allclose(out, x * 2.0))
+            self.assertTrue(jnp.allclose(w.value, 2.0))
+
+    def test_sharded_state_read_and_update(self):
+        buf = brainstate.State(jnp.arange(self.n * 2, dtype=jnp.float32))
+        def accumulate(x):
+            buf.value = buf.value + x
+            return x
+        f = brainstate.transform.shard_map(
+            accumulate, self.mesh, in_specs=(P('x'),), out_specs=P('x'),
+            state_in_specs={buf: P('x')}, state_out_specs={buf: P('x')})
+        x = jnp.ones(self.n * 2, dtype=jnp.float32)
+        f(x)
+        self.assertTrue(jnp.allclose(buf.value, jnp.arange(self.n * 2) + 1.0))
+
+    def test_collective_psum(self):
+        def global_sum(x):
+            return jax.lax.psum(jnp.sum(x, keepdims=True), axis_name='x')
+        f = brainstate.transform.shard_map(
+            global_sum, self.mesh, in_specs=(P('x'),), out_specs=P())
+        x = jnp.arange(self.n * 4, dtype=jnp.float32)
+        out = f(x)
+        self.assertTrue(jnp.allclose(out, jnp.sum(x)))
+
+    def test_mixed_readonly_param_and_sharded_state(self):
+        w = brainstate.ParamState(jnp.array(2.0))
+        buf = brainstate.State(jnp.zeros(self.n * 2))
+        wbefore = w.value
+        def step(x):
+            y = x * w.value
+            buf.value = buf.value + y
+            return y
+        f = brainstate.transform.shard_map(
+            step, self.mesh, in_specs=(P('x'),), out_specs=P('x'),
+            state_in_specs={buf: P('x')}, state_out_specs={buf: P('x')})
+        x = jnp.arange(self.n * 2, dtype=jnp.float32)
+        out = f(x)
+        self.assertTrue(jnp.allclose(out, x * 2.0))
+        self.assertTrue(jnp.allclose(buf.value, x * 2.0))
+        self.assertTrue(jnp.allclose(w.value, wbefore))
+
+    def test_compose_under_jit(self):
+        bias = brainstate.ParamState(jnp.array(5.0))
+        f = brainstate.transform.shard_map(
+            lambda x: x + bias.value, self.mesh, in_specs=(P('x'),), out_specs=P('x'))
+        run = jax.jit(f)
+        x = jnp.arange(self.n * 2, dtype=jnp.float32)
+        out = run(x)
+        self.assertTrue(jnp.allclose(out, x + 5.0))
+
+    def test_2d_mesh_data_and_model(self):
+        if self.n < 2 or self.n % 2 != 0:
+            self.skipTest('needs an even device count >= 2')
+        d = self.n // 2
+        mesh = jax.make_mesh((d, 2), ('data', 'model'))
+        f = brainstate.transform.shard_map(
+            lambda x: x + 1.0, mesh,
+            in_specs=(P('data', 'model'),), out_specs=P('data', 'model'))
+        x = jnp.arange(d * 2, dtype=jnp.float32).reshape(d, 2)
+        out = f(x)
+        self.assertEqual(out.shape, (d, 2))
+        self.assertTrue(jnp.allclose(out, x + 1.0))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
shard_map discovered the States touched by 'fun' by tracing it with StatefulFunction/make_jaxpr but without the mesh axis environment, so any mesh-axis collective in 'fun' (e.g. jax.lax.psum) failed during state discovery with 'NameError: unbound axis name'. Pass axis_env=tuple(mesh.shape.items()) so collectives trace cleanly during discovery; the real computation still runs under jax.shard_map where the axes are manual.

Also expand the docstring with comprehensive, self-contained examples (replicated read-only params, per-shard state buffers, cross-shard psum, composition under jax.jit, 2D data+model meshes) and add a TestShardMapUseCases suite covering those cases, including a regression test for the collective-tracing bug.
