### PR TITLE
docs(examples): add runnable shard_map, vjp, and jvp transform examples

### DIFF
--- a/examples/012_shard_map_spmd.py
+++ b/examples/012_shard_map_spmd.py
@@ -1,0 +1,241 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+``brainstate.transform.shard_map`` — single-program multiple-data (SPMD) sharding.
+
+``shard_map`` runs a *stateful* function over shards of data placed across a
+device mesh. It is a state-aware wrapper over :func:`jax.shard_map`: positional
+arguments are split per ``in_specs``, :class:`brainstate.State` objects are
+replicated (default) or sharded per ``state_in_specs`` / ``state_out_specs``,
+and any state writes inside the function are threaded back out afterwards.
+
+This script walks through seven self-contained use cases:
+
+1. Basic data-parallel elementwise map (no state).
+2. A replicated read-only parameter (``ParamState`` read but never written).
+3. A *sharded* write-back buffer accumulated in place across calls.
+4. Cross-shard communication with the ``jax.lax.psum`` collective.
+5. Data-parallel evaluation of a ``brainstate.nn`` layer over a batch.
+6. Composition with ``jax.jit`` to amortise the per-call re-trace.
+7. A 2-D mesh combining data- and model- (tensor-) parallelism.
+
+Most machines expose a single device, so we ask XLA to emulate eight CPU
+devices. This MUST happen before JAX is imported, hence it is the very first
+thing the script does.
+"""
+
+import os
+
+# Emulate 8 devices on a single host. Must be set before importing jax.
+os.environ.setdefault('XLA_FLAGS', '--xla_force_host_platform_device_count=8')
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+
+import brainstate
+
+N = jax.device_count()
+print(f"Running shard_map examples across {N} devices: {jax.devices()}\n")
+
+# A 1-D mesh whose single axis we name 'x'. PartitionSpec('x') means "split this
+# array's leading dimension across the devices along the 'x' axis"; PartitionSpec()
+# (empty) means "replicate".
+mesh = jax.make_mesh((N,), ('x',))
+
+
+# -----------------------------------------------------------------------------
+# 1. Basic data-parallel map (no state)
+# -----------------------------------------------------------------------------
+# Each device receives a contiguous slice of ``data`` and applies ``fun`` to it.
+# The global result is the concatenation of every per-shard result, so it is
+# identical to running ``fun`` on the whole array.
+def double(data):
+    return data * 2.0
+
+
+f_double = brainstate.transform.shard_map(
+    double, mesh, in_specs=(P('x'),), out_specs=P('x'),
+)
+data = jnp.arange(N * 2, dtype=jnp.float32)
+out = f_double(data)
+print("1. Data-parallel map (no state)")
+print(f"   in  = {data}")
+print(f"   out = {out}")
+assert jnp.allclose(out, data * 2.0)
+print("   matches data * 2.0\n")
+
+
+# -----------------------------------------------------------------------------
+# 2. Replicated read-only parameter
+# -----------------------------------------------------------------------------
+# A scalar ``ParamState`` is read but never written. By default states are
+# replicated (PartitionSpec()), so every device sees the same value, and the
+# State is left untouched after the call.
+weight = brainstate.ParamState(jnp.array(3.0))
+
+
+def scale(data):
+    return data * weight.value
+
+
+f_scale = brainstate.transform.shard_map(
+    scale, mesh, in_specs=(P('x'),), out_specs=P('x'),
+)
+out = f_scale(data)
+print("2. Replicated read-only parameter")
+print(f"   out = {out}")
+assert jnp.allclose(out, data * 3.0)
+assert jnp.allclose(weight.value, 3.0)  # read-only state preserved
+print("   parameter replicated and preserved after the call\n")
+
+
+# -----------------------------------------------------------------------------
+# 3. Sharded write-back buffer (per-shard accumulation)
+# -----------------------------------------------------------------------------
+# Give a State an explicit P('x') partition so each device keeps its own slice.
+# The buffer is read and written in place; ``state_out_specs`` re-threads the new
+# values back into the State so repeated calls accumulate.
+buffer = brainstate.State(jnp.zeros(N * 2))
+
+
+def accumulate(data):
+    buffer.value = buffer.value + data
+    return data
+
+
+f_accum = brainstate.transform.shard_map(
+    accumulate, mesh, in_specs=(P('x'),), out_specs=P('x'),
+    state_in_specs={buffer: P('x')}, state_out_specs={buffer: P('x')},
+)
+ones = jnp.ones(N * 2)
+for step in range(3):
+    f_accum(ones)
+print("3. Sharded write-back buffer")
+print(f"   buffer after 3 accumulations of ones = {buffer.value}")
+assert jnp.allclose(buffer.value, 3.0)
+print("   each shard accumulated in place\n")
+
+
+# -----------------------------------------------------------------------------
+# 4. Cross-shard communication with a collective (psum)
+# -----------------------------------------------------------------------------
+# Devices are otherwise independent; ``jax.lax.psum`` sums a value across the
+# named mesh axis so every shard ends up with the global total. Here each device
+# contributes a partial sum, and the reduced total is replicated back (out_specs
+# is the empty PartitionSpec).
+def global_sum(data):
+    partial = jnp.sum(data, keepdims=True)
+    return jax.lax.psum(partial, axis_name='x')
+
+
+f_sum = brainstate.transform.shard_map(
+    global_sum, mesh, in_specs=(P('x'),), out_specs=P(),
+)
+data = jnp.arange(N * 4, dtype=jnp.float32)
+out = f_sum(data)
+print("4. Collective psum (global reduction)")
+print(f"   sum over all shards = {out} (expected {jnp.sum(data)})")
+assert jnp.allclose(out, jnp.sum(data))
+print()
+
+
+# -----------------------------------------------------------------------------
+# 5. Data-parallel evaluation of a neural-network layer
+# -----------------------------------------------------------------------------
+# A ``brainstate.nn`` layer's parameters are ordinary States; by default they
+# are replicated, so every device holds the full weights and applies the layer
+# to its own slice of the batch. The result equals a single-device forward pass.
+layer = brainstate.nn.Linear(8, 4)
+batch = brainstate.random.randn(N * 2, 8)
+
+
+def forward(x):
+    return layer(x)
+
+
+f_forward = brainstate.transform.shard_map(
+    forward, mesh, in_specs=(P('x'),), out_specs=P('x'),
+)
+sharded_out = f_forward(batch)
+reference = layer(batch)
+print("5. Data-parallel layer over a batch")
+print(f"   batch {tuple(batch.shape)} -> output {tuple(sharded_out.shape)}")
+assert jnp.allclose(sharded_out, reference, atol=1e-5)
+print("   sharded forward matches single-device forward\n")
+
+
+# -----------------------------------------------------------------------------
+# 6. Composition with jax.jit
+# -----------------------------------------------------------------------------
+# ``shard_map`` re-traces ``fun`` on every call to discover its state usage.
+# Wrapping the sharded function in ``jax.jit`` amortises that on the hot path.
+bias = brainstate.ParamState(jnp.array(5.0))
+
+
+def add_bias(data):
+    return data + bias.value
+
+
+f_bias = brainstate.transform.shard_map(
+    add_bias, mesh, in_specs=(P('x'),), out_specs=P('x'),
+)
+jit_f = jax.jit(f_bias)
+data = jnp.arange(N * 2, dtype=jnp.float32)
+out = jit_f(data)
+print("6. Composition with jax.jit")
+print(f"   jit(shard_map(...)) out = {out}")
+assert jnp.allclose(out, data + 5.0)
+print()
+
+
+# -----------------------------------------------------------------------------
+# 7. 2-D mesh: data + model (tensor) parallelism
+# -----------------------------------------------------------------------------
+# A 2-D mesh names two axes: 'data' (split the batch) and 'model' (split the
+# contraction dimension of a weight matrix). We compute ``y = x @ W`` where the
+# shared inner dimension is sharded across 'model'; each shard produces a partial
+# product, and ``psum`` over the 'model' axis assembles the full result.
+if N >= 2 and N % 2 == 0:
+    d = N // 2
+    mesh2d = jax.make_mesh((d, 2), ('data', 'model'))
+
+    batch_size, d_in, d_out = d * 3, 2 * 4, 5  # divisible by ('data', 'model')
+    x_full = brainstate.random.randn(batch_size, d_in)
+    w_full = brainstate.random.randn(d_in, d_out)
+
+    def tensor_parallel_matmul(x, w):
+        # x: (batch/data, d_in/model)   w: (d_in/model, d_out)
+        partial = x @ w                       # (batch/data, d_out) partial sum
+        return jax.lax.psum(partial, axis_name='model')
+
+    f_tp = brainstate.transform.shard_map(
+        tensor_parallel_matmul, mesh2d,
+        # batch over 'data', contraction dim over 'model'; W rows over 'model'.
+        in_specs=(P('data', 'model'), P('model', None)),
+        out_specs=P('data', None),
+    )
+    y = f_tp(x_full, w_full)
+    reference = x_full @ w_full
+    print("7. 2-D mesh: data + model parallelism")
+    print(f"   mesh {dict(mesh2d.shape)}: x{tuple(x_full.shape)} @ W{tuple(w_full.shape)}"
+          f" -> y{tuple(y.shape)}")
+    assert jnp.allclose(y, reference, atol=1e-4)
+    print("   tensor-parallel matmul matches the dense result\n")
+else:
+    print("7. 2-D mesh example skipped (needs an even device count >= 2)\n")
+
+print("All shard_map examples passed.")

--- a/examples/013_vjp_reverse_mode.py
+++ b/examples/013_vjp_reverse_mode.py
@@ -1,0 +1,236 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+``brainstate.transform.vjp`` — state-aware reverse-mode autodiff.
+
+``vjp`` traces a function (which may read and write :class:`brainstate.State`
+objects), applies :func:`jax.vjp`, and returns the primal output together with a
+*pullback* ``vjp_fn``. Calling ``vjp_fn(v)`` computes ``v @ J`` where ``J`` is
+the Jacobian of the function at the primals. One forward trace amortises any
+number of backward passes, which makes ``vjp`` the natural primitive for full
+Jacobians, custom cotangents, and higher-order products.
+
+What ``vjp_fn`` returns depends on ``grad_states`` and ``argnums``:
+
+    grad_states   argnums                 vjp_fn(v) returns
+    -----------   ---------------------   --------------------------
+    None          int / sequence          arg_cotangents
+    provided      int / sequence          (state_cts, arg_cts)
+    provided      None (or no primals)     state_cotangents
+
+This script demonstrates eight use cases:
+
+1. Plain reverse-mode autodiff (no states); matches ``jax.vjp``.
+2. Gradients with respect to states -> ``(state_ct, arg_ct)``.
+3. State-only gradients (the canonical neural-network case).
+4. ``has_aux=True`` together with a state write-back.
+5. A full Jacobian by reusing the pullback over rows of the identity.
+6. Multiple arguments via a sequence ``argnums``.
+7. A Hessian-vector product (reverse-over-reverse).
+8. A small linear-regression training loop driven by ``vjp``.
+"""
+
+import jax
+import jax.numpy as jnp
+
+import brainstate
+
+
+# -----------------------------------------------------------------------------
+# 1. Plain reverse-mode autodiff (no states)
+# -----------------------------------------------------------------------------
+# With a scalar ``int`` argnums (default 0) the argument cotangent is returned
+# unwrapped. Evaluating ``vjp_fn(1.0)`` on a scalar output reproduces grad(f).
+def f(x):
+    return jnp.sum(x ** 2)
+
+
+x = jnp.array([1.0, 2.0, 3.0])
+out, vjp_fn = brainstate.transform.vjp(f, x)
+grad_x = vjp_fn(1.0)  # d/dx sum(x**2) = 2x
+print("1. Plain reverse-mode autodiff")
+print(f"   f(x) = {out}")
+print(f"   grad = {grad_x}")
+assert jnp.allclose(grad_x, 2.0 * x)
+assert jnp.allclose(grad_x, jax.grad(f)(x))  # cross-check against jax.grad
+print("   matches jax.grad\n")
+
+
+# -----------------------------------------------------------------------------
+# 2. Gradients with respect to states
+# -----------------------------------------------------------------------------
+# Passing ``grad_states`` also produces cotangents for those states; the pullback
+# then returns ``(state_ct, arg_ct)``.
+w = brainstate.ParamState(jnp.array([2.0, 3.0]))
+
+
+def weighted_sum(inp):
+    return jnp.sum(w.value * inp)
+
+
+inp = jnp.array([5.0, 7.0])
+out, vjp_fn = brainstate.transform.vjp(weighted_sum, inp, grad_states=w)
+state_ct, arg_ct = vjp_fn(1.0)
+print("2. Gradients with respect to states")
+print(f"   d/dw sum(w*inp) = {state_ct}  (expected inp = {inp})")
+print(f"   d/dinp sum(w*inp) = {arg_ct}  (expected w = {w.value})")
+assert jnp.allclose(state_ct, inp)
+assert jnp.allclose(arg_ct, w.value)
+print()
+
+
+# -----------------------------------------------------------------------------
+# 3. State-only gradients (canonical neural-network case)
+# -----------------------------------------------------------------------------
+# The loss closes over its trainable parameters and takes no differentiable
+# positional argument, so the pullback returns just the state cotangents (a list
+# matching ``grad_states``). This is exactly what an optimizer consumes.
+weight = brainstate.ParamState(jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+bias = brainstate.ParamState(jnp.array([0.0, 0.0]))
+data = jnp.array([1.0, 1.0])
+
+
+def predict_loss():
+    y = data @ weight.value + bias.value
+    return jnp.sum(y ** 2)
+
+
+out, vjp_fn = brainstate.transform.vjp(predict_loss, grad_states=[weight, bias])
+grad_w, grad_b = vjp_fn(1.0)
+print("3. State-only gradients")
+print(f"   loss = {out}")
+print(f"   grad_w shape {tuple(grad_w.shape)}, grad_b shape {tuple(grad_b.shape)}")
+# Cross-check against brainstate.transform.grad, which targets the same states.
+ref_w, ref_b = brainstate.transform.grad(predict_loss, grad_states=[weight, bias])()
+assert jnp.allclose(grad_w, ref_w) and jnp.allclose(grad_b, ref_b)
+print("   matches brainstate.transform.grad\n")
+
+
+# -----------------------------------------------------------------------------
+# 4. Auxiliary data and state write-back
+# -----------------------------------------------------------------------------
+# ``has_aux=True`` returns a side output untouched by differentiation. Any state
+# the function writes keeps its new value after the trace (the same side effect
+# the function would have produced if called directly).
+counter = brainstate.State(jnp.array(0.0))
+
+
+def loss_with_aux(x):
+    counter.value = counter.value + 1.0  # a step counter, written each call
+    return jnp.sum(x ** 2), {'mean': jnp.mean(x)}
+
+
+x = jnp.array([1.0, 2.0])
+out, vjp_fn, aux = brainstate.transform.vjp(loss_with_aux, x, has_aux=True)
+grad_x = vjp_fn(1.0)
+print("4. Auxiliary data and state write-back")
+print(f"   aux['mean'] = {aux['mean']}")
+print(f"   grad = {grad_x}")
+print(f"   counter after trace = {counter.value}")
+assert jnp.allclose(grad_x, 2.0 * x)
+assert jnp.allclose(counter.value, 1.0)  # write threaded back into the State
+print()
+
+
+# -----------------------------------------------------------------------------
+# 5. Full Jacobian by reusing the pullback
+# -----------------------------------------------------------------------------
+# A single forward trace produces a reusable pullback. Mapping it over the rows
+# of the identity yields one gradient per output row -- i.e. the full Jacobian.
+def vector_fn(x):
+    return jnp.array([jnp.sum(x), jnp.sum(x ** 2)])
+
+
+x = jnp.array([1.0, 2.0, 3.0])
+out, vjp_fn = brainstate.transform.vjp(vector_fn, x)
+jac = jax.vmap(vjp_fn)(jnp.eye(2))  # each row = gradient of one output
+print("5. Full Jacobian from one trace")
+print(f"   Jacobian =\n{jac}")
+assert jnp.allclose(jac, jax.jacrev(vector_fn)(x))  # cross-check against jacrev
+print("   matches jax.jacrev\n")
+
+
+# -----------------------------------------------------------------------------
+# 6. Multiple arguments via a sequence argnums
+# -----------------------------------------------------------------------------
+# A sequence ``argnums`` returns a tuple of cotangents, one per requested index.
+def bilinear(a, b):
+    return jnp.sum(a * b)
+
+
+a = jnp.array([1.0, 2.0])
+b = jnp.array([3.0, 4.0])
+out, vjp_fn = brainstate.transform.vjp(bilinear, a, b, argnums=(0, 1))
+ga, gb = vjp_fn(1.0)
+print("6. Multiple arguments")
+print(f"   d/da = {ga} (expected b), d/db = {gb} (expected a)")
+assert jnp.allclose(ga, b) and jnp.allclose(gb, a)
+print()
+
+
+# -----------------------------------------------------------------------------
+# 7. Hessian-vector product (reverse-over-reverse)
+# -----------------------------------------------------------------------------
+# A pullback differentiates other gradients too. Here we VJP a gradient function
+# to form Hessian-vector products without ever materialising the Hessian.
+def rosen(x):
+    return jnp.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1.0 - x[:-1]) ** 2)
+
+
+x = jnp.array([0.5, 1.5, 2.0])
+grad_fn = jax.grad(rosen)
+_, hvp_fn = brainstate.transform.vjp(grad_fn, x)
+v = jnp.array([1.0, 0.0, 0.0])
+hvp = hvp_fn(v)  # (H @ v) because H is symmetric
+print("7. Hessian-vector product")
+print(f"   H @ v = {hvp}")
+assert jnp.allclose(hvp, jax.hessian(rosen)(x) @ v)  # cross-check
+print("   matches jax.hessian(rosen)(x) @ v\n")
+
+
+# -----------------------------------------------------------------------------
+# 8. A tiny linear-regression training loop driven by vjp
+# -----------------------------------------------------------------------------
+# Fit ``y = 2 x + 1`` with plain SGD. The loss closes over the parameters, so the
+# state-only pullback (vjp_fn(1.0)) directly yields the parameter gradients.
+xs = brainstate.random.uniform(-1.0, 1.0, (128, 1))
+ys = 2.0 * xs + 1.0
+
+slope = brainstate.ParamState(jnp.zeros((1, 1)))
+intercept = brainstate.ParamState(jnp.zeros((1,)))
+
+
+def mse():
+    pred = xs @ slope.value + intercept.value
+    return jnp.mean((pred - ys) ** 2)
+
+
+lr = 0.5
+print("8. Linear-regression training loop")
+for step in range(201):
+    loss, back = brainstate.transform.vjp(mse, grad_states=[slope, intercept])
+    g_slope, g_intercept = back(1.0)
+    slope.value = slope.value - lr * g_slope
+    intercept.value = intercept.value - lr * g_intercept
+    if step % 50 == 0:
+        print(f"   step {step:3d}: loss={float(loss):.5f}, "
+              f"slope={float(slope.value.reshape(())):.3f}, "
+              f"intercept={float(intercept.value.reshape(())):.3f}")
+assert jnp.allclose(slope.value, 2.0, atol=1e-2)
+assert jnp.allclose(intercept.value, 1.0, atol=1e-2)
+print("   converged to slope~2, intercept~1\n")
+
+print("All vjp examples passed.")

--- a/examples/014_jvp_forward_mode.py
+++ b/examples/014_jvp_forward_mode.py
@@ -1,0 +1,194 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+``brainstate.transform.jvp`` — state-aware forward-mode autodiff.
+
+``jvp`` traces a function (which may read and write :class:`brainstate.State`
+objects), applies :func:`jax.jvp` with respect to its positional arguments, and
+returns ``(primal_out, tangent_out)``. ``tangent_out`` is the directional
+derivative ``J @ v`` of the function along the tangent ``v``: one forward pass
+gives one Jacobian *column* (combination), making forward mode the cheap choice
+when the number of inputs is small (tall Jacobians).
+
+States are treated as constants for the forward pass (zero tangent), but states
+that the function *writes* are still updated afterwards.
+
+This script demonstrates seven use cases:
+
+1. Basic directional derivative of a scalar function.
+2. A JVP with states held constant plus a state write-back.
+3. ``has_aux=True``.
+4. A Jacobian built column-by-column (forward mode); cross-checked vs jacfwd.
+5. Tall vs wide Jacobian intuition (forward mode cheap for few inputs).
+6. Tangent propagation through a small ``brainstate.nn`` network.
+7. A forward-over-reverse Hessian-vector product, cross-checked against the
+   reverse-mode HVP.
+"""
+
+import jax
+import jax.numpy as jnp
+
+import brainstate
+
+
+# -----------------------------------------------------------------------------
+# 1. Basic directional derivative
+# -----------------------------------------------------------------------------
+# ``primals`` and ``tangents`` are tuples matching the function signature. The
+# tangent output is the derivative of ``f`` in the direction of ``tangents``.
+def f(x):
+    return jnp.sum(x ** 2)
+
+
+x = jnp.array([1.0, 2.0, 3.0])
+v = jnp.array([1.0, 0.0, 0.0])
+primal, tangent = brainstate.transform.jvp(f, (x,), (v,))
+print("1. Basic directional derivative")
+print(f"   f(x) = {primal}")
+print(f"   df along v = {tangent}  (expected grad . v = {float(jnp.dot(2.0 * x, v))})")
+assert jnp.allclose(tangent, jnp.dot(2.0 * x, v))
+print()
+
+
+# -----------------------------------------------------------------------------
+# 2. States held constant, with write-back
+# -----------------------------------------------------------------------------
+# State values carry zero tangent (they are constants of the forward pass), so
+# the tangent output depends only on the positional tangent. A state the function
+# writes still receives its new value afterwards.
+gain = brainstate.ParamState(jnp.array(4.0))
+calls = brainstate.State(jnp.array(0.0))
+
+
+def scaled(x):
+    calls.value = calls.value + 1.0  # written: updated after the trace
+    return gain.value * x            # gain: read-only constant
+
+
+x = jnp.array([1.0, 2.0])
+v = jnp.array([1.0, 1.0])
+primal, tangent = brainstate.transform.jvp(scaled, (x,), (v,))
+print("2. States held constant + write-back")
+print(f"   primal = {primal}, tangent = {tangent}  (expected gain * v = {gain.value * v})")
+print(f"   calls after trace = {calls.value}")
+assert jnp.allclose(tangent, gain.value * v)
+assert jnp.allclose(calls.value, 1.0)
+print()
+
+
+# -----------------------------------------------------------------------------
+# 3. Auxiliary data
+# -----------------------------------------------------------------------------
+# ``has_aux=True`` returns a third value that is not differentiated.
+def f_aux(x):
+    return jnp.sum(x ** 3), {'max': jnp.max(x)}
+
+
+x = jnp.array([1.0, 2.0, 3.0])
+v = jnp.array([1.0, 1.0, 1.0])
+primal, tangent, aux = brainstate.transform.jvp(f_aux, (x,), (v,), has_aux=True)
+print("3. Auxiliary data")
+print(f"   primal = {primal}, tangent = {tangent}, aux['max'] = {aux['max']}")
+assert jnp.allclose(tangent, jnp.dot(3.0 * x ** 2, v))
+print()
+
+
+# -----------------------------------------------------------------------------
+# 4. Jacobian column-by-column (forward mode)
+# -----------------------------------------------------------------------------
+# Each JVP with a basis tangent ``e_i`` returns column ``i`` of the Jacobian.
+# Mapping over the basis with ``jax.vmap`` assembles the whole matrix; this is
+# what ``jax.jacfwd`` does under the hood.
+def vector_fn(x):
+    return jnp.array([jnp.sum(x), jnp.sum(x ** 2), jnp.prod(x)])
+
+
+x = jnp.array([1.0, 2.0, 3.0])
+basis = jnp.eye(x.shape[0])
+columns = jax.vmap(lambda e: brainstate.transform.jvp(vector_fn, (x,), (e,))[1])(basis)
+jac = columns.T  # vmap stacks columns along axis 0; transpose to (outputs, inputs)
+print("4. Jacobian column-by-column (forward mode)")
+print(f"   Jacobian =\n{jac}")
+assert jnp.allclose(jac, jax.jacfwd(vector_fn)(x))  # cross-check
+print("   matches jax.jacfwd\n")
+
+
+# -----------------------------------------------------------------------------
+# 5. Tall vs wide Jacobian intuition
+# -----------------------------------------------------------------------------
+# Forward mode costs one pass per *input*; reverse mode one pass per *output*.
+# For a tall Jacobian (few inputs, many outputs), forward mode wins: here 2
+# inputs map to 50 outputs, so 2 JVPs reconstruct the full Jacobian.
+def expand(x):  # R^2 -> R^50
+    freqs = jnp.linspace(1.0, 5.0, 50)
+    return jnp.sin(freqs * x[0]) + jnp.cos(freqs * x[1])
+
+
+x = jnp.array([0.3, 0.7])
+cols = jax.vmap(lambda e: brainstate.transform.jvp(expand, (x,), (e,))[1])(jnp.eye(2))
+jac = cols.T  # (50, 2)
+print("5. Tall Jacobian (R^2 -> R^50)")
+print(f"   Jacobian shape = {tuple(jac.shape)} from just {x.shape[0]} forward passes")
+assert jnp.allclose(jac, jax.jacfwd(expand)(x), atol=1e-5)
+print("   matches jax.jacfwd\n")
+
+
+# -----------------------------------------------------------------------------
+# 6. Tangent propagation through a network
+# -----------------------------------------------------------------------------
+# Push a tangent through a small network's input. The parameters are constant
+# (zero tangent), so the output tangent is the network's Jacobian-vector product
+# w.r.t. the input -- useful for sensitivity analysis.
+net = brainstate.nn.Sequential(
+    brainstate.nn.Linear(3, 8),
+    brainstate.nn.ReLU(),
+    brainstate.nn.Linear(8, 2),
+)
+x = brainstate.random.randn(3)
+v = jnp.array([1.0, 0.0, 0.0])  # perturb only the first input feature
+
+
+def net_fn(inp):
+    return net(inp)
+
+
+primal, tangent = brainstate.transform.jvp(net_fn, (x,), (v,))
+print("6. Tangent propagation through a network")
+print(f"   output = {primal}")
+print(f"   d(output)/d(input_0) = {tangent}")
+assert jnp.allclose(tangent, jax.jacfwd(net_fn)(x) @ v, atol=1e-5)
+print("   matches jacfwd(net)(x) @ v\n")
+
+
+# -----------------------------------------------------------------------------
+# 7. Forward-over-reverse Hessian-vector product
+# -----------------------------------------------------------------------------
+# Composing forward-mode over a reverse-mode gradient gives Hessian-vector
+# products: jvp(grad(f))(x; v) == H(x) @ v. This is typically the cheapest HVP.
+def rosen(x):
+    return jnp.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1.0 - x[:-1]) ** 2)
+
+
+x = jnp.array([0.5, 1.5, 2.0])
+v = jnp.array([1.0, 0.0, 0.0])
+grad_fn = jax.grad(rosen)
+_, hvp = brainstate.transform.jvp(grad_fn, (x,), (v,))
+print("7. Forward-over-reverse Hessian-vector product")
+print(f"   H @ v = {hvp}")
+assert jnp.allclose(hvp, jax.hessian(rosen)(x) @ v)
+print("   matches jax.hessian(rosen)(x) @ v\n")
+
+print("All jvp examples passed.")

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,12 +3,26 @@
 We provide several kinds of examples to demonstrate the usage of the ``brainstate`` library. The examples are organized
 in the following categories:
 
-- The files with name started with ``0__`` are the examples for deep neural networks.
+- The files with name started with ``0__`` are the examples for deep neural networks and the functional /
+  transform API.
 - The files with name started with ``1__`` are the examples for brain simulation models, especially spiking neural
   networks.
 - The files with name started with ``2__`` are the examples for brain-inspired computing models, especially training
   spiking neural networks.
 - The files with name started with ``3__`` are the examples for rate-based recurrent neural networks.
+
+## State-aware transforms (autodiff & parallelism)
+
+Self-contained, runnable walkthroughs of the state-aware
+``brainstate.transform`` primitives:
+
+- ``012_shard_map_spmd.py`` — single-program multiple-data sharding across a
+  device mesh with ``shard_map`` (data parallelism, replicated/sharded states,
+  collectives, ``jit`` composition, and 2-D data + model parallelism).
+- ``013_vjp_reverse_mode.py`` — reverse-mode autodiff with ``vjp`` (state
+  gradients, full Jacobians, Hessian-vector products, a training loop).
+- ``014_jvp_forward_mode.py`` — forward-mode autodiff with ``jvp`` (directional
+  derivatives, column-by-column Jacobians, forward-over-reverse HVPs).
 
 
 


### PR DESCRIPTION
Add three self-contained, runnable example scripts demonstrating the
state-aware brainstate.transform autodiff and parallelism primitives:

- examples/012_shard_map_spmd.py: SPMD sharding across a device mesh —
  data-parallel maps, replicated and sharded states, the psum collective,
  jit composition, and 2-D data + model (tensor) parallelism.
- examples/013_vjp_reverse_mode.py: reverse-mode autodiff — plain vjp,
  state gradients, state-only gradients, has_aux write-back, full Jacobian
  via pullback reuse, multi-arg argnums, Hessian-vector products, and a
  linear-regression training loop.
- examples/014_jvp_forward_mode.py: forward-mode autodiff — directional
  derivatives, states-as-constants, has_aux, column-by-column Jacobians,
  tall-Jacobian intuition, network tangent propagation, and a
  forward-over-reverse HVP.

Each script cross-checks its results against jax (grad/jacrev/jacfwd/
hessian) or brainstate.transform.grad and asserts agreement. Also lists
the new examples in examples/README.md.
