### PR TITLE
refactor(transform): move shard_map version resolution into _compatible_import

### DIFF
--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -42,6 +42,7 @@ Examples:
     >>> # These imports work across different JAX versions
 """
 
+import inspect
 from functools import partial
 from typing import Iterable, TypeVar, Callable
 
@@ -99,6 +100,10 @@ __all__ = [
     'new_jaxpr_eqn',
     'no_effects',
     'valid_jaxtype',
+
+    # shard_map
+    'jax_shard_map',
+    'SHARD_MAP_CHECK_KW',
 ]
 
 
@@ -389,3 +394,18 @@ def is_jit_primitive(eqn: JaxprEqn) -> bool:
         return eqn.primitive.name in ['pjit', 'xla_call']
     else:
         return eqn.primitive.name in ['jit', 'xla_call']
+
+
+# Resolve jax.shard_map across versions: it was promoted to the top level in
+# JAX 0.8.0 (with the ``check_vma`` flag); older releases (0.6.x/0.7.x) expose
+# it as ``jax.experimental.shard_map.shard_map`` with a ``check_rep`` flag.
+jax_shard_map = getattr(jax, 'shard_map', None)
+if jax_shard_map is None:  # pragma: no cover - depends on installed jax
+    from jax.experimental.shard_map import shard_map as jax_shard_map
+_shard_map_params = set(inspect.signature(jax_shard_map).parameters)
+if 'check_vma' in _shard_map_params:
+    SHARD_MAP_CHECK_KW = 'check_vma'
+elif 'check_rep' in _shard_map_params:
+    SHARD_MAP_CHECK_KW = 'check_rep'
+else:  # pragma: no cover - unexpected jax signature
+    SHARD_MAP_CHECK_KW = None

--- a/brainstate/transform/_shard_map.py
+++ b/brainstate/transform/_shard_map.py
@@ -13,32 +13,18 @@
 # limitations under the License.
 # ==============================================================================
 
-import inspect
 from functools import wraps
 from typing import Callable, Dict, Optional, Union
 
 import jax
 from jax.sharding import NamedSharding, PartitionSpec
 
+from brainstate._compatible_import import jax_shard_map, SHARD_MAP_CHECK_KW
 from brainstate._state import State
 from brainstate._utils import set_module_as
 from ._make_jaxpr import StatefulFunction
 
 __all__ = ['shard_map']
-
-# Resolve jax.shard_map across versions: it was promoted to the top level in
-# JAX 0.8.0 (with the ``check_vma`` flag); older releases (0.6.x/0.7.x) expose
-# it as ``jax.experimental.shard_map.shard_map`` with a ``check_rep`` flag.
-_jax_shard_map = getattr(jax, 'shard_map', None)
-if _jax_shard_map is None:  # pragma: no cover - depends on installed jax
-    from jax.experimental.shard_map import shard_map as _jax_shard_map
-_shard_map_params = set(inspect.signature(_jax_shard_map).parameters)
-if 'check_vma' in _shard_map_params:
-    _CHECK_KW = 'check_vma'
-elif 'check_rep' in _shard_map_params:
-    _CHECK_KW = 'check_rep'
-else:  # pragma: no cover - unexpected jax signature
-    _CHECK_KW = None
 
 
 def _prep_spec_table(table):
@@ -252,9 +238,9 @@ def shard_map(
             in_specs=(in_state_specs, local_arg_specs),
             out_specs=(out_specs, out_state_specs),
         )
-        if _CHECK_KW is not None:
-            sm_kwargs[_CHECK_KW] = check_vma
-        sharded = _jax_shard_map(pure, **sm_kwargs)
+        if SHARD_MAP_CHECK_KW is not None:
+            sm_kwargs[SHARD_MAP_CHECK_KW] = check_vma
+        sharded = jax_shard_map(pure, **sm_kwargs)
         out, write_vals = sharded(in_state_vals, sharded_args)
 
         # 6. Restore ALL states: writes -> new values, reads -> originals

--- a/brainstate/transform/_shard_map_test.py
+++ b/brainstate/transform/_shard_map_test.py
@@ -109,31 +109,31 @@ class TestShardMap(unittest.TestCase):
 
 
 class TestCheckKwNonePath(unittest.TestCase):
-    """Cover the _CHECK_KW is None branch (line 185->187) via mocking."""
+    """Cover the SHARD_MAP_CHECK_KW is None branch (line 185->187) via mocking."""
 
     def setUp(self):
         self.n = jax.device_count()
         self.mesh = jax.make_mesh((self.n,), ('x',))
 
     def test_check_kw_none_skips_flag(self):
-        """When _CHECK_KW is None, the check flag is not passed to jax.shard_map."""
+        """When SHARD_MAP_CHECK_KW is None, the check flag is not passed to jax.shard_map."""
         import unittest.mock as mock
         import brainstate.transform._shard_map as sm_mod
 
         def fun(data):
             return data * 2.0
 
-        # Temporarily set _CHECK_KW to None and wrap _jax_shard_map to verify no flag is added.
+        # Temporarily set SHARD_MAP_CHECK_KW to None and wrap jax_shard_map to verify no flag is added.
         calls = []
 
-        original_sm = sm_mod._jax_shard_map
+        original_sm = sm_mod.jax_shard_map
 
         def capturing_sm(fn, **kwargs):
             calls.append(set(kwargs.keys()))
             return original_sm(fn, **{k: v for k, v in kwargs.items() if k not in ('check_vma', 'check_rep')}, **({'check_vma': True} if 'check_vma' in inspect.signature(original_sm).parameters else {}))
 
-        with mock.patch.object(sm_mod, '_CHECK_KW', None):
-            with mock.patch.object(sm_mod, '_jax_shard_map', side_effect=capturing_sm):
+        with mock.patch.object(sm_mod, 'SHARD_MAP_CHECK_KW', None):
+            with mock.patch.object(sm_mod, 'jax_shard_map', side_effect=capturing_sm):
                 f = brainstate.transform.shard_map(
                     fun, self.mesh, in_specs=(P('x'),), out_specs=P('x'),
                 )


### PR DESCRIPTION
Consolidate the JAX-version-dependent resolution of shard_map and its
check keyword into the dedicated compatibility module. Exposes
jax_shard_map and SHARD_MAP_CHECK_KW (added to __all__); _shard_map.py
now imports them instead of resolving inline, and drops the now-unused
inspect import.
