### PR TITLE
feat(repr): clean up __repr__ for graph.Node and nn.Module

### DIFF
--- a/brainstate/graph/_node.py
+++ b/brainstate/graph/_node.py
@@ -82,6 +82,39 @@ class Node(PrettyObject, metaclass=GraphNodeMeta):
             clear=_node_clear,
         )
 
+    def __pretty_repr_item__(self, name: str, value: Any) -> tuple[str, Any] | None:
+        """Filter an attribute for the pretty representation.
+
+        Keeps the ``repr`` faithful to the node's *graph state* while removing
+        noise. An attribute is omitted (``None`` is returned) when:
+
+        - its value is ``None`` (carries no information), or
+        - it is listed in :attr:`graph_invisible_attrs`, i.e. it is explicitly
+          excluded from graph flattening and therefore is not part of the node's
+          state.
+
+        Every other attribute is shown unchanged, so private-but-real state
+        (an attribute such as ``_weight`` that is still flattened) remains
+        visible.
+
+        Parameters
+        ----------
+        name : str
+            The attribute name.
+        value : Any
+            The attribute value.
+
+        Returns
+        -------
+        tuple of (str, Any) or None
+            The ``(name, value)`` pair to display, or ``None`` to hide it.
+        """
+        if value is None:
+            return None
+        if name in getattr(self, 'graph_invisible_attrs', ()):
+            return None
+        return name, value
+
     def __deepcopy__(self: G, memo=None) -> G:
         graphdef, state = treefy_split(self)
         # ``state`` is a pytree of ``TreefyState`` whose only leaves are the

--- a/brainstate/graph/_node_test.py
+++ b/brainstate/graph/_node_test.py
@@ -632,5 +632,70 @@ class TestNodeDeepCopy(unittest.TestCase):
         self.assertIsInstance(m2, brainstate.nn.Linear)
 
 
+class TestNodeRepr(unittest.TestCase):
+    """Cover the ``__repr__`` of :class:`Node`."""
+
+    def test_repr_identifies_type(self):
+        """The representation starts with the concrete class name."""
+
+        class MyNode(Node):
+            def __init__(self):
+                self.value = 1
+
+        self.assertTrue(repr(MyNode()).startswith('MyNode('))
+
+    def test_repr_hides_none_values(self):
+        """Attributes whose value is ``None`` are omitted from the repr."""
+
+        class MyNode(Node):
+            def __init__(self):
+                self.kept = 1
+                self.empty = None
+
+        r = repr(MyNode())
+        self.assertIn('kept', r)
+        self.assertNotIn('empty', r)
+
+    def test_repr_hides_invisible_attrs(self):
+        """Attributes excluded from flattening are omitted from the repr."""
+
+        class MyNode(Node):
+            graph_invisible_attrs = ('hidden',)
+
+            def __init__(self):
+                self.shown = 1
+                self.hidden = 2
+
+        r = repr(MyNode())
+        self.assertIn('shown', r)
+        self.assertNotIn('hidden', r)
+
+    def test_repr_keeps_private_but_real_state(self):
+        """A private attribute that is still flattened stays visible."""
+
+        class MyNode(Node):
+            def __init__(self):
+                self._weight = 7
+
+        # ``_weight`` is part of the graph state (it is flattened), so the repr
+        # must mirror that and show it.
+        self.assertIn('_weight', [k for k, _ in _node_flatten(MyNode())[0]])
+        self.assertIn('_weight', repr(MyNode()))
+
+    def test_pretty_repr_item_contract(self):
+        """``__pretty_repr_item__`` returns the expected filtering decisions."""
+
+        class MyNode(Node):
+            graph_invisible_attrs = ('inv',)
+
+            def __init__(self):
+                self.a = 1
+
+        node = MyNode()
+        self.assertEqual(node.__pretty_repr_item__('a', 1), ('a', 1))
+        self.assertIsNone(node.__pretty_repr_item__('a', None))
+        self.assertIsNone(node.__pretty_repr_item__('inv', 5))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/nn/_module.py
+++ b/brainstate/nn/_module.py
@@ -191,8 +191,32 @@ class Module(Node, ParamDesc):
             return out
 
     def __pretty_repr_item__(self, name, value):
+        """Filter an attribute for the pretty representation.
+
+        Builds on :meth:`brainstate.graph.Node.__pretty_repr_item__` (which drops
+        ``None`` values and attributes listed in ``graph_invisible_attrs``) and
+        additionally exposes property-backed private fields under their public
+        name by stripping a single leading underscore (e.g. ``_name`` -> ``name``,
+        ``_in_size`` -> ``in_size``).
+
+        Parameters
+        ----------
+        name : str
+            The attribute name.
+        value : Any
+            The attribute value.
+
+        Returns
+        -------
+        tuple of (str, Any) or None
+            The ``(name, value)`` pair to display, or ``None`` to hide it.
+        """
+        item = super().__pretty_repr_item__(name, value)
+        if item is None:
+            return None
+        name, value = item
         if name.startswith('_'):
-            return None if value is None else (name[1:], value)  # skip the first `_`
+            name = name[1:]  # expose ``_name`` as ``name``, etc.
         return name, value
 
     def __call__(self, *args, **kwargs):

--- a/brainstate/nn/_module_test.py
+++ b/brainstate/nn/_module_test.py
@@ -871,6 +871,44 @@ class TestModuleCall(unittest.TestCase):
         mod = Module(name='abc')
         self.assertIn('abc', repr(mod))
 
+    def test_pretty_repr_item_hides_none_public(self):
+        """A public attribute with a ``None`` value is hidden from the repr."""
+        mod = Module()
+        self.assertIsNone(mod.__pretty_repr_item__('w_mask', None))
+
+    def test_pretty_repr_item_hides_invisible(self):
+        """Attributes listed in ``graph_invisible_attrs`` are hidden."""
+
+        class WithInvisible(Module):
+            graph_invisible_attrs = ('secret',)
+
+        mod = WithInvisible()
+        self.assertIsNone(mod.__pretty_repr_item__('secret', 123))
+
+    def test_repr_identifies_type_and_hides_none(self):
+        """The repr names the class and omits unset (``None``) attributes."""
+
+        class Tiny(Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = 2.0
+                self.bias = None
+
+        r = repr(Tiny())
+        self.assertTrue(r.startswith('Tiny('))
+        self.assertIn('scale', r)
+        self.assertNotIn('bias', r)
+
+    def test_repr_empty_module(self):
+        """A module with only unset attributes renders compactly."""
+        self.assertEqual(repr(Module()), 'Module()')
+
+    def test_repr_linear_omits_none_mask(self):
+        """A ``Linear`` with no weight mask does not show ``w_mask=None``."""
+        r = repr(brainstate.nn.Linear(3, 4))
+        self.assertIn('Linear(', r)
+        self.assertNotIn('w_mask', r)
+
 
 class TestModuleStateCollection(unittest.TestCase):
     """Cover ``states``/``state_trees`` collection and filtering."""


### PR DESCRIPTION
Give Node and Module a professional, focused representation that mirrors
the graph's own notion of relevant state:

- Node gains a __pretty_repr_item__ that hides None-valued attributes and
  attributes listed in graph_invisible_attrs (which are excluded from
  flattening), while keeping private-but-real state visible.
- Module delegates to Node's filter (dropping None and invisible attrs)
  before exposing property-backed fields (_name -> name, _in_size ->
  in_size), so noise like 'w_mask=None' no longer appears.

Add repr tests for both classes.
