### PR TITLE
feat(interop): convert models between brainstate.nn and flax.nnx / flax.linen / equinox

### DIFF
--- a/brainstate/__init__.py
+++ b/brainstate/__init__.py
@@ -36,6 +36,7 @@ from . import random
 from . import transform
 from . import typing
 from . import util
+from . import interop
 # Create deprecated module proxies with scoped APIs
 from ._deprecation import create_deprecated_module_proxy
 from ._error import (

--- a/brainstate/interop/__init__.py
+++ b/brainstate/interop/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Convert standard-layer models between ``brainstate.nn`` and ``flax.nnx`` / ``flax.linen`` /
+``equinox``.
+
+The public functions construct an architecturally-equivalent model in the target framework and
+transfer weights, guaranteeing numerical output-equivalence for everything that converts (single
+layers and ``Sequential`` stacks of registered layers). Unsupported layers / structures raise
+informative errors rather than producing a silently-wrong model.
+
+See Also
+--------
+register_layer_mapping : add a conversion for a custom layer type.
+supported_layers : list the layers convertible for each framework.
+"""
+
+from ._api import (
+    from_nnx, to_nnx,
+    from_linen, to_linen,
+    from_equinox, to_equinox,
+)
+from ._errors import (
+    InteropError,
+    MissingDependencyError,
+    UnmappedLayerError,
+    UnsupportedLayerError,
+    UnsupportedStructureError,
+    MissingShapeError,
+    ConversionError,
+)
+from ._registry import LayerMapping, register_layer_mapping, supported_layers
+
+__all__ = [
+    'from_nnx', 'to_nnx',
+    'from_linen', 'to_linen',
+    'from_equinox', 'to_equinox',
+    'register_layer_mapping', 'supported_layers', 'LayerMapping',
+    'InteropError', 'MissingDependencyError', 'UnmappedLayerError',
+    'UnsupportedLayerError', 'UnsupportedStructureError', 'MissingShapeError',
+    'ConversionError',
+]

--- a/brainstate/interop/_api.py
+++ b/brainstate/interop/_api.py
@@ -1,0 +1,214 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Public conversion functions.
+
+Each function lazily imports its framework adapter (which imports ``flax`` / ``equinox`` and
+registers that framework's layer mappings on first use), so importing ``brainstate`` adds no
+hard dependency on either framework.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ._common import Context
+from ._engine import to_bst, to_foreign
+
+__all__ = [
+    'from_nnx', 'to_nnx',
+    'from_linen', 'to_linen',
+    'from_equinox', 'to_equinox',
+    'ensure_framework_loaded',
+]
+
+_ADAPTERS = {}
+
+
+def ensure_framework_loaded(framework: str):
+    """Import and cache the adapter for ``framework``; raises if the framework is missing."""
+    if framework not in _ADAPTERS:
+        if framework == 'nnx':
+            from ._frameworks._nnx import NnxAdapter
+            _ADAPTERS['nnx'] = NnxAdapter()
+        elif framework == 'linen':
+            from ._frameworks._linen import LinenAdapter
+            _ADAPTERS['linen'] = LinenAdapter()
+        elif framework == 'equinox':
+            from ._frameworks._equinox import EquinoxAdapter
+            _ADAPTERS['equinox'] = EquinoxAdapter()
+        else:
+            raise ValueError(f"Unknown framework: {framework!r}")
+    return _ADAPTERS[framework]
+
+
+def _shape(sample_input):
+    if sample_input is None:
+        return None
+    if hasattr(sample_input, 'shape'):
+        return tuple(sample_input.shape)
+    return tuple(sample_input)
+
+
+# ---------------------------------------------------------------------------
+# flax.nnx
+# ---------------------------------------------------------------------------
+
+def from_nnx(model, *, sample_input=None):
+    """Convert a ``flax.nnx`` model into an equivalent ``brainstate.nn`` model.
+
+    Parameters
+    ----------
+    model : flax.nnx.Module
+        The source model. Either a single registered layer or an ``nnx`` sequential stack.
+    sample_input : array or tuple of int, optional
+        A single *unbatched* example (or its shape). Required when the model contains a
+        convolution or spatial batch-norm layer, whose brainstate equivalents carry a concrete
+        ``in_size``.
+
+    Returns
+    -------
+    brainstate.nn.Module
+        The converted model, weight-equivalent to ``model``.
+
+    Raises
+    ------
+    MissingDependencyError
+        If ``flax`` is not installed.
+    UnmappedLayerError, UnsupportedLayerError, UnsupportedStructureError, MissingShapeError
+        See :mod:`brainstate.interop` error types.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate as bst
+        >>> from flax import nnx
+        >>> src = nnx.Linear(3, 4, rngs=nnx.Rngs(0))
+        >>> dst = bst.interop.from_nnx(src)
+    """
+    adapter = ensure_framework_loaded('nnx')
+    s = _shape(sample_input)
+    return to_bst(model, adapter, Context(sample_input=s, cur_size=s))
+
+
+def to_nnx(model, *, rngs=None):
+    """Convert a ``brainstate.nn`` model into an equivalent ``flax.nnx`` model.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The source model.
+    rngs : flax.nnx.Rngs, optional
+        RNG container used to construct the nnx layers. Construction weights are overwritten
+        immediately, so this only matters if you reuse the ``rngs`` afterwards.
+
+    Returns
+    -------
+    flax.nnx.Module
+        The converted model.
+    """
+    adapter = ensure_framework_loaded('nnx')
+    return to_foreign(model, adapter, Context(rngs=rngs))
+
+
+# ---------------------------------------------------------------------------
+# flax.linen
+# ---------------------------------------------------------------------------
+
+def from_linen(module, params, *, sample_input=None):
+    """Convert a ``flax.linen`` module + params into an equivalent ``brainstate.nn`` model.
+
+    Parameters
+    ----------
+    module : flax.linen.Module
+        The linen module describing the architecture.
+    params : Mapping
+        The variables produced by ``module.init(...)`` (e.g. ``{'params': ..., 'batch_stats':
+        ...}``).
+    sample_input : array or tuple of int, optional
+        Required when the model contains convolution / spatial batch-norm layers.
+
+    Returns
+    -------
+    brainstate.nn.Module
+        The converted model.
+    """
+    adapter = ensure_framework_loaded('linen')
+    s = _shape(sample_input)
+    node = adapter.wrap(module, params)
+    return to_bst(node, adapter, Context(sample_input=s, cur_size=s))
+
+
+def to_linen(model):
+    """Convert a ``brainstate.nn`` model into a ``flax.linen`` ``(module, params)`` pair.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The source model.
+
+    Returns
+    -------
+    tuple
+        ``(linen_module, params)`` where ``params`` is a ``FrozenDict`` accepted by
+        ``linen_module.apply``.
+    """
+    adapter = ensure_framework_loaded('linen')
+    wrapped = to_foreign(model, adapter, Context())
+    return adapter.finalize(wrapped)
+
+
+# ---------------------------------------------------------------------------
+# equinox
+# ---------------------------------------------------------------------------
+
+def from_equinox(model, *, sample_input=None):
+    """Convert an ``equinox`` model into an equivalent ``brainstate.nn`` model.
+
+    Parameters
+    ----------
+    model : equinox.Module
+        The source model. Either a single registered layer or an ``eqx.nn.Sequential``.
+    sample_input : array or tuple of int, optional
+        Required when the model contains convolution layers.
+
+    Returns
+    -------
+    brainstate.nn.Module
+        The converted model.
+    """
+    adapter = ensure_framework_loaded('equinox')
+    s = _shape(sample_input)
+    return to_bst(model, adapter, Context(sample_input=s, cur_size=s))
+
+
+def to_equinox(model, *, key=None):
+    """Convert a ``brainstate.nn`` model into an equivalent ``equinox`` model.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The source model.
+    key : jax PRNG key, optional
+        Key used to construct the equinox layers (weights are overwritten immediately).
+
+    Returns
+    -------
+    equinox.Module
+        The converted model.
+    """
+    adapter = ensure_framework_loaded('equinox')
+    return to_foreign(model, adapter, Context(key=key))

--- a/brainstate/interop/_common.py
+++ b/brainstate/interop/_common.py
@@ -1,0 +1,333 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared interop machinery: lazy imports, conversion context, the framework-adapter base,
+and the *brainstate side* of every conversion.
+
+This module is the single home for brainstate's internal storage layout (which ``State``
+attribute and dict key backs each parameter). Framework adapters call the ``build_*`` and
+``bst_get_*`` / ``bst_set_*`` helpers here; they never reach into brainstate internals
+directly. If a brainstate layer's internal structure changes, only this file changes.
+"""
+
+from __future__ import annotations
+
+import importlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import brainstate.nn as bnn
+import brainstate.random as brandom
+from brainstate.nn import init
+
+from ._errors import MissingDependencyError, MissingShapeError
+
+__all__ = ['Context', 'FrameworkAdapter', 'lazy_import', 'new_key']
+
+_INSTALL_HINTS = {
+    'flax': 'pip install flax',
+    'equinox': 'pip install equinox',
+}
+
+
+def lazy_import(module_name: str):
+    """Import an optional framework module, raising :class:`MissingDependencyError` if absent.
+
+    Parameters
+    ----------
+    module_name : str
+        Top-level package to import (e.g. ``"flax"``, ``"equinox"``).
+
+    Returns
+    -------
+    module
+        The imported module.
+    """
+    top = module_name.split('.')[0]
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as e:
+        hint = _INSTALL_HINTS.get(top, f'pip install {top}')
+        raise MissingDependencyError(top, hint) from e
+
+
+def new_key():
+    """Return a throwaway PRNG key from :mod:`brainstate.random` for foreign construction.
+
+    Weights are overwritten immediately after construction, so the key value is irrelevant;
+    sourcing it from ``brainstate.random`` keeps RNG usage consistent with the rest of the
+    codebase.
+    """
+    return brandom.split_key()
+
+
+@dataclass
+class Context:
+    """Threaded state for a single conversion call.
+
+    Parameters
+    ----------
+    sample_input : tuple of int, optional
+        Unbatched input shape (brainstate convention, no batch dim) used to materialize the
+        concrete ``in_size`` of spatial layers (``Conv``, spatial ``BatchNorm``) during import.
+    cur_size : tuple of int, optional
+        The running input size as the engine walks a ``Sequential`` during import. Advanced to
+        each brainstate layer's ``out_size`` after it is built.
+    """
+
+    sample_input: Optional[Tuple[int, ...]] = None
+    cur_size: Optional[Tuple[int, ...]] = None
+    rngs: object = None  # optional user-supplied nnx.Rngs for export construction
+    key: object = None   # optional user-supplied PRNG key for equinox export construction
+
+    def require_size(self, layer_name: str) -> Tuple[int, ...]:
+        """Return the current spatial input size, or raise :class:`MissingShapeError`."""
+        if self.cur_size is None:
+            raise MissingShapeError(
+                f"Importing `{layer_name}` requires the spatial input shape, but no "
+                f"`sample_input` was provided. Pass `sample_input=<a single unbatched example "
+                f"or its shape>` to the conversion function."
+            )
+        return tuple(self.cur_size)
+
+
+class FrameworkAdapter(ABC):
+    """Generic, layer-agnostic structural plumbing for one framework.
+
+    Concrete adapters know how to recurse a model's containers and build a ``Sequential`` in
+    their framework. Per-layer parameter read/write lives in the registered mappings, not here.
+    """
+
+    name: str
+
+    @abstractmethod
+    def is_sequential(self, node) -> bool:
+        """Whether ``node`` is a supported sequential stack."""
+
+    @abstractmethod
+    def iter_children(self, node):
+        """Yield ``(key, child)`` for a sequential node, in forward order."""
+
+    @abstractmethod
+    def has_child_modules(self, node) -> bool:
+        """Whether ``node`` holds sub-modules (used to flag custom-forward containers)."""
+
+    @abstractmethod
+    def layer_type(self, node) -> type:
+        """The concrete leaf type used for registry lookup."""
+
+    @abstractmethod
+    def build_sequential(self, children: list):
+        """Build a framework-native sequential container from converted ``children``."""
+
+
+# ---------------------------------------------------------------------------
+# brainstate side: builders + accessors (the only place brainstate paths live)
+# ---------------------------------------------------------------------------
+
+def _zeros_init():
+    return init.ZeroInit()
+
+
+# --- Linear ---------------------------------------------------------------
+
+def build_linear(in_features: int, out_features: int, has_bias: bool):
+    """Construct a brainstate ``Linear`` with the given feature sizes and bias flag."""
+    return bnn.Linear(in_features, out_features,
+                      b_init=_zeros_init() if has_bias else None)
+
+
+def bst_get_linear(layer):
+    """Return ``(weight, bias_or_None)`` of a brainstate ``Linear``/``Conv``."""
+    d = layer.weight.value
+    return d['weight'], d.get('bias', None)
+
+
+def bst_set_linear(layer, weight, bias):
+    """Write weight (and optional bias) of a brainstate ``Linear``/``Conv``."""
+    d = {'weight': weight}
+    if bias is not None:
+        d['bias'] = bias
+    layer.weight.value = d
+
+
+# --- Embedding ------------------------------------------------------------
+
+def build_embedding(num_embeddings: int, embedding_size: int):
+    """Construct a brainstate ``Embedding``."""
+    return bnn.Embedding(num_embeddings, embedding_size)
+
+
+def bst_get_embedding(layer):
+    """Return the embedding table array."""
+    return layer.weight.value
+
+
+def bst_set_embedding(layer, table):
+    """Write the embedding table array."""
+    layer.weight.value = table
+
+
+# --- Conv -----------------------------------------------------------------
+
+_CONV_CLS = {1: bnn.Conv1d, 2: bnn.Conv2d, 3: bnn.Conv3d}
+
+
+def build_conv(num_spatial_dims, in_size, out_channels, kernel_size,
+               stride, padding, rhs_dilation, groups, has_bias):
+    """Construct a brainstate ``Conv{1,2,3}d`` (channels-last)."""
+    cls = _CONV_CLS[num_spatial_dims]
+    return cls(in_size=tuple(in_size), out_channels=out_channels, kernel_size=kernel_size,
+               stride=stride, padding=padding, rhs_dilation=rhs_dilation, groups=groups,
+               b_init=_zeros_init() if has_bias else None)
+
+
+# Conv shares Linear's weight-dict accessors (bst_get_linear / bst_set_linear).
+
+
+# --- Normalization --------------------------------------------------------
+
+def build_layernorm(in_size, has_scale, has_bias, epsilon):
+    return bnn.LayerNorm(tuple(in_size), use_scale=has_scale, use_bias=has_bias, epsilon=epsilon)
+
+
+def build_rmsnorm(in_size, has_scale, epsilon):
+    return bnn.RMSNorm(tuple(in_size), use_scale=has_scale, epsilon=epsilon)
+
+
+def build_groupnorm(in_size, num_groups, has_scale, has_bias, epsilon):
+    return bnn.GroupNorm(tuple(in_size), num_groups=num_groups,
+                         use_scale=has_scale, use_bias=has_bias, epsilon=epsilon)
+
+
+def bst_get_norm(layer, attr, has_offset):
+    """Return ``(scale_or_None, offset_or_None)`` from a normalization layer.
+
+    Parameters
+    ----------
+    layer : Module
+        The brainstate normalization layer.
+    attr : str
+        The ``State`` attribute holding the affine dict (``"weight"`` for LayerNorm/GroupNorm,
+        ``"scale"`` for RMSNorm).
+    has_offset : bool
+        Whether an offset (bias) role is present.
+    """
+    state = getattr(layer, attr)
+    if state is None:
+        return None, None
+    d = state.value
+    scale = d.get('scale', None)
+    offset = d.get('bias', None) if has_offset else None
+    return scale, offset
+
+
+def bst_set_norm(layer, attr, scale, offset):
+    """Write the affine parameters of a normalization layer."""
+    d = {}
+    if scale is not None:
+        d['scale'] = scale
+    if offset is not None:
+        d['bias'] = offset
+    getattr(layer, attr).value = d
+
+
+# --- BatchNorm ------------------------------------------------------------
+
+_BN_CLS = {1: bnn.BatchNorm1d, 2: bnn.BatchNorm2d, 3: bnn.BatchNorm3d}
+
+
+def build_batchnorm(num_spatial_dims, in_size, epsilon, momentum, affine):
+    """Construct a brainstate ``BatchNorm{1,2,3}d`` (feature axis last)."""
+    cls = _BN_CLS[num_spatial_dims]
+    return cls(in_size=tuple(in_size), epsilon=epsilon, momentum=momentum, affine=affine)
+
+
+def bst_get_batchnorm(layer):
+    """Return ``(scale, offset, running_mean, running_var)`` (any may be ``None``)."""
+    scale = offset = None
+    if layer.weight is not None:
+        d = layer.weight.value
+        scale = d.get('scale', None)
+        offset = d.get('bias', None)
+    rmean = None if layer.running_mean is None else layer.running_mean.value
+    rvar = None if layer.running_var is None else layer.running_var.value
+    return scale, offset, rmean, rvar
+
+
+def bst_set_batchnorm(layer, scale, offset, running_mean, running_var):
+    """Write affine + running statistics of a brainstate ``BatchNorm``."""
+    if layer.weight is not None:
+        layer.weight.value = {'scale': scale, 'bias': offset}
+    if running_mean is not None:
+        layer.running_mean.value = running_mean
+    if running_var is not None:
+        layer.running_var.value = running_var
+
+
+# --- LSTM -----------------------------------------------------------------
+
+def build_lstm(num_in: int, num_out: int):
+    """Construct a brainstate ``LSTMCell``."""
+    return bnn.LSTMCell(num_in, num_out)
+
+
+def bst_get_lstm(layer):
+    """Return ``(W, b)`` of the fused LSTM kernel: ``W`` is ``(in+h, 4h)``, ``b`` is ``(4h,)``."""
+    d = layer.W.weight.value
+    return d['weight'], d['bias']
+
+
+def bst_set_lstm(layer, weight, bias):
+    """Write the fused LSTM kernel."""
+    layer.W.weight.value = {'weight': weight, 'bias': bias}
+
+
+# --- Dropout --------------------------------------------------------------
+
+def build_dropout(prob: float):
+    """Construct a brainstate ``Dropout`` (``prob`` = keep probability)."""
+    return bnn.Dropout(prob)
+
+
+# ---------------------------------------------------------------------------
+# brainstate recurrent cells that have no equivalence-preserving conversion
+# ---------------------------------------------------------------------------
+
+_GRU_REASON = (
+    "GRUCell conversion is unsupported: brainstate's GRU uses the Cho-2014 variant (reset "
+    "applied before the hidden matmul, `Wh([x, r*h])`) while flax/nnx/equinox use the cuDNN "
+    "variant (reset applied after, `r * (W_hn h + b_hn)`). These are mathematically distinct "
+    "and cannot be matched by transferring weights."
+)
+_NO_EQUIV_REASON = (
+    "{name} has no equivalence-preserving counterpart in flax.nnx / flax.linen / equinox "
+    "(no matching cell, or a differing recurrence formulation), so it is not converted."
+)
+
+
+def register_bst_unsupported():
+    """Register brainstate recurrent cells that cannot be converted equivalence-preservingly.
+
+    Idempotent; called by each framework adapter on import.
+    """
+    from ._registry import register_unsupported_bst
+    if hasattr(bnn, 'GRUCell'):
+        register_unsupported_bst(bnn.GRUCell, _GRU_REASON)
+    for cls_name in ('ValinaRNNCell', 'MGUCell', 'URLSTMCell'):
+        cls = getattr(bnn, cls_name, None)
+        if cls is not None:
+            register_unsupported_bst(cls, _NO_EQUIV_REASON.format(name=cls_name))

--- a/brainstate/interop/_conversion_test.py
+++ b/brainstate/interop/_conversion_test.py
@@ -1,0 +1,659 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Forward-equivalence + round-trip conversion tests across nnx / linen / equinox.
+
+Each test builds a model in one framework, converts it, and asserts the converted model produces
+numerically identical output. ``pytest.importorskip`` skips a framework's tests when it is not
+installed.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from absl.testing import absltest
+
+import brainstate
+import brainstate.nn as bnn
+from brainstate import interop
+from brainstate.interop._errors import (ConversionError, MissingDependencyError,
+                                        MissingShapeError, UnmappedLayerError,
+                                        UnsupportedLayerError,
+                                        UnsupportedStructureError)
+
+TOL = dict(rtol=1e-4, atol=1e-4)
+
+
+def _key():
+    return brainstate.random.split_key()
+
+
+def assert_close(a, b, msg=''):
+    np.testing.assert_allclose(np.asarray(a), np.asarray(b), err_msg=msg, **TOL)
+
+
+def bst_forward(layer, x, *, lstm=False, batch=None):
+    """Run a brainstate layer in eval mode and return its output."""
+    with brainstate.environ.context(fit=False):
+        if lstm:
+            layer.init_state(batch)
+            return layer.update(x)
+        return layer(x)
+
+
+# ===========================================================================
+# flax.nnx
+# ===========================================================================
+
+class NnxConversionTest(absltest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+
+    def _rngs(self):
+        return self.nnx.Rngs(_key())
+
+    # --- Linear / Embedding ------------------------------------------------
+
+    def test_linear_import_and_export(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 3)
+        src = nnx.Linear(3, 5, rngs=self._rngs())
+        dst = interop.from_nnx(src)
+        assert_close(src(x), bst_forward(dst, x), 'linear import')
+        # export round-trip
+        back = interop.to_nnx(dst)
+        assert_close(src(x), back(x), 'linear export')
+
+    def test_linear_no_bias(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(2, 3)
+        src = nnx.Linear(3, 5, use_bias=False, rngs=self._rngs())
+        dst = interop.from_nnx(src)
+        self.assertNotIn('bias', dst.weight.value)
+        assert_close(src(x), bst_forward(dst, x), 'linear no-bias')
+
+    def test_embedding(self):
+        nnx = self.nnx
+        src = nnx.Embed(7, 4, rngs=self._rngs())
+        idx = jnp.array([0, 3, 6, 1])
+        dst = interop.from_nnx(src)
+        assert_close(src(idx), bst_forward(dst, idx), 'embed import')
+        assert_close(src(idx), interop.to_nnx(dst)(idx), 'embed export')
+
+    # --- Normalization -----------------------------------------------------
+
+    def test_layernorm(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 6)
+        src = nnx.LayerNorm(6, rngs=self._rngs())
+        # give scale/bias non-trivial values
+        src.scale[...] = brainstate.random.randn(6)
+        src.bias[...] = brainstate.random.randn(6)
+        dst = interop.from_nnx(src)
+        assert_close(src(x), bst_forward(dst, x), 'layernorm import')
+        assert_close(src(x), interop.to_nnx(dst)(x), 'layernorm export')
+
+    def test_rmsnorm(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 6)
+        src = nnx.RMSNorm(6, rngs=self._rngs())
+        src.scale[...] = brainstate.random.randn(6)
+        dst = interop.from_nnx(src)
+        assert_close(src(x), bst_forward(dst, x), 'rmsnorm import')
+        assert_close(src(x), interop.to_nnx(dst)(x), 'rmsnorm export')
+
+    def test_groupnorm(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 8)
+        src = nnx.GroupNorm(8, num_groups=2, rngs=self._rngs())
+        src.scale[...] = brainstate.random.randn(8)
+        src.bias[...] = brainstate.random.randn(8)
+        dst = interop.from_nnx(src)
+        assert_close(src(x), bst_forward(dst, x), 'groupnorm import')
+        assert_close(src(x), interop.to_nnx(dst)(x), 'groupnorm export')
+
+    # --- Conv --------------------------------------------------------------
+
+    def test_conv2d(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(2, 8, 8, 3)
+        src = nnx.Conv(3, 4, (3, 3), rngs=self._rngs())
+        dst = interop.from_nnx(src, sample_input=(8, 8, 3))
+        assert_close(src(x), bst_forward(dst, x), 'conv2d import')
+        assert_close(src(x), interop.to_nnx(dst)(x), 'conv2d export')
+
+    def test_conv1d(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(2, 16, 3)
+        src = nnx.Conv(3, 5, (3,), rngs=self._rngs())
+        dst = interop.from_nnx(src, sample_input=(16, 3))
+        assert_close(src(x), bst_forward(dst, x), 'conv1d import')
+        assert_close(src(x), interop.to_nnx(dst)(x), 'conv1d export')
+
+    # --- BatchNorm ---------------------------------------------------------
+
+    def test_batchnorm_import_export(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 5, 3)
+        src = nnx.BatchNorm(3, use_running_average=True, rngs=self._rngs())
+        src.scale[...] = brainstate.random.randn(3)
+        src.bias[...] = brainstate.random.randn(3)
+        src.mean[...] = brainstate.random.randn(3)
+        src.var[...] = brainstate.random.rand(3) + 0.5
+        dst = interop.from_nnx(src, sample_input=(5, 3))
+        assert_close(src(x), bst_forward(dst, x), 'batchnorm import')
+        assert_close(src(x), interop.to_nnx(dst)(x), 'batchnorm export')
+
+    # --- LSTM --------------------------------------------------------------
+
+    def test_lstm(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(2, 3)
+        src = nnx.LSTMCell(3, 4, rngs=self._rngs())
+        dst = interop.from_nnx(src)
+        h_bst = bst_forward(dst, x, lstm=True, batch=2)
+        carry = (jnp.zeros((2, 4)), jnp.zeros((2, 4)))
+        (_, h_src), _ = src(carry, x)
+        assert_close(h_src, h_bst, 'lstm import')
+        # export
+        back = interop.to_nnx(dst)
+        (_, h_back), _ = back(carry, x)
+        assert_close(h_src, h_back, 'lstm export')
+
+    # --- Dropout / Sequential ----------------------------------------------
+
+    def test_dropout_keep_prob(self):
+        nnx = self.nnx
+        src = nnx.Dropout(0.3, rngs=self._rngs())
+        dst = interop.from_nnx(src)
+        self.assertAlmostEqual(float(dst.prob), 0.7, places=6)
+        back = interop.to_nnx(dst)
+        self.assertAlmostEqual(float(back.rate), 0.3, places=6)
+
+    def test_sequential(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 3)
+        src = nnx.Sequential(
+            nnx.Linear(3, 6, rngs=self._rngs()),
+            nnx.LayerNorm(6, rngs=self._rngs()),
+            nnx.Linear(6, 2, rngs=self._rngs()),
+        )
+        dst = interop.from_nnx(src)
+        self.assertIsInstance(dst, bnn.Sequential)
+        assert_close(src(x), bst_forward(dst, x), 'sequential import')
+        assert_close(src(x), interop.to_nnx(dst)(x), 'sequential export')
+
+    # --- error paths -------------------------------------------------------
+
+    def test_gru_unsupported_both_directions(self):
+        nnx = self.nnx
+        with self.assertRaises(UnsupportedLayerError):
+            interop.from_nnx(nnx.GRUCell(3, 4, rngs=self._rngs()))
+        with self.assertRaises(UnsupportedLayerError):
+            interop.to_nnx(bnn.GRUCell(3, 4))
+
+    def test_unmapped_leaf(self):
+        nnx = self.nnx
+
+        class Custom(nnx.Module):
+            def __init__(self):
+                self.scalar = 1.0
+
+        with self.assertRaises(UnmappedLayerError):
+            interop.from_nnx(Custom())
+
+    def test_unsupported_structure(self):
+        nnx = self.nnx
+        rngs = self._rngs()
+
+        class TwoBranch(nnx.Module):
+            def __init__(self, rngs):
+                self.a = nnx.Linear(3, 3, rngs=rngs)
+                self.b = nnx.Linear(3, 3, rngs=rngs)
+
+        with self.assertRaises(UnsupportedStructureError):
+            interop.from_nnx(TwoBranch(rngs))
+
+    def test_missing_shape_for_conv(self):
+        nnx = self.nnx
+        with self.assertRaises(MissingShapeError):
+            interop.from_nnx(nnx.Conv(3, 4, (3, 3), rngs=self._rngs()))
+
+
+# ===========================================================================
+# flax.linen
+# ===========================================================================
+
+class LinenConversionTest(absltest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nn = pytest.importorskip('flax.linen')
+
+    def _apply(self, module, variables, *args, **kw):
+        return module.apply(variables, *args, **kw)
+
+    def test_linear(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 3)
+        m = nn.Dense(5)
+        v = m.init(_key(), jnp.ones((1, 3)))
+        dst = interop.from_linen(m, v)
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'dense import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, x), m2.apply(v2, x), 'dense export')
+
+    def test_embedding(self):
+        nn = self.nn
+        m = nn.Embed(7, 4)
+        v = m.init(_key(), jnp.array([[0, 1]]))
+        idx = jnp.array([0, 3, 6])
+        dst = interop.from_linen(m, v)
+        assert_close(m.apply(v, idx), bst_forward(dst, idx), 'embed import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, idx), m2.apply(v2, idx), 'embed export')
+
+    def test_layernorm(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 6)
+        m = nn.LayerNorm()
+        v = m.init(_key(), jnp.ones((1, 6)))
+        v = jax.tree_util.tree_map(lambda a: brainstate.random.randn(*a.shape)
+                                   if a.ndim else a, v)
+        dst = interop.from_linen(m, v)
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'layernorm import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, x), m2.apply(v2, x), 'layernorm export')
+
+    def test_rmsnorm(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 6)
+        m = nn.RMSNorm()
+        v = m.init(_key(), jnp.ones((1, 6)))
+        dst = interop.from_linen(m, v)
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'rmsnorm import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, x), m2.apply(v2, x), 'rmsnorm export')
+
+    def test_groupnorm(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 8)
+        m = nn.GroupNorm(num_groups=2)
+        v = m.init(_key(), jnp.ones((1, 8)))
+        dst = interop.from_linen(m, v)
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'groupnorm import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, x), m2.apply(v2, x), 'groupnorm export')
+
+    def test_conv2d(self):
+        nn = self.nn
+        x = brainstate.random.randn(2, 8, 8, 3)
+        m = nn.Conv(features=4, kernel_size=(3, 3))
+        v = m.init(_key(), jnp.ones((1, 8, 8, 3)))
+        dst = interop.from_linen(m, v, sample_input=(8, 8, 3))
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'conv2d import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, x), m2.apply(v2, x), 'conv2d export')
+
+    def test_batchnorm(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 5, 3)
+        m = nn.BatchNorm(use_running_average=True)
+        v = m.init(_key(), jnp.ones((1, 5, 3)))
+        v = jax.tree_util.tree_map(
+            lambda a: brainstate.random.rand(*a.shape) + 0.5 if a.ndim == 1 else a, v)
+        dst = interop.from_linen(m, v, sample_input=(5, 3))
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'batchnorm import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, x), m2.apply(v2, x), 'batchnorm export')
+
+    def test_lstm(self):
+        nn = self.nn
+        x = brainstate.random.randn(2, 3)
+        m = nn.LSTMCell(features=4)
+        carry0 = (jnp.zeros((2, 4)), jnp.zeros((2, 4)))
+        v = m.init(_key(), carry0, jnp.ones((2, 3)))
+        dst = interop.from_linen(m, v)
+        h_bst = bst_forward(dst, x, lstm=True, batch=2)
+        (_, h_src), _ = m.apply(v, carry0, x)
+        assert_close(h_src, h_bst, 'lstm import')
+        m2, v2 = interop.to_linen(dst)
+        (_, h_back), _ = m2.apply(v2, carry0, x)
+        assert_close(h_src, h_back, 'lstm export')
+
+    def test_sequential_import(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 3)
+        m = nn.Sequential([nn.Dense(6), nn.LayerNorm(), nn.Dense(2)])
+        v = m.init(_key(), jnp.ones((1, 3)))
+        dst = interop.from_linen(m, v)
+        self.assertIsInstance(dst, bnn.Sequential)
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'linen seq import')
+
+    def test_sequential_with_dropout(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 3)
+        src = bnn.Sequential(bnn.Linear(3, 6), bnn.Dropout(1.0), bnn.Linear(6, 2))
+        m, v = interop.to_linen(src)
+        # Dropout slot carries no params.
+        self.assertEqual(sorted(v['params'].keys()), ['layers_0', 'layers_2'])
+        assert_close(bst_forward(src, x), m.apply(v, x), 'seq+dropout export')
+
+    def test_unsupported_structure(self):
+        nn = self.nn
+
+        class TwoDense(nn.Module):
+            @nn.compact
+            def __call__(self, x):
+                return nn.Dense(2)(nn.Dense(4)(x))
+
+        m = TwoDense()
+        v = m.init(_key(), jnp.ones((1, 3)))
+        with self.assertRaises(UnsupportedStructureError):
+            interop.from_linen(m, v)
+
+    def test_gru_unsupported(self):
+        nn = self.nn
+        m = nn.GRUCell(features=4)
+        v = m.init(_key(), jnp.zeros((1, 4)), jnp.ones((1, 3)))
+        with self.assertRaises(UnsupportedLayerError):
+            interop.from_linen(m, v)
+
+    def test_missing_shape_for_conv(self):
+        nn = self.nn
+        m = nn.Conv(features=4, kernel_size=(3, 3))
+        v = m.init(_key(), jnp.ones((1, 8, 8, 3)))
+        with self.assertRaises(MissingShapeError):
+            interop.from_linen(m, v)
+
+
+# ===========================================================================
+# equinox
+# ===========================================================================
+
+class EquinoxConversionTest(absltest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.eqx = pytest.importorskip('equinox')
+
+    def test_linear(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(4, 3)
+        src = eqx.nn.Linear(3, 5, key=_key())
+        dst = interop.from_equinox(src)
+        assert_close(jax.vmap(src)(x), bst_forward(dst, x), 'linear import')
+        back = interop.to_equinox(dst)
+        assert_close(jax.vmap(src)(x), jax.vmap(back)(x), 'linear export')
+
+    def test_embedding(self):
+        eqx = self.eqx
+        src = eqx.nn.Embedding(7, 4, key=_key())
+        idx = jnp.array([0, 3, 6])
+        dst = interop.from_equinox(src)
+        assert_close(jax.vmap(src)(idx), bst_forward(dst, idx), 'embed import')
+        back = interop.to_equinox(dst)
+        assert_close(jax.vmap(src)(idx), jax.vmap(back)(idx), 'embed export')
+
+    def test_layernorm(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(4, 6)
+        src = eqx.nn.LayerNorm(6)
+        # set random weight/bias
+        src = eqx.tree_at(lambda m: (m.weight, m.bias), src,
+                          (brainstate.random.randn(6), brainstate.random.randn(6)))
+        dst = interop.from_equinox(src)
+        assert_close(jax.vmap(src)(x), bst_forward(dst, x), 'layernorm import')
+        back = interop.to_equinox(dst)
+        assert_close(jax.vmap(src)(x), jax.vmap(back)(x), 'layernorm export')
+
+    def test_rmsnorm(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(4, 6)
+        src = eqx.nn.RMSNorm(6)
+        src = eqx.tree_at(lambda m: m.weight, src, brainstate.random.randn(6))
+        dst = interop.from_equinox(src)
+        assert_close(jax.vmap(src)(x), bst_forward(dst, x), 'rmsnorm import')
+        back = interop.to_equinox(dst)
+        assert_close(jax.vmap(src)(x), jax.vmap(back)(x), 'rmsnorm export')
+
+    def test_groupnorm(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(4, 8)
+        src = eqx.nn.GroupNorm(groups=2, channels=8)
+        src = eqx.tree_at(lambda m: (m.weight, m.bias), src,
+                          (brainstate.random.randn(8), brainstate.random.randn(8)))
+        dst = interop.from_equinox(src)
+        assert_close(jax.vmap(src)(x), bst_forward(dst, x), 'groupnorm import')
+        back = interop.to_equinox(dst)
+        assert_close(jax.vmap(src)(x), jax.vmap(back)(x), 'groupnorm export')
+
+    def test_conv2d(self):
+        eqx = self.eqx
+        # equinox conv is NCHW, unbatched
+        x_nchw = brainstate.random.randn(2, 3, 8, 8)
+        src = eqx.nn.Conv2d(3, 4, 3, key=_key())
+        dst = interop.from_equinox(src, sample_input=(8, 8, 3))
+        # brainstate is NHWC
+        x_nhwc = jnp.transpose(x_nchw, (0, 2, 3, 1))
+        y_src = jax.vmap(src)(x_nchw)               # (N, out, H, W)
+        y_src_nhwc = jnp.transpose(y_src, (0, 2, 3, 1))
+        assert_close(y_src_nhwc, bst_forward(dst, x_nhwc), 'conv2d import')
+        back = interop.to_equinox(dst)
+        y_back = jnp.transpose(jax.vmap(back)(x_nchw), (0, 2, 3, 1))
+        assert_close(y_src_nhwc, y_back, 'conv2d export')
+
+    def test_lstm(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(2, 3)
+        src = eqx.nn.LSTMCell(3, 4, key=_key())
+
+        def run_src(xi):
+            h, c = src(xi, (jnp.zeros(4), jnp.zeros(4)))
+            return h
+
+        dst = interop.from_equinox(src)
+        h_bst = bst_forward(dst, x, lstm=True, batch=2)
+        assert_close(jax.vmap(run_src)(x), h_bst, 'lstm import')
+        back = interop.to_equinox(dst)
+
+        def run_back(xi):
+            h, c = back(xi, (jnp.zeros(4), jnp.zeros(4)))
+            return h
+
+        assert_close(jax.vmap(run_src)(x), jax.vmap(run_back)(x), 'lstm export')
+
+    def test_dropout_keep_prob(self):
+        eqx = self.eqx
+        src = eqx.nn.Dropout(0.3)
+        dst = interop.from_equinox(src)
+        self.assertAlmostEqual(float(dst.prob), 0.7, places=6)
+        back = interop.to_equinox(dst)
+        self.assertAlmostEqual(float(back.p), 0.3, places=6)
+
+    def test_sequential(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(4, 3)
+        src = eqx.nn.Sequential([
+            eqx.nn.Linear(3, 6, key=_key()),
+            eqx.nn.Linear(6, 2, key=_key()),
+        ])
+        dst = interop.from_equinox(src)
+        self.assertIsInstance(dst, bnn.Sequential)
+        assert_close(jax.vmap(src)(x), bst_forward(dst, x), 'sequential import')
+        back = interop.to_equinox(dst)
+        assert_close(jax.vmap(src)(x), jax.vmap(back)(x), 'sequential export')
+
+    def test_batchnorm_unsupported_both_directions(self):
+        eqx = self.eqx
+        # export bst BatchNorm -> equinox
+        with self.assertRaises(UnsupportedLayerError):
+            interop.to_equinox(bnn.BatchNorm1d((5, 3)))
+        # import equinox BatchNorm -> bst
+        bn = eqx.nn.BatchNorm(input_size=3, axis_name='batch')
+        with self.assertRaises(UnsupportedLayerError):
+            interop.from_equinox(bn)
+
+    def test_gru_unsupported(self):
+        eqx = self.eqx
+        with self.assertRaises(UnsupportedLayerError):
+            interop.from_equinox(eqx.nn.GRUCell(3, 4, key=_key()))
+
+    def test_unsupported_structure(self):
+        eqx = self.eqx
+
+        class TwoLinear(eqx.Module):
+            a: eqx.nn.Linear
+            b: eqx.nn.Linear
+
+            def __init__(self, key):
+                k1, k2 = jax.random.split(key)
+                self.a = eqx.nn.Linear(3, 3, key=k1)
+                self.b = eqx.nn.Linear(3, 3, key=k2)
+
+            def __call__(self, x):
+                return self.b(self.a(x))
+
+        with self.assertRaises(UnsupportedStructureError):
+            interop.from_equinox(TwoLinear(_key()))
+
+
+# ===========================================================================
+# custom mapping + public API + missing dependency
+# ===========================================================================
+
+class CustomMappingTest(absltest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+
+    def test_register_custom_layer_mapping(self):
+        nnx = self.nnx
+        from brainstate.interop import LayerMapping, register_layer_mapping
+
+        # A user-defined nnx leaf wrapping a scale factor.
+        class ScaleLayer(nnx.Module):
+            def __init__(self, factor):
+                self.factor = factor
+
+            def __call__(self, x):
+                return x * self.factor
+
+        # A brainstate counterpart.
+        class BstScale(bnn.Module):
+            def __init__(self, factor):
+                super().__init__()
+                self.factor = factor
+
+            def update(self, x):
+                return x * self.factor
+
+        register_layer_mapping(LayerMapping(
+            BstScale, 'nnx', ScaleLayer,
+            to_bst=lambda m, ctx: BstScale(m.factor),
+            to_foreign=lambda layer, ctx: ScaleLayer(layer.factor),
+        ))
+        x = brainstate.random.randn(3)
+        dst = interop.from_nnx(ScaleLayer(2.0))
+        self.assertIsInstance(dst, BstScale)
+        assert_close(dst.update(x), x * 2.0)
+        back = interop.to_nnx(dst)
+        self.assertIsInstance(back, ScaleLayer)
+
+
+class EngineErrorPathsTest(absltest.TestCase):
+    """Container-structure error paths shared by the generic engine (exercised via nnx)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+
+    def test_empty_sequential_import(self):
+        nnx = self.nnx
+        with self.assertRaises(UnsupportedStructureError):
+            interop.from_nnx(nnx.Sequential())
+
+    def test_bst_custom_container_attr(self):
+        class Container(bnn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = bnn.Linear(3, 3)
+
+            def update(self, x):
+                return x
+
+        with self.assertRaises(UnsupportedStructureError):
+            interop.to_nnx(Container())
+
+    def test_bst_custom_container_list(self):
+        # Children held only inside a list (exercises the list branch of child detection).
+        class Container(bnn.Module):
+            def __init__(self):
+                super().__init__()
+                self.items = [bnn.Linear(3, 3), bnn.Linear(3, 3)]
+
+            def update(self, x):
+                return x
+
+        with self.assertRaises(UnsupportedStructureError):
+            interop.to_nnx(Container())
+
+    def test_bst_custom_container_dict(self):
+        # Children held only inside a dict (exercises the dict branch of child detection).
+        class Container(bnn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mapped = {'x': bnn.Linear(3, 3)}
+
+            def update(self, x):
+                return x
+
+        with self.assertRaises(UnsupportedStructureError):
+            interop.to_nnx(Container())
+
+    def test_bst_unmapped_leaf_export(self):
+        class Leaf(bnn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scalar = 1.0
+
+            def update(self, x):
+                return x
+
+        with self.assertRaises(UnmappedLayerError):
+            interop.to_nnx(Leaf())
+
+
+class PublicApiTest(absltest.TestCase):
+
+    def test_supported_layers_lists_core_types(self):
+        pytest.importorskip('flax.nnx')
+        table = interop.supported_layers('nnx')
+        self.assertIn('nnx', table)
+        self.assertIn('Linear', table['nnx'])
+        self.assertIn('LSTMCell', table['nnx'])
+
+    def test_missing_dependency_error(self):
+        from brainstate.interop._common import lazy_import
+        with self.assertRaises(MissingDependencyError):
+            lazy_import('a_framework_that_does_not_exist_xyz')
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/brainstate/interop/_engine.py
+++ b/brainstate/interop/_engine.py
@@ -1,0 +1,102 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""The generic recursive conversion engine.
+
+``to_bst`` walks a foreign model and builds the brainstate equivalent; ``to_foreign`` does the
+reverse. A node is resolved *leaf-first*: a registered leaf type is converted directly (even if
+it internally holds sub-modules, e.g. an LSTM cell). Only unregistered nodes are considered for
+container treatment, where a ``Sequential`` recurses and any other multi-module node raises an
+informative ``UnsupportedStructureError``.
+"""
+
+from __future__ import annotations
+
+import brainstate.nn as bnn
+
+from ._common import Context, FrameworkAdapter
+from ._errors import (UnmappedLayerError, UnsupportedLayerError,
+                      UnsupportedStructureError)
+from ._registry import (lookup_export, lookup_import, unsupported_bst_reason,
+                        unsupported_foreign_reason)
+
+__all__ = ['to_bst', 'to_foreign']
+
+
+def to_bst(node, adapter: FrameworkAdapter, ctx: Context):
+    """Convert a foreign ``node`` (leaf or ``Sequential``) into a brainstate module."""
+    ftype = adapter.layer_type(node)
+    mapping = lookup_import(adapter.name, ftype)
+    if mapping is not None:
+        bst_layer = mapping.to_bst(node, ctx)
+        out_size = getattr(bst_layer, 'out_size', None)
+        if out_size is not None:
+            ctx.cur_size = tuple(out_size)
+        return bst_layer
+
+    reason = unsupported_foreign_reason(adapter.name, ftype)
+    if reason is not None:
+        raise UnsupportedLayerError(reason)
+
+    if adapter.is_sequential(node):
+        children = [to_bst(child, adapter, ctx) for _, child in adapter.iter_children(node)]
+        if not children:
+            raise UnsupportedStructureError("Cannot convert an empty Sequential container.")
+        return bnn.Sequential(*children)
+
+    if adapter.has_child_modules(node):
+        raise UnsupportedStructureError(
+            f"Cannot convert `{ftype.__name__}`: only single layers and Sequential stacks of "
+            f"registered layers are supported. A container with custom forward logic "
+            f"(skips/branching) cannot be reconstructed."
+        )
+    raise UnmappedLayerError(ftype, adapter.name)
+
+
+def to_foreign(node, adapter: FrameworkAdapter, ctx: Context):
+    """Convert a brainstate ``node`` (leaf or ``Sequential``) into a foreign module."""
+    btype = type(node)
+    mapping = lookup_export(btype, adapter.name)
+    if mapping is not None:
+        return mapping.to_foreign(node, ctx)
+
+    reason = unsupported_bst_reason(btype, adapter.name)
+    if reason is not None:
+        raise UnsupportedLayerError(reason)
+
+    if isinstance(node, bnn.Sequential):
+        children = [to_foreign(child, adapter, ctx) for child in node.layers]
+        if not children:
+            raise UnsupportedStructureError("Cannot convert an empty Sequential container.")
+        return adapter.build_sequential(children)
+
+    if _bst_has_child_modules(node):
+        raise UnsupportedStructureError(
+            f"Cannot convert `{btype.__name__}`: only single layers and Sequential stacks of "
+            f"registered layers are supported. A module with custom forward logic cannot be "
+            f"reconstructed."
+        )
+    raise UnmappedLayerError(btype, adapter.name)
+
+
+def _bst_has_child_modules(node) -> bool:
+    for v in vars(node).values():
+        if isinstance(v, bnn.Module):
+            return True
+        if isinstance(v, (list, tuple)) and any(isinstance(x, bnn.Module) for x in v):
+            return True
+        if isinstance(v, dict) and any(isinstance(x, bnn.Module) for x in v.values()):
+            return True
+    return False

--- a/brainstate/interop/_errors.py
+++ b/brainstate/interop/_errors.py
@@ -1,0 +1,100 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Error types raised by :mod:`brainstate.interop`."""
+
+from __future__ import annotations
+
+from brainstate._error import BrainStateError
+
+__all__ = [
+    'InteropError',
+    'MissingDependencyError',
+    'UnmappedLayerError',
+    'UnsupportedLayerError',
+    'UnsupportedStructureError',
+    'MissingShapeError',
+    'ConversionError',
+]
+
+
+class InteropError(BrainStateError):
+    """Base class for all :mod:`brainstate.interop` errors."""
+
+
+class MissingDependencyError(InteropError):
+    """Raised when an optional framework (``flax`` / ``equinox``) is not installed.
+
+    Parameters
+    ----------
+    package : str
+        The name of the missing package.
+    install_hint : str
+        A ``pip install`` command the user can run.
+    """
+
+    def __init__(self, package: str, install_hint: str):
+        self.package = package
+        super().__init__(
+            f"Converting to/from this framework requires the optional dependency "
+            f"'{package}', which is not installed. Install it with: {install_hint}"
+        )
+
+
+class UnmappedLayerError(InteropError):
+    """Raised when no conversion mapping is registered for a *leaf* layer type."""
+
+    def __init__(self, layer_type: type, framework: str):
+        self.layer_type = layer_type
+        self.framework = framework
+        name = getattr(layer_type, '__name__', repr(layer_type))
+        super().__init__(
+            f"No interop mapping is registered for layer type `{name}` "
+            f"(framework: {framework}). Register one with "
+            f"`brainstate.interop.register_layer_mapping(...)`, or remove the layer "
+            f"from the model before converting."
+        )
+
+
+class UnsupportedLayerError(InteropError):
+    """Raised for a known layer type that is deliberately unsupported in this version.
+
+    The message explains *why* (e.g. a mathematical variant mismatch) so the user is not
+    left guessing.
+    """
+
+
+class UnsupportedStructureError(InteropError):
+    """Raised when a container's forward logic cannot be reconstructed.
+
+    Only single layers and ``Sequential`` stacks of registered layers convert; a module
+    with custom ``__call__`` (skips, branching, attention) raises this error.
+    """
+
+
+class MissingShapeError(InteropError):
+    """Raised when importing a spatial layer (``Conv``/``BatchNorm``) without a sample input.
+
+    brainstate's ``Conv`` and spatial ``BatchNorm`` carry a concrete ``in_size`` (including
+    spatial dimensions) that a framework-agnostic foreign layer does not encode, so a
+    ``sample_input`` is required to materialize them.
+    """
+
+
+class ConversionError(InteropError):
+    """Raised when a weight transfer fails (shape/dtype/unit mismatch).
+
+    The message includes the offending role and the shapes involved.
+    """

--- a/brainstate/interop/_frameworks/_equinox.py
+++ b/brainstate/interop/_frameworks/_equinox.py
@@ -1,0 +1,312 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""equinox adapter + layer mappings.
+
+equinox is torch-like: Linear weight is ``(out, in)`` and Conv weight is ``(out, in, *k)``
+(NCHW), so kernels need transpose/permute relative to brainstate's flax-style layout. equinox
+modules are immutable pytrees, so parameters are written via ``eqx.tree_at``.
+"""
+
+from __future__ import annotations
+
+import brainunit as u
+
+from .. import _common as C
+from .._common import FrameworkAdapter, lazy_import, new_key
+from .._errors import ConversionError
+from .._registry import (LayerMapping, register_layer_mapping,
+                         register_unsupported_bst_for, register_unsupported_foreign)
+
+eqx = lazy_import('equinox')
+import brainstate.nn as bnn  # noqa: E402
+
+_CONV = {1: eqx.nn.Conv1d, 2: eqx.nn.Conv2d, 3: eqx.nn.Conv3d}
+
+
+def _set(module, **fields):
+    """Return ``module`` with the named array fields replaced (immutable update)."""
+    names = list(fields.keys())
+    return eqx.tree_at(lambda m: [getattr(m, n) for n in names], module,
+                       [fields[n] for n in names])
+
+
+def _split4(arr, axis=-1):
+    return list(u.math.split(arr, 4, axis=axis))
+
+
+# ---------------------------------------------------------------------------
+# Linear  (bst (in,out) <-> eqx (out,in))
+# ---------------------------------------------------------------------------
+
+def _linear_to_bst(m, ctx):
+    w = u.math.transpose(m.weight, (1, 0))   # (out,in) -> (in,out)
+    has_bias = m.bias is not None
+    layer = C.build_linear(w.shape[0], w.shape[1], has_bias)
+    C.bst_set_linear(layer, w, m.bias if has_bias else None)
+    return layer
+
+
+def _linear_to_foreign(layer, ctx):
+    w, b = C.bst_get_linear(layer)
+    m = eqx.nn.Linear(w.shape[0], w.shape[1], use_bias=b is not None, key=ctx.key or new_key())
+    m = _set(m, weight=u.math.transpose(w, (1, 0)))
+    if b is not None:
+        m = _set(m, bias=b)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Embedding
+# ---------------------------------------------------------------------------
+
+def _embed_to_bst(m, ctx):
+    table = m.weight
+    layer = C.build_embedding(table.shape[0], table.shape[1])
+    C.bst_set_embedding(layer, table)
+    return layer
+
+
+def _embed_to_foreign(layer, ctx):
+    table = C.bst_get_embedding(layer)
+    m = eqx.nn.Embedding(table.shape[0], table.shape[1], key=ctx.key or new_key())
+    return _set(m, weight=table)
+
+
+# ---------------------------------------------------------------------------
+# LayerNorm / RMSNorm / GroupNorm  (1-D affine vectors -> identity)
+# ---------------------------------------------------------------------------
+
+def _layernorm_to_bst(m, ctx):
+    scale = m.weight
+    bias = m.bias
+    num = (scale if scale is not None else bias).shape[0]
+    layer = C.build_layernorm((num,), scale is not None, bias is not None, float(m.eps))
+    C.bst_set_norm(layer, 'weight', scale, bias)
+    return layer
+
+
+def _layernorm_to_foreign(layer, ctx):
+    scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
+    num = (scale if scale is not None else offset).shape[0]
+    m = eqx.nn.LayerNorm(num, eps=float(layer.epsilon),
+                         use_weight=scale is not None, use_bias=offset is not None)
+    if scale is not None:
+        m = _set(m, weight=scale)
+    if offset is not None:
+        m = _set(m, bias=offset)
+    return m
+
+
+def _rmsnorm_to_bst(m, ctx):
+    scale = m.weight
+    num = scale.shape[0]
+    layer = C.build_rmsnorm((num,), scale is not None, float(m.eps))
+    C.bst_set_norm(layer, 'scale', scale, None)
+    return layer
+
+
+def _rmsnorm_to_foreign(layer, ctx):
+    scale, _ = C.bst_get_norm(layer, 'scale', has_offset=False)
+    num = scale.shape[0]
+    # brainstate RMSNorm has no offset -> use_bias=False
+    m = eqx.nn.RMSNorm(num, eps=float(layer.epsilon), use_weight=True, use_bias=False)
+    return _set(m, weight=scale)
+
+
+def _groupnorm_to_bst(m, ctx):
+    scale = m.weight
+    bias = m.bias
+    num = m.channels
+    layer = C.build_groupnorm((num,), int(m.groups), scale is not None, bias is not None,
+                              float(m.eps))
+    C.bst_set_norm(layer, 'weight', scale, bias)
+    return layer
+
+
+def _groupnorm_to_foreign(layer, ctx):
+    scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
+    num = (scale if scale is not None else offset).shape[0]
+    m = eqx.nn.GroupNorm(int(layer.num_groups), num, eps=float(layer.epsilon),
+                         channelwise_affine=scale is not None)
+    if scale is not None:
+        m = _set(m, weight=scale)
+    if offset is not None:
+        m = _set(m, bias=offset)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Dropout (prob[keep] <-> p[drop])
+# ---------------------------------------------------------------------------
+
+def _dropout_to_bst(m, ctx):
+    return C.build_dropout(1.0 - float(m.p))
+
+
+def _dropout_to_foreign(layer, ctx):
+    return eqx.nn.Dropout(1.0 - float(layer.prob))
+
+
+# ---------------------------------------------------------------------------
+# Conv  (bst (*k,in,out) NHWC <-> eqx (out,in,*k) NCHW)
+# ---------------------------------------------------------------------------
+
+def _kernel_perm_to_eqx(nd):
+    # bst (*k, in, out) -> eqx (out, in, *k)
+    return (nd + 1, nd) + tuple(range(nd))
+
+
+def _conv_to_bst(m, ctx):
+    w = m.weight                          # (out, in//g, *k)
+    nd = w.ndim - 2
+    perm = _kernel_perm_to_eqx(nd)
+    inv = tuple(int(i) for i in __import__('numpy').argsort(perm))
+    w_bst = u.math.transpose(w, inv)      # -> (*k, in//g, out)
+    out_channels = w.shape[0]
+    kernel_size = tuple(w.shape[2:])
+    in_size = ctx.require_size('Conv')
+    has_bias = m.bias is not None
+    layer = C.build_conv(
+        nd, in_size, out_channels, kernel_size,
+        stride=m.stride, padding=m.padding, rhs_dilation=m.dilation,
+        groups=m.groups, has_bias=has_bias,
+    )
+    b = u.math.reshape(m.bias, (1,) * nd + (out_channels,)) if has_bias else None
+    C.bst_set_linear(layer, w_bst, b)
+    return layer
+
+
+def _conv_to_foreign(layer, ctx):
+    w, b = C.bst_get_linear(layer)        # w: (*k, in//g, out)
+    nd = len(layer.kernel_size)
+    if any(d != 1 for d in layer.lhs_dilation):
+        raise ConversionError(
+            "equinox Conv does not support input (lhs) dilation; cannot export this layer."
+        )
+    cls = _CONV[nd]
+    m = cls(layer.in_channels, layer.out_channels, tuple(layer.kernel_size),
+            stride=tuple(layer.stride), padding=layer.padding,
+            dilation=tuple(layer.rhs_dilation), groups=layer.groups,
+            use_bias=b is not None, key=ctx.key or new_key())
+    w_eqx = u.math.transpose(w, _kernel_perm_to_eqx(nd))   # (out, in//g, *k)
+    m = _set(m, weight=w_eqx)
+    if b is not None:
+        out_channels = layer.out_channels
+        m = _set(m, bias=u.math.reshape(b, (out_channels,) + (1,) * nd))
+    return m
+
+
+# ---------------------------------------------------------------------------
+# LSTMCell  (fused (in+h,4h) [i,g,f,o] + forget+1 fold  <->  weight_ih/hh (4h,*) [i,f,g,o])
+# ---------------------------------------------------------------------------
+
+def _lstm_to_foreign(layer, ctx):
+    W, bias = C.bst_get_lstm(layer)
+    num_in = W.shape[0] - layer.num_out
+    h = layer.num_out
+    Wi, Wh = W[:num_in], W[num_in:]
+    ii, ig, if_, io = _split4(Wi)            # bst order i,g,f,o
+    hi, hg, hf, ho = _split4(Wh)
+    bi, bg, bf, bo = _split4(bias)
+    # assemble in std order i,f,g,o, then transpose to (4h, *)
+    weight_ih = u.math.transpose(u.math.concatenate([ii, if_, ig, io], axis=-1), (1, 0))
+    weight_hh = u.math.transpose(u.math.concatenate([hi, hf, hg, ho], axis=-1), (1, 0))
+    bias_std = u.math.concatenate([bi, bf + 1.0, bg, bo], axis=-1)   # forget +1 fold
+    m = eqx.nn.LSTMCell(num_in, h, use_bias=True, key=ctx.key or new_key())
+    return _set(m, weight_ih=weight_ih, weight_hh=weight_hh, bias=bias_std)
+
+
+def _lstm_to_bst(m, ctx):
+    Wih = u.math.transpose(m.weight_ih, (1, 0))   # (in, 4h) std order i,f,g,o
+    Whh = u.math.transpose(m.weight_hh, (1, 0))   # (h, 4h)
+    si, sf, sg, so = _split4(Wih)
+    ti, tf, tg, to = _split4(Whh)
+    bi, bf, bg, bo = _split4(m.bias)
+    num_in = Wih.shape[0]
+    h = m.weight_hh.shape[1]
+    Wi = u.math.concatenate([si, sg, sf, so], axis=-1)        # back to bst order i,g,f,o
+    Wh = u.math.concatenate([ti, tg, tf, to], axis=-1)
+    W = u.math.concatenate([Wi, Wh], axis=0)
+    bias = u.math.concatenate([bi, bg, bf - 1.0, bo], axis=-1)
+    layer = C.build_lstm(num_in, h)
+    C.bst_set_lstm(layer, W, bias)
+    return layer
+
+
+# ---------------------------------------------------------------------------
+# Adapter + registration
+# ---------------------------------------------------------------------------
+
+class EquinoxAdapter(FrameworkAdapter):
+    """Structural plumbing for equinox."""
+
+    name = 'equinox'
+
+    def is_sequential(self, node) -> bool:
+        return isinstance(node, eqx.nn.Sequential)
+
+    def iter_children(self, node):
+        return list(enumerate(node.layers))
+
+    def has_child_modules(self, node) -> bool:
+        import dataclasses
+        for f in dataclasses.fields(node):
+            v = getattr(node, f.name, None)
+            if isinstance(v, eqx.Module):
+                return True
+            if isinstance(v, (list, tuple)) and any(isinstance(x, eqx.Module) for x in v):
+                return True
+            if isinstance(v, dict) and any(isinstance(x, eqx.Module) for x in v.values()):
+                return True
+        return False
+
+    def layer_type(self, node) -> type:
+        return type(node)
+
+    def build_sequential(self, children: list):
+        return eqx.nn.Sequential(children)
+
+
+def _register():
+    pairs = [
+        (bnn.Linear, eqx.nn.Linear, _linear_to_bst, _linear_to_foreign),
+        (bnn.Embedding, eqx.nn.Embedding, _embed_to_bst, _embed_to_foreign),
+        (bnn.LayerNorm, eqx.nn.LayerNorm, _layernorm_to_bst, _layernorm_to_foreign),
+        (bnn.RMSNorm, eqx.nn.RMSNorm, _rmsnorm_to_bst, _rmsnorm_to_foreign),
+        (bnn.GroupNorm, eqx.nn.GroupNorm, _groupnorm_to_bst, _groupnorm_to_foreign),
+        (bnn.Dropout, eqx.nn.Dropout, _dropout_to_bst, _dropout_to_foreign),
+        (bnn.Conv1d, eqx.nn.Conv1d, _conv_to_bst, _conv_to_foreign),
+        (bnn.Conv2d, eqx.nn.Conv2d, _conv_to_bst, _conv_to_foreign),
+        (bnn.Conv3d, eqx.nn.Conv3d, _conv_to_bst, _conv_to_foreign),
+        (bnn.LSTMCell, eqx.nn.LSTMCell, _lstm_to_bst, _lstm_to_foreign),
+    ]
+    for bst_type, foreign_type, to_bst, to_foreign in pairs:
+        register_layer_mapping(LayerMapping(bst_type, 'equinox', foreign_type, to_bst, to_foreign))
+
+    _bn_reason = (
+        "equinox BatchNorm is unsupported: equinox stores running statistics in an external "
+        "`eqx.nn.State` object (threaded through the forward pass under a named vmap axis), "
+        "which cannot be expressed through the simple from_equinox/to_equinox(model) API."
+    )
+    for bn in (eqx.nn.BatchNorm,):
+        register_unsupported_foreign('equinox', bn, _bn_reason)
+    for bn in (bnn.BatchNorm0d, bnn.BatchNorm1d, bnn.BatchNorm2d, bnn.BatchNorm3d):
+        register_unsupported_bst_for('equinox', bn, _bn_reason)
+    register_unsupported_foreign('equinox', eqx.nn.GRUCell, C._GRU_REASON)
+    C.register_bst_unsupported()
+
+
+_register()

--- a/brainstate/interop/_frameworks/_linen.py
+++ b/brainstate/interop/_frameworks/_linen.py
@@ -1,0 +1,426 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""flax.linen adapter + layer mappings.
+
+linen is *functional*: a model is a ``(module, variables)`` pair rather than a single object
+holding its own weights. The adapter wraps both into a lightweight :class:`_LinenNode` so the
+generic engine can traverse it uniformly. Each node carries the slice of the variables tree that
+belongs to its module, so leaf mappings simply read/write ``node.variables['params'][...]``.
+
+linen shares brainstate's tensor layout (Linear ``(in, out)``, Conv ``(*k, in, out)`` NHWC), so
+the weight maths is identical to the nnx adapter; only the param-tree plumbing differs. linen
+``nn.Sequential`` names its children ``layers_0``, ``layers_1``, ... by position, which is how
+children are sliced on import and re-assembled on export.
+"""
+
+from __future__ import annotations
+
+import brainunit as u
+
+from .. import _common as C
+from .._common import FrameworkAdapter, lazy_import
+from .._errors import ConversionError
+from .._registry import (LayerMapping, register_layer_mapping,
+                         register_unsupported_foreign)
+
+linen = lazy_import('flax.linen')
+_flax_core = lazy_import('flax.core')
+import brainstate.nn as bnn  # noqa: E402
+
+nn = linen
+
+
+class _LinenNode:
+    """A linen ``module`` paired with the slice of the variables tree it owns.
+
+    Parameters
+    ----------
+    module : flax.linen.Module
+        The (unbound) linen module describing this node's architecture.
+    variables : dict
+        A plain (unfrozen) variables mapping for *this* module, e.g.
+        ``{'params': {...}, 'batch_stats': {...}}``. Collections absent for the module are simply
+        omitted.
+    """
+
+    __slots__ = ('module', 'variables')
+
+    def __init__(self, module, variables):
+        self.module = module
+        self.variables = variables
+
+
+def _params(node: _LinenNode) -> dict:
+    return node.variables.get('params', {}) or {}
+
+
+def _split4(arr, axis=-1):
+    return list(u.math.split(arr, 4, axis=axis))
+
+
+# ---------------------------------------------------------------------------
+# Linear (nn.Dense)
+# ---------------------------------------------------------------------------
+
+def _linear_to_bst(node, ctx):
+    p = _params(node)
+    w = p['kernel']
+    b = p.get('bias')
+    layer = C.build_linear(w.shape[0], w.shape[1], b is not None)
+    C.bst_set_linear(layer, w, b)
+    return layer
+
+
+def _linear_to_foreign(layer, ctx):
+    w, b = C.bst_get_linear(layer)
+    module = nn.Dense(features=w.shape[1], use_bias=b is not None)
+    params = {'kernel': w}
+    if b is not None:
+        params['bias'] = b
+    return _LinenNode(module, {'params': params})
+
+
+# ---------------------------------------------------------------------------
+# Embedding (nn.Embed)
+# ---------------------------------------------------------------------------
+
+def _embed_to_bst(node, ctx):
+    table = _params(node)['embedding']
+    layer = C.build_embedding(table.shape[0], table.shape[1])
+    C.bst_set_embedding(layer, table)
+    return layer
+
+
+def _embed_to_foreign(layer, ctx):
+    table = C.bst_get_embedding(layer)
+    module = nn.Embed(num_embeddings=table.shape[0], features=table.shape[1])
+    return _LinenNode(module, {'params': {'embedding': table}})
+
+
+# ---------------------------------------------------------------------------
+# LayerNorm / RMSNorm / GroupNorm  (1-D affine vectors -> identity)
+# ---------------------------------------------------------------------------
+
+def _layernorm_to_bst(node, ctx):
+    p = _params(node)
+    scale = p.get('scale')
+    bias = p.get('bias')
+    num = (scale if scale is not None else bias).shape[0]
+    layer = C.build_layernorm((num,), scale is not None, bias is not None,
+                              float(node.module.epsilon))
+    C.bst_set_norm(layer, 'weight', scale, bias)
+    return layer
+
+
+def _layernorm_to_foreign(layer, ctx):
+    scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
+    module = nn.LayerNorm(epsilon=float(layer.epsilon),
+                          use_scale=scale is not None, use_bias=offset is not None)
+    params = {}
+    if scale is not None:
+        params['scale'] = scale
+    if offset is not None:
+        params['bias'] = offset
+    return _LinenNode(module, {'params': params})
+
+
+def _rmsnorm_to_bst(node, ctx):
+    scale = _params(node)['scale']
+    layer = C.build_rmsnorm((scale.shape[0],), True, float(node.module.epsilon))
+    C.bst_set_norm(layer, 'scale', scale, None)
+    return layer
+
+
+def _rmsnorm_to_foreign(layer, ctx):
+    scale, _ = C.bst_get_norm(layer, 'scale', has_offset=False)
+    module = nn.RMSNorm(epsilon=float(layer.epsilon), use_scale=True)
+    return _LinenNode(module, {'params': {'scale': scale}})
+
+
+def _groupnorm_to_bst(node, ctx):
+    p = _params(node)
+    scale = p.get('scale')
+    bias = p.get('bias')
+    num = (scale if scale is not None else bias).shape[0]
+    layer = C.build_groupnorm((num,), int(node.module.num_groups),
+                              scale is not None, bias is not None, float(node.module.epsilon))
+    C.bst_set_norm(layer, 'weight', scale, bias)
+    return layer
+
+
+def _groupnorm_to_foreign(layer, ctx):
+    scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
+    module = nn.GroupNorm(num_groups=int(layer.num_groups), epsilon=float(layer.epsilon),
+                          use_scale=scale is not None, use_bias=offset is not None)
+    params = {}
+    if scale is not None:
+        params['scale'] = scale
+    if offset is not None:
+        params['bias'] = offset
+    return _LinenNode(module, {'params': params})
+
+
+# ---------------------------------------------------------------------------
+# Dropout (stateless; prob[keep] <-> rate[drop])
+# ---------------------------------------------------------------------------
+
+def _dropout_to_bst(node, ctx):
+    return C.build_dropout(1.0 - float(node.module.rate))
+
+
+def _dropout_to_foreign(layer, ctx):
+    # No parameters. ``deterministic=True`` is baked in so the exported module (and any
+    # ``nn.Sequential`` containing it, which forwards call kwargs to every child) is directly
+    # applicable and output-equivalent to brainstate's eval-mode Dropout. Cross-framework RNG
+    # streams cannot be matched, so equivalence for Dropout is only defined in eval mode.
+    return _LinenNode(nn.Dropout(rate=1.0 - float(layer.prob), deterministic=True), {})
+
+
+# ---------------------------------------------------------------------------
+# Conv  (bst (*k,in,out) NHWC <-> linen (*k,in,out) NHWC: kernel identity, bias reshape)
+# ---------------------------------------------------------------------------
+
+def _conv_to_bst(node, ctx):
+    m = node.module
+    p = _params(node)
+    w = p['kernel']                       # (*k, in//g, out)
+    kernel_size = tuple(w.shape[:-2])
+    nd = len(kernel_size)
+    out_channels = w.shape[-1]
+    if any(d != 1 for d in _as_tuple(getattr(m, 'input_dilation', 1) or 1, nd)):
+        raise ConversionError(
+            "linen Conv with `input_dilation` != 1 (transposed convolution) is not supported "
+            "by this converter."
+        )
+    in_size = ctx.require_size('Conv')
+    b = p.get('bias')
+    layer = C.build_conv(
+        nd, in_size, out_channels, kernel_size,
+        stride=getattr(m, 'strides', 1) or 1,
+        padding=getattr(m, 'padding', 'SAME'),
+        rhs_dilation=getattr(m, 'kernel_dilation', 1) or 1,
+        groups=int(getattr(m, 'feature_group_count', 1)),
+        has_bias=b is not None,
+    )
+    bias = u.math.reshape(b, (1,) * nd + (out_channels,)) if b is not None else None
+    C.bst_set_linear(layer, w, bias)
+    return layer
+
+
+def _conv_to_foreign(layer, ctx):
+    w, b = C.bst_get_linear(layer)
+    nd = len(layer.kernel_size)
+    module = nn.Conv(
+        features=layer.out_channels,
+        kernel_size=tuple(layer.kernel_size),
+        strides=tuple(layer.stride),
+        padding=layer.padding,
+        input_dilation=tuple(layer.lhs_dilation),
+        kernel_dilation=tuple(layer.rhs_dilation),
+        feature_group_count=layer.groups,
+        use_bias=b is not None,
+    )
+    params = {'kernel': w}
+    if b is not None:
+        params['bias'] = u.math.reshape(b, (b.shape[-1],))
+    return _LinenNode(module, {'params': params})
+
+
+# ---------------------------------------------------------------------------
+# BatchNorm  (bst (1,...,1,C) <-> linen (C,); running stats in batch_stats collection)
+# ---------------------------------------------------------------------------
+
+def _batchnorm_to_bst(node, ctx):
+    p = _params(node)
+    bs = node.variables.get('batch_stats', {})
+    scale = p.get('scale')
+    bias = p.get('bias')
+    mean = bs['mean']
+    var = bs['var']
+    in_size = ctx.require_size('BatchNorm')
+    nd = len(in_size) - 1
+    affine = scale is not None
+    layer = C.build_batchnorm(nd, in_size, float(node.module.epsilon),
+                              float(node.module.momentum), affine)
+
+    def _r(v):
+        return u.math.reshape(v, (1,) * nd + (v.shape[-1],))
+
+    C.bst_set_batchnorm(
+        layer,
+        _r(scale) if scale is not None else None,
+        _r(bias) if bias is not None else None,
+        _r(mean), _r(var),
+    )
+    return layer
+
+
+def _batchnorm_to_foreign(layer, ctx):
+    scale, offset, mean, var = C.bst_get_batchnorm(layer)
+
+    def _f(v):
+        return u.math.reshape(v, (v.shape[-1],))
+
+    module = nn.BatchNorm(
+        use_running_average=True,
+        momentum=float(layer.momentum),
+        epsilon=float(layer.epsilon),
+        use_scale=scale is not None,
+        use_bias=offset is not None,
+    )
+    params = {}
+    if scale is not None:
+        params['scale'] = _f(scale)
+    if offset is not None:
+        params['bias'] = _f(offset)
+    return _LinenNode(module, {'params': params,
+                               'batch_stats': {'mean': _f(mean), 'var': _f(var)}})
+
+
+# ---------------------------------------------------------------------------
+# LSTMCell  (fused (in+h,4h) [i,g,f,o] + forget+1 fold  <->  8 Denses [i,f,g,o])
+# ---------------------------------------------------------------------------
+
+def _lstm_to_bst(node, ctx):
+    p = _params(node)
+    ii, if_, ig, io = (p['ii']['kernel'], p['if']['kernel'],
+                       p['ig']['kernel'], p['io']['kernel'])
+    hi, hf, hg, ho = (p['hi']['kernel'], p['hf']['kernel'],
+                      p['hg']['kernel'], p['ho']['kernel'])
+    bi, bf, bg, bo = (p['hi']['bias'], p['hf']['bias'], p['hg']['bias'], p['ho']['bias'])
+    num_in = ii.shape[0]
+    h = ii.shape[1]
+    Wi = u.math.concatenate([ii, ig, if_, io], axis=-1)   # back to brainstate order i,g,f,o
+    Wh = u.math.concatenate([hi, hg, hf, ho], axis=-1)
+    W = u.math.concatenate([Wi, Wh], axis=0)
+    bias = u.math.concatenate([bi, bg, bf - 1.0, bo], axis=-1)
+    layer = C.build_lstm(num_in, h)
+    C.bst_set_lstm(layer, W, bias)
+    return layer
+
+
+def _lstm_to_foreign(layer, ctx):
+    W, bias = C.bst_get_lstm(layer)
+    num_in = W.shape[0] - layer.num_out
+    h = layer.num_out
+    Wi, Wh = W[:num_in], W[num_in:]
+    ii, ig, if_, io = _split4(Wi)            # brainstate order i,g,f,o
+    hi, hg, hf, ho = _split4(Wh)
+    bi, bg, bf, bo = _split4(bias)
+    module = nn.LSTMCell(features=h)
+    params = {
+        'ii': {'kernel': ii}, 'if': {'kernel': if_},
+        'ig': {'kernel': ig}, 'io': {'kernel': io},
+        'hi': {'kernel': hi, 'bias': bi}, 'hf': {'kernel': hf, 'bias': bf + 1.0},
+        'hg': {'kernel': hg, 'bias': bg}, 'ho': {'kernel': ho, 'bias': bo},
+    }
+    return _LinenNode(module, {'params': params})
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _as_tuple(v, nd):
+    if isinstance(v, (tuple, list)):
+        return tuple(v)
+    return (v,) * nd
+
+
+# ---------------------------------------------------------------------------
+# Adapter + registration
+# ---------------------------------------------------------------------------
+
+class LinenAdapter(FrameworkAdapter):
+    """Structural plumbing for the functional flax.linen framework.
+
+    A ``node`` here is a :class:`_LinenNode` bundling a module with the slice of the variables
+    tree it owns. ``wrap`` builds the root node from a user ``(module, variables)`` pair; the
+    per-leaf mappings return ``_LinenNode`` objects on export; ``finalize`` unwraps the root back
+    into a ``(module, FrozenDict)`` pair.
+    """
+
+    name = 'linen'
+
+    def wrap(self, module, variables):
+        """Bundle a linen ``module`` and its ``variables`` into a traversable node."""
+        return _LinenNode(module, _flax_core.unfreeze(variables))
+
+    def finalize(self, node):
+        """Return the ``(module, FrozenDict)`` pair represented by an export ``node``."""
+        return node.module, _flax_core.freeze(node.variables)
+
+    def is_sequential(self, node) -> bool:
+        return isinstance(node.module, nn.Sequential)
+
+    def iter_children(self, node):
+        children = []
+        for i, layer in enumerate(node.module.layers):
+            key = f'layers_{i}'
+            sub = {}
+            for coll, tree in node.variables.items():
+                if isinstance(tree, dict) and key in tree:
+                    sub[coll] = tree[key]
+            children.append((i, _LinenNode(layer, sub)))
+        return children
+
+    def has_child_modules(self, node) -> bool:
+        # A leaf's param collection maps names -> arrays; a container maps names -> sub-trees.
+        return any(isinstance(v, dict) for v in _params(node).values())
+
+    def layer_type(self, node) -> type:
+        return type(node.module)
+
+    def build_sequential(self, children: list):
+        layers = [c.module for c in children]
+        merged: dict = {}
+        for i, c in enumerate(children):
+            key = f'layers_{i}'
+            for coll, tree in c.variables.items():
+                merged.setdefault(coll, {})[key] = tree
+        return _LinenNode(nn.Sequential(layers), merged)
+
+
+def _register():
+    pairs = [
+        (bnn.Linear, nn.Dense, _linear_to_bst, _linear_to_foreign),
+        (bnn.Embedding, nn.Embed, _embed_to_bst, _embed_to_foreign),
+        (bnn.LayerNorm, nn.LayerNorm, _layernorm_to_bst, _layernorm_to_foreign),
+        (bnn.RMSNorm, nn.RMSNorm, _rmsnorm_to_bst, _rmsnorm_to_foreign),
+        (bnn.GroupNorm, nn.GroupNorm, _groupnorm_to_bst, _groupnorm_to_foreign),
+        (bnn.Dropout, nn.Dropout, _dropout_to_bst, _dropout_to_foreign),
+        (bnn.Conv1d, nn.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.Conv2d, nn.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.Conv3d, nn.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.BatchNorm1d, nn.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
+        (bnn.BatchNorm2d, nn.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
+        (bnn.BatchNorm3d, nn.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
+        (bnn.LSTMCell, nn.LSTMCell, _lstm_to_bst, _lstm_to_foreign),
+    ]
+    for bst_type, foreign_type, to_bst, to_foreign in pairs:
+        register_layer_mapping(LayerMapping(bst_type, 'linen', foreign_type, to_bst, to_foreign))
+
+    register_unsupported_foreign(
+        'linen', nn.GRUCell,
+        "GRUCell conversion is unsupported: brainstate's GRU uses the Cho-2014 variant (reset "
+        "applied before the hidden matmul, `Wh([x, r*h])`) while flax.linen uses the cuDNN "
+        "variant (reset applied after, `r * (W_hn h + b_hn)`). These are mathematically distinct "
+        "and cannot be matched by transferring weights."
+    )
+    C.register_bst_unsupported()
+
+
+_register()

--- a/brainstate/interop/_frameworks/_nnx.py
+++ b/brainstate/interop/_frameworks/_nnx.py
@@ -1,0 +1,374 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""flax.nnx adapter + layer mappings.
+
+nnx is reference-semantic like brainstate and shares its tensor layout (Linear ``(in, out)``,
+Conv ``(*k, in, out)`` NHWC), so most weight transfers are the identity; the differences are
+bias shape (conv/batch-norm) and the fused-vs-split LSTM kernel + gate order.
+"""
+
+from __future__ import annotations
+
+import brainunit as u
+
+from .. import _common as C
+from .._common import FrameworkAdapter, lazy_import, new_key
+from .._registry import (LayerMapping, register_layer_mapping,
+                         register_unsupported_bst, register_unsupported_foreign)
+
+nnx = lazy_import('flax.nnx')
+import brainstate.nn as bnn  # noqa: E402
+
+# brainstate LSTM stores gates [i, g, f, o]; nnx/torch use [i, f, g, o]. Self-inverse swap.
+
+
+def _get(var):
+    """Read an nnx Variable's array (new ``[...]`` API, falling back to ``.value``)."""
+    try:
+        return var[...]
+    except Exception:  # pragma: no cover - version fallback
+        return var.value
+
+
+def _set(var, arr):
+    """Write an nnx Variable's array."""
+    try:
+        var[...] = arr
+    except Exception:  # pragma: no cover - version fallback
+        var.value = arr
+
+
+def _rngs(ctx):
+    return ctx.rngs if ctx.rngs is not None else nnx.Rngs(0)
+
+
+def _split4(arr, axis=-1):
+    return list(u.math.split(arr, 4, axis=axis))
+
+
+# ---------------------------------------------------------------------------
+# Linear
+# ---------------------------------------------------------------------------
+
+def _linear_to_bst(m, ctx):
+    w = _get(m.kernel)
+    has_bias = m.bias is not None
+    layer = C.build_linear(w.shape[0], w.shape[1], has_bias)
+    C.bst_set_linear(layer, w, _get(m.bias) if has_bias else None)
+    return layer
+
+
+def _linear_to_foreign(layer, ctx):
+    w, b = C.bst_get_linear(layer)
+    m = nnx.Linear(w.shape[0], w.shape[1], use_bias=b is not None, rngs=_rngs(ctx))
+    _set(m.kernel, w)
+    if b is not None:
+        _set(m.bias, b)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Embedding
+# ---------------------------------------------------------------------------
+
+def _embed_to_bst(m, ctx):
+    table = _get(m.embedding)
+    layer = C.build_embedding(table.shape[0], table.shape[1])
+    C.bst_set_embedding(layer, table)
+    return layer
+
+
+def _embed_to_foreign(layer, ctx):
+    table = C.bst_get_embedding(layer)
+    m = nnx.Embed(table.shape[0], table.shape[1], rngs=_rngs(ctx))
+    _set(m.embedding, table)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# LayerNorm / RMSNorm / GroupNorm  (1-D affine vectors -> identity)
+# ---------------------------------------------------------------------------
+
+def _layernorm_to_bst(m, ctx):
+    scale = None if m.scale is None else _get(m.scale)
+    bias = None if m.bias is None else _get(m.bias)
+    num = (scale if scale is not None else bias).shape[0]
+    layer = C.build_layernorm((num,), scale is not None, bias is not None, float(m.epsilon))
+    C.bst_set_norm(layer, 'weight', scale, bias)
+    return layer
+
+
+def _layernorm_to_foreign(layer, ctx):
+    scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
+    num = (scale if scale is not None else offset).shape[0]
+    m = nnx.LayerNorm(num, epsilon=float(layer.epsilon),
+                      use_scale=scale is not None, use_bias=offset is not None, rngs=_rngs(ctx))
+    if scale is not None:
+        _set(m.scale, scale)
+    if offset is not None:
+        _set(m.bias, offset)
+    return m
+
+
+def _rmsnorm_to_bst(m, ctx):
+    scale = None if m.scale is None else _get(m.scale)
+    num = scale.shape[0]
+    layer = C.build_rmsnorm((num,), scale is not None, float(m.epsilon))
+    C.bst_set_norm(layer, 'scale', scale, None)
+    return layer
+
+
+def _rmsnorm_to_foreign(layer, ctx):
+    scale, _ = C.bst_get_norm(layer, 'scale', has_offset=False)
+    num = scale.shape[0]
+    m = nnx.RMSNorm(num, epsilon=float(layer.epsilon), use_scale=True, rngs=_rngs(ctx))
+    _set(m.scale, scale)
+    return m
+
+
+def _groupnorm_to_bst(m, ctx):
+    scale = None if m.scale is None else _get(m.scale)
+    bias = None if m.bias is None else _get(m.bias)
+    num = (scale if scale is not None else bias).shape[0]
+    layer = C.build_groupnorm((num,), int(m.num_groups), scale is not None, bias is not None,
+                              float(m.epsilon))
+    C.bst_set_norm(layer, 'weight', scale, bias)
+    return layer
+
+
+def _groupnorm_to_foreign(layer, ctx):
+    scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
+    num = (scale if scale is not None else offset).shape[0]
+    m = nnx.GroupNorm(num, num_groups=int(layer.num_groups), epsilon=float(layer.epsilon),
+                      use_scale=scale is not None, use_bias=offset is not None, rngs=_rngs(ctx))
+    if scale is not None:
+        _set(m.scale, scale)
+    if offset is not None:
+        _set(m.bias, offset)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Dropout (stateless; prob[keep] <-> rate[drop])
+# ---------------------------------------------------------------------------
+
+def _dropout_to_bst(m, ctx):
+    return C.build_dropout(1.0 - float(m.rate))
+
+
+def _dropout_to_foreign(layer, ctx):
+    return nnx.Dropout(1.0 - float(layer.prob), rngs=_rngs(ctx))
+
+
+# ---------------------------------------------------------------------------
+# Conv
+# ---------------------------------------------------------------------------
+
+def _conv_bias_reshape_to_bst(b, nd):
+    # nnx (out,) -> brainstate (1,...,1,out)
+    return u.math.reshape(b, (1,) * nd + (b.shape[-1],))
+
+
+def _conv_bias_reshape_to_foreign(b):
+    # brainstate (1,...,1,out) -> nnx (out,)
+    return u.math.reshape(b, (b.shape[-1],))
+
+
+def _conv_to_bst(m, ctx):
+    w = _get(m.kernel)  # (*k, in//g, out)
+    kernel_size = tuple(w.shape[:-2])
+    nd = len(kernel_size)
+    out_channels = w.shape[-1]
+    in_size = ctx.require_size('Conv')
+    has_bias = m.bias is not None
+    groups = int(getattr(m, 'feature_group_count', 1))
+    layer = C.build_conv(
+        nd, in_size, out_channels, kernel_size,
+        stride=getattr(m, 'strides', 1) or 1,
+        padding=getattr(m, 'padding', 'SAME'),
+        rhs_dilation=getattr(m, 'kernel_dilation', 1) or 1,
+        groups=groups,
+        has_bias=has_bias,
+    )
+    b = _conv_bias_reshape_to_bst(_get(m.bias), nd) if has_bias else None
+    C.bst_set_linear(layer, w, b)
+    return layer
+
+
+def _conv_to_foreign(layer, ctx):
+    w, b = C.bst_get_linear(layer)
+    nd = len(layer.kernel_size)
+    m = nnx.Conv(
+        layer.in_channels, layer.out_channels, tuple(layer.kernel_size),
+        strides=tuple(layer.stride),
+        padding=layer.padding,
+        kernel_dilation=tuple(layer.rhs_dilation),
+        input_dilation=tuple(layer.lhs_dilation),
+        feature_group_count=layer.groups,
+        use_bias=b is not None,
+        rngs=_rngs(ctx),
+    )
+    _set(m.kernel, w)
+    if b is not None:
+        _set(m.bias, _conv_bias_reshape_to_foreign(b))
+    return m
+
+
+# ---------------------------------------------------------------------------
+# BatchNorm
+# ---------------------------------------------------------------------------
+
+def _bn_reshape_to_bst(v, nd):
+    return u.math.reshape(v, (1,) * nd + (v.shape[-1],))
+
+
+def _bn_reshape_to_foreign(v):
+    return u.math.reshape(v, (v.shape[-1],))
+
+
+def _batchnorm_to_bst(m, ctx):
+    scale = None if m.scale is None else _get(m.scale)
+    bias = None if m.bias is None else _get(m.bias)
+    mean = _get(m.mean)
+    var = _get(m.var)
+    in_size = ctx.require_size('BatchNorm')
+    nd = len(in_size) - 1
+    affine = scale is not None
+    layer = C.build_batchnorm(nd, in_size, float(m.epsilon), float(m.momentum), affine)
+    C.bst_set_batchnorm(
+        layer,
+        _bn_reshape_to_bst(scale, nd) if scale is not None else None,
+        _bn_reshape_to_bst(bias, nd) if bias is not None else None,
+        _bn_reshape_to_bst(mean, nd),
+        _bn_reshape_to_bst(var, nd),
+    )
+    return layer
+
+
+def _batchnorm_to_foreign(layer, ctx):
+    scale, offset, mean, var = C.bst_get_batchnorm(layer)
+    num = (scale if scale is not None else mean).shape[-1]
+    # ``use_running_average=True`` so the exported layer normalizes with the transferred running
+    # statistics by default, matching brainstate's eval-mode forward (the only mode in which
+    # BatchNorm output is framework-equivalent). Flip it for training.
+    m = nnx.BatchNorm(num, momentum=float(layer.momentum), epsilon=float(layer.epsilon),
+                      use_scale=scale is not None, use_bias=offset is not None,
+                      use_running_average=True, rngs=_rngs(ctx))
+    if scale is not None:
+        _set(m.scale, _bn_reshape_to_foreign(scale))
+    if offset is not None:
+        _set(m.bias, _bn_reshape_to_foreign(offset))
+    _set(m.mean, _bn_reshape_to_foreign(mean))
+    _set(m.var, _bn_reshape_to_foreign(var))
+    return m
+
+
+# ---------------------------------------------------------------------------
+# LSTMCell  (fused (in+h,4h) [i,g,f,o] + forget+1 fold  <->  8 Denses [i,f,g,o])
+# ---------------------------------------------------------------------------
+
+def _lstm_to_foreign(layer, ctx):
+    W, bias = C.bst_get_lstm(layer)              # W: (in+h, 4h), bias: (4h,)
+    num_in = W.shape[0] - layer.num_out
+    h = layer.num_out
+    Wi, Wh = W[:num_in], W[num_in:]
+    ii, ig, if_, io = _split4(Wi)                # brainstate order i,g,f,o
+    hi, hg, hf, ho = _split4(Wh)
+    bi, bg, bf, bo = _split4(bias)
+    m = nnx.LSTMCell(num_in, h, rngs=_rngs(ctx))
+    _set(m.ii.kernel, ii); _set(m.if_.kernel, if_); _set(m.ig.kernel, ig); _set(m.io.kernel, io)
+    _set(m.hi.kernel, hi); _set(m.hf.kernel, hf); _set(m.hg.kernel, hg); _set(m.ho.kernel, ho)
+    _set(m.hi.bias, bi); _set(m.hf.bias, bf + 1.0); _set(m.hg.bias, bg); _set(m.ho.bias, bo)
+    return m
+
+
+def _lstm_to_bst(m, ctx):
+    ii, if_, ig, io = _get(m.ii.kernel), _get(m.if_.kernel), _get(m.ig.kernel), _get(m.io.kernel)
+    hi, hf, hg, ho = _get(m.hi.kernel), _get(m.hf.kernel), _get(m.hg.kernel), _get(m.ho.kernel)
+    bi, bf, bg, bo = _get(m.hi.bias), _get(m.hf.bias), _get(m.hg.bias), _get(m.ho.bias)
+    num_in = ii.shape[0]
+    h = ii.shape[1]
+    Wi = u.math.concatenate([ii, ig, if_, io], axis=-1)   # back to brainstate order i,g,f,o
+    Wh = u.math.concatenate([hi, hg, hf, ho], axis=-1)
+    W = u.math.concatenate([Wi, Wh], axis=0)
+    bias = u.math.concatenate([bi, bg, bf - 1.0, bo], axis=-1)
+    layer = C.build_lstm(num_in, h)
+    C.bst_set_lstm(layer, W, bias)
+    return layer
+
+
+# ---------------------------------------------------------------------------
+# Adapter + registration
+# ---------------------------------------------------------------------------
+
+class NnxAdapter(FrameworkAdapter):
+    """Structural plumbing for flax.nnx."""
+
+    name = 'nnx'
+
+    def is_sequential(self, node) -> bool:
+        return isinstance(node, getattr(nnx, 'Sequential', ()))
+
+    def iter_children(self, node):
+        return list(enumerate(node.layers))
+
+    def has_child_modules(self, node) -> bool:
+        for v in vars(node).values():
+            if isinstance(v, nnx.Module):
+                return True
+            if isinstance(v, (list, tuple)) and any(isinstance(x, nnx.Module) for x in v):
+                return True
+        return False
+
+    def layer_type(self, node) -> type:
+        return type(node)
+
+    def build_sequential(self, children: list):
+        return nnx.Sequential(*children)
+
+
+def _register():
+    pairs = [
+        (bnn.Linear, nnx.Linear, _linear_to_bst, _linear_to_foreign),
+        (bnn.Embedding, nnx.Embed, _embed_to_bst, _embed_to_foreign),
+        (bnn.LayerNorm, nnx.LayerNorm, _layernorm_to_bst, _layernorm_to_foreign),
+        (bnn.RMSNorm, nnx.RMSNorm, _rmsnorm_to_bst, _rmsnorm_to_foreign),
+        (bnn.GroupNorm, nnx.GroupNorm, _groupnorm_to_bst, _groupnorm_to_foreign),
+        (bnn.Dropout, nnx.Dropout, _dropout_to_bst, _dropout_to_foreign),
+        (bnn.Conv1d, nnx.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.Conv2d, nnx.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.Conv3d, nnx.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.BatchNorm1d, nnx.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
+        (bnn.BatchNorm2d, nnx.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
+        (bnn.BatchNorm3d, nnx.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
+        (bnn.LSTMCell, nnx.LSTMCell, _lstm_to_bst, _lstm_to_foreign),
+    ]
+    for bst_type, foreign_type, to_bst, to_foreign in pairs:
+        register_layer_mapping(LayerMapping(bst_type, 'nnx', foreign_type, to_bst, to_foreign))
+
+    # nnx.Conv is one class for all spatial dims; map import to the right brainstate class by
+    # spatial-dim count handled in _conv_to_bst (it picks Conv{nd}d via build_conv).
+    register_unsupported_foreign(
+        'nnx', nnx.GRUCell,
+        "GRUCell conversion is unsupported: brainstate's GRU uses the Cho-2014 variant "
+        "(reset applied before the hidden matmul, `Wh([x, r*h])`) while flax/nnx use the cuDNN "
+        "variant (reset applied after, `r * (W_hn h + b_hn)`). These are mathematically distinct "
+        "and cannot be matched by transferring weights."
+    )
+    C.register_bst_unsupported()
+
+
+_register()

--- a/brainstate/interop/_registry.py
+++ b/brainstate/interop/_registry.py
@@ -1,0 +1,177 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Registry of layer conversion mappings.
+
+A :class:`LayerMapping` ties a brainstate layer type to a foreign layer type and carries the
+two conversion closures (``to_bst`` and ``to_foreign``). Co-locating both directions in one
+object keeps round-trip correctness reviewable in one place. The registry is populated lazily:
+each framework adapter module registers its mappings when it is first imported (which only
+happens after the framework itself imports successfully).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+__all__ = [
+    'LayerMapping',
+    'register_layer_mapping',
+    'register_unsupported_bst',
+    'register_unsupported_bst_for',
+    'register_unsupported_foreign',
+    'lookup_import',
+    'lookup_export',
+    'unsupported_bst_reason',
+    'unsupported_foreign_reason',
+    'supported_layers',
+]
+
+
+@dataclass
+class LayerMapping:
+    """A bidirectional conversion mapping for one layer type.
+
+    Parameters
+    ----------
+    bst_type : type
+        The brainstate ``Module`` subclass.
+    framework : str
+        One of ``"nnx"``, ``"linen"``, ``"equinox"``.
+    foreign_type : type
+        The foreign layer class.
+    to_bst : Callable
+        ``(foreign_module, ctx) -> bst.nn.Module``. Builds and weight-fills a brainstate layer.
+    to_foreign : Callable
+        ``(bst_module, ctx) -> foreign``. Builds and weight-fills the foreign layer. For the
+        functional ``linen`` framework the return value is whatever the linen adapter expects
+        (a ``(module, params)`` pair handled by the adapter).
+    """
+
+    bst_type: type
+    framework: str
+    foreign_type: type
+    to_bst: Callable
+    to_foreign: Callable
+
+
+# framework -> {foreign_type: LayerMapping}
+_IMPORT: Dict[str, Dict[type, LayerMapping]] = {}
+# (bst_type, framework) -> LayerMapping
+_EXPORT: Dict[Tuple[type, str], LayerMapping] = {}
+# brainstate types that are deliberately unsupported (any framework): type -> reason
+_UNSUPPORTED_BST: Dict[type, str] = {}
+# brainstate types unsupported for a *specific* framework: (bst_type, framework) -> reason
+_UNSUPPORTED_BST_FW: Dict[Tuple[type, str], str] = {}
+# framework -> {foreign_type: reason}
+_UNSUPPORTED_FOREIGN: Dict[str, Dict[type, str]] = {}
+
+
+def register_layer_mapping(mapping: LayerMapping) -> None:
+    """Register (or override) a :class:`LayerMapping` in both directions.
+
+    Parameters
+    ----------
+    mapping : LayerMapping
+        The mapping to register.
+    """
+    _IMPORT.setdefault(mapping.framework, {})[mapping.foreign_type] = mapping
+    _EXPORT[(mapping.bst_type, mapping.framework)] = mapping
+
+
+def register_unsupported_bst(bst_type: type, reason: str) -> None:
+    """Mark a brainstate layer type as deliberately unsupported for export (any framework)."""
+    _UNSUPPORTED_BST[bst_type] = reason
+
+
+def register_unsupported_bst_for(framework: str, bst_type: type, reason: str) -> None:
+    """Mark a brainstate layer type as unsupported for export to one specific framework."""
+    _UNSUPPORTED_BST_FW[(bst_type, framework)] = reason
+
+
+def register_unsupported_foreign(framework: str, foreign_type: type, reason: str) -> None:
+    """Mark a foreign layer type as deliberately unsupported for import."""
+    _UNSUPPORTED_FOREIGN.setdefault(framework, {})[foreign_type] = reason
+
+
+def _lookup_by_mro(table: dict, key_type: type):
+    """Look up ``key_type`` allowing subclasses to match a registered base class."""
+    if key_type in table:
+        return table[key_type]
+    for base in key_type.__mro__:
+        if base in table:
+            return table[base]
+    return None
+
+
+def lookup_import(framework: str, foreign_type: type) -> Optional[LayerMapping]:
+    """Return the import mapping for a foreign type, or ``None``."""
+    return _lookup_by_mro(_IMPORT.get(framework, {}), foreign_type)
+
+
+def lookup_export(bst_type: type, framework: str) -> Optional[LayerMapping]:
+    """Return the export mapping for a brainstate type + framework, or ``None``."""
+    table = {bt: m for (bt, fw), m in _EXPORT.items() if fw == framework}
+    return _lookup_by_mro(table, bst_type)
+
+
+def unsupported_bst_reason(bst_type: type, framework: Optional[str] = None) -> Optional[str]:
+    """Return the deliberate-unsupported reason for a brainstate type, or ``None``.
+
+    Checks the framework-specific table first (when ``framework`` is given), then the
+    framework-agnostic table.
+    """
+    if framework is not None:
+        for base in bst_type.__mro__:
+            if (base, framework) in _UNSUPPORTED_BST_FW:
+                return _UNSUPPORTED_BST_FW[(base, framework)]
+    for base in bst_type.__mro__:
+        if base in _UNSUPPORTED_BST:
+            return _UNSUPPORTED_BST[base]
+    return None
+
+
+def unsupported_foreign_reason(framework: str, foreign_type: type) -> Optional[str]:
+    """Return the deliberate-unsupported reason for a foreign type, or ``None``."""
+    table = _UNSUPPORTED_FOREIGN.get(framework, {})
+    for base in foreign_type.__mro__:
+        if base in table:
+            return table[base]
+    return None
+
+
+def supported_layers(framework: Optional[str] = None) -> Dict[str, list]:
+    """List the brainstate layer types with registered conversions.
+
+    Parameters
+    ----------
+    framework : str, optional
+        Restrict to a single framework. If ``None``, report all frameworks.
+
+    Returns
+    -------
+    dict
+        Mapping ``framework -> [brainstate type names]``.
+    """
+    # ensure adapters are imported so registries are populated
+    from . import _api  # noqa: F401  (triggers lazy framework imports on demand)
+    frameworks = [framework] if framework else ['nnx', 'linen', 'equinox']
+    out = {}
+    for fw in frameworks:
+        _api.ensure_framework_loaded(fw)
+        names = sorted({bt.__name__ for (bt, f) in _EXPORT if f == fw})
+        out[fw] = names
+    return out

--- a/brainstate/interop/_registry_test.py
+++ b/brainstate/interop/_registry_test.py
@@ -1,0 +1,124 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Unit tests for the framework-agnostic conversion registry."""
+
+from absl.testing import absltest
+
+from brainstate.interop import _registry as R
+from brainstate.interop._registry import (LayerMapping, lookup_export,
+                                          lookup_import,
+                                          register_layer_mapping,
+                                          register_unsupported_bst,
+                                          register_unsupported_bst_for,
+                                          register_unsupported_foreign,
+                                          unsupported_bst_reason,
+                                          unsupported_foreign_reason)
+
+
+class _BstBase:
+    pass
+
+
+class _BstLayer(_BstBase):
+    pass
+
+
+class _ForeignBase:
+    pass
+
+
+class _ForeignLayer(_ForeignBase):
+    pass
+
+
+class _ForeignSubclass(_ForeignLayer):
+    pass
+
+
+class RegistryTest(absltest.TestCase):
+    """Registration and lookup, using a private throwaway framework name."""
+
+    FW = '_test_fw_registry'
+
+    def tearDown(self):
+        # Keep global registry state clean across tests.
+        R._IMPORT.pop(self.FW, None)
+        R._UNSUPPORTED_FOREIGN.pop(self.FW, None)
+        for key in list(R._EXPORT):
+            if key[1] == self.FW:
+                R._EXPORT.pop(key)
+        for key in list(R._UNSUPPORTED_BST_FW):
+            if key[1] == self.FW:
+                R._UNSUPPORTED_BST_FW.pop(key)
+        R._UNSUPPORTED_BST.pop(_BstLayer, None)
+        super().tearDown()
+
+    def test_register_and_lookup_both_directions(self):
+        m = LayerMapping(_BstLayer, self.FW, _ForeignLayer,
+                         to_bst=lambda n, c: 'to_bst', to_foreign=lambda n, c: 'to_foreign')
+        register_layer_mapping(m)
+        self.assertIs(lookup_import(self.FW, _ForeignLayer), m)
+        self.assertIs(lookup_export(_BstLayer, self.FW), m)
+
+    def test_import_lookup_is_mro_aware(self):
+        m = LayerMapping(_BstLayer, self.FW, _ForeignLayer,
+                         to_bst=lambda n, c: None, to_foreign=lambda n, c: None)
+        register_layer_mapping(m)
+        # A subclass of the registered foreign type resolves to the base mapping.
+        self.assertIs(lookup_import(self.FW, _ForeignSubclass), m)
+
+    def test_export_lookup_is_mro_aware(self):
+        m = LayerMapping(_BstBase, self.FW, _ForeignLayer,
+                         to_bst=lambda n, c: None, to_foreign=lambda n, c: None)
+        register_layer_mapping(m)
+        # _BstLayer subclasses _BstBase -> resolves to base mapping.
+        self.assertIs(lookup_export(_BstLayer, self.FW), m)
+
+    def test_lookup_miss_returns_none(self):
+        self.assertIsNone(lookup_import(self.FW, _ForeignLayer))
+        self.assertIsNone(lookup_export(_BstLayer, self.FW))
+
+    def test_unsupported_foreign(self):
+        register_unsupported_foreign(self.FW, _ForeignLayer, 'nope-foreign')
+        self.assertEqual(unsupported_foreign_reason(self.FW, _ForeignLayer), 'nope-foreign')
+        # MRO-aware: subclass inherits the reason.
+        self.assertEqual(unsupported_foreign_reason(self.FW, _ForeignSubclass), 'nope-foreign')
+        self.assertIsNone(unsupported_foreign_reason(self.FW, _BstLayer))
+
+    def test_unsupported_bst_framework_specific_and_agnostic(self):
+        register_unsupported_bst_for(self.FW, _BstLayer, 'fw-specific')
+        self.assertEqual(unsupported_bst_reason(_BstLayer, self.FW), 'fw-specific')
+        # Without a framework, the framework-specific entry does not apply.
+        self.assertIsNone(unsupported_bst_reason(_BstLayer))
+        # Agnostic entry applies to any framework and to no-framework queries.
+        register_unsupported_bst(_BstLayer, 'agnostic')
+        self.assertEqual(unsupported_bst_reason(_BstLayer), 'agnostic')
+        # framework-specific takes precedence when a framework is given.
+        self.assertEqual(unsupported_bst_reason(_BstLayer, self.FW), 'fw-specific')
+
+    def test_register_overrides_existing(self):
+        m1 = LayerMapping(_BstLayer, self.FW, _ForeignLayer,
+                          to_bst=lambda n, c: 1, to_foreign=lambda n, c: 1)
+        m2 = LayerMapping(_BstLayer, self.FW, _ForeignLayer,
+                          to_bst=lambda n, c: 2, to_foreign=lambda n, c: 2)
+        register_layer_mapping(m1)
+        register_layer_mapping(m2)
+        self.assertIs(lookup_import(self.FW, _ForeignLayer), m2)
+        self.assertIs(lookup_export(_BstLayer, self.FW), m2)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/brainstate/interop/_transforms.py
+++ b/brainstate/interop/_transforms.py
@@ -1,0 +1,235 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Invertible array transforms used to bridge differing weight layouts across frameworks.
+
+Every :class:`Transform` defines ``forward`` (brainstate -> foreign) and ``inverse``
+(foreign -> brainstate) such that ``inverse(forward(x)) == x``. Expressing each layout
+difference as a single invertible object means a layer's correspondence is declared once and
+is correct in both conversion directions by construction.
+
+All transforms use :mod:`brainunit.math` for array operations so that ``brainunit.Quantity``
+weights are preserved (units carried through transposes/reshapes).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence, Tuple
+
+import brainunit as u
+import numpy as np
+
+__all__ = [
+    'Transform',
+    'Identity',
+    'Transpose',
+    'PermuteAxes',
+    'Reshape',
+    'AddScalar',
+    'ReorderBlocks',
+    'SplitConcat',
+    'Chain',
+]
+
+
+class Transform:
+    """Base class for an invertible array transform."""
+
+    def forward(self, x):
+        """Map a brainstate-layout array to the foreign layout."""
+        raise NotImplementedError
+
+    def inverse(self, x):
+        """Map a foreign-layout array back to the brainstate layout."""
+        raise NotImplementedError
+
+    def __repr__(self):
+        return f"{type(self).__name__}()"
+
+
+class Identity(Transform):
+    """The identity transform (layouts already agree)."""
+
+    def forward(self, x):
+        return x
+
+    def inverse(self, x):
+        return x
+
+
+class Transpose(Transform):
+    """Permute array axes by ``perm`` (forward) and by its inverse permutation (inverse).
+
+    Parameters
+    ----------
+    perm : tuple of int
+        Axis permutation applied in the forward (brainstate -> foreign) direction.
+    """
+
+    def __init__(self, perm: Sequence[int]):
+        self.perm = tuple(perm)
+        self.inv_perm = tuple(int(i) for i in np.argsort(self.perm))
+
+    def forward(self, x):
+        return u.math.transpose(x, self.perm)
+
+    def inverse(self, x):
+        return u.math.transpose(x, self.inv_perm)
+
+    def __repr__(self):
+        return f"Transpose(perm={self.perm})"
+
+
+class PermuteAxes(Transpose):
+    """Alias of :class:`Transpose` with a name that reads well for conv NHWC<->NCHW reorders."""
+
+
+class Reshape(Transform):
+    """Reshape between two layouts whose target shapes are computed from the input shape.
+
+    Parameters
+    ----------
+    forward_shape : Callable[[tuple], tuple]
+        Given the brainstate-layout shape, returns the foreign-layout shape.
+    inverse_shape : Callable[[tuple], tuple]
+        Given the foreign-layout shape, returns the brainstate-layout shape.
+    """
+
+    def __init__(self,
+                 forward_shape: Callable[[Tuple[int, ...]], Tuple[int, ...]],
+                 inverse_shape: Callable[[Tuple[int, ...]], Tuple[int, ...]]):
+        self._forward_shape = forward_shape
+        self._inverse_shape = inverse_shape
+
+    def forward(self, x):
+        return u.math.reshape(x, self._forward_shape(tuple(x.shape)))
+
+    def inverse(self, x):
+        return u.math.reshape(x, self._inverse_shape(tuple(x.shape)))
+
+
+class AddScalar(Transform):
+    """Add a constant in the forward direction, subtract it in the inverse direction.
+
+    Used to fold a baked-in constant (e.g. the LSTM forget-gate ``+1``) into / out of a bias.
+
+    Parameters
+    ----------
+    constant : float
+        The constant added when going brainstate -> foreign.
+    """
+
+    def __init__(self, constant: float):
+        self.constant = constant
+
+    def forward(self, x):
+        return x + self.constant
+
+    def inverse(self, x):
+        return x - self.constant
+
+    def __repr__(self):
+        return f"AddScalar({self.constant})"
+
+
+class ReorderBlocks(Transform):
+    """Reorder equal-sized contiguous blocks along an axis.
+
+    Splits the axis into ``len(order)`` equal blocks; the forward output's block ``p`` is the
+    input's block ``order[p]``. The inverse uses the inverse permutation. Used for gate
+    re-ordering (e.g. brainstate LSTM ``[i, g, f, o]`` <-> flax/torch ``[i, f, g, o]``).
+
+    Parameters
+    ----------
+    axis : int
+        Axis along which blocks are laid out.
+    order : tuple of int
+        Permutation; forward output block ``p`` = input block ``order[p]``.
+    """
+
+    def __init__(self, axis: int, order: Sequence[int]):
+        self.axis = axis
+        self.order = tuple(order)
+        self.inv_order = tuple(int(i) for i in np.argsort(self.order))
+
+    def _apply(self, x, order):
+        n = len(order)
+        blocks = u.math.split(x, n, axis=self.axis)
+        return u.math.concatenate([blocks[i] for i in order], axis=self.axis)
+
+    def forward(self, x):
+        return self._apply(x, self.order)
+
+    def inverse(self, x):
+        return self._apply(x, self.inv_order)
+
+    def __repr__(self):
+        return f"ReorderBlocks(axis={self.axis}, order={self.order})"
+
+
+class SplitConcat(Transform):
+    """Split one array into a tuple of sub-arrays (forward); concatenate back (inverse).
+
+    Unlike the other transforms this maps array <-> tuple-of-arrays, so it is used by the
+    dedicated RNN adapters (to un-fuse brainstate's ``(in+h, ...)`` kernel into separate
+    input/recurrent kernels) rather than by the generic per-role engine.
+
+    Parameters
+    ----------
+    axis : int
+        Axis along which to split / concatenate.
+    sizes : tuple of int
+        Sizes of the consecutive chunks along ``axis``.
+    """
+
+    def __init__(self, axis: int, sizes: Sequence[int]):
+        self.axis = axis
+        self.sizes = tuple(sizes)
+
+    def forward(self, x) -> tuple:
+        idx = np.cumsum(self.sizes)[:-1].tolist()
+        return tuple(u.math.split(x, idx, axis=self.axis))
+
+    def inverse(self, xs) -> object:
+        return u.math.concatenate(list(xs), axis=self.axis)
+
+    def __repr__(self):
+        return f"SplitConcat(axis={self.axis}, sizes={self.sizes})"
+
+
+class Chain(Transform):
+    """Compose transforms: ``forward`` applies left-to-right, ``inverse`` right-to-left.
+
+    Parameters
+    ----------
+    *transforms : Transform
+        The transforms to compose. ``forward`` applies ``transforms[0]`` first.
+    """
+
+    def __init__(self, *transforms: Transform):
+        self.transforms = transforms
+
+    def forward(self, x):
+        for tf in self.transforms:
+            x = tf.forward(x)
+        return x
+
+    def inverse(self, x):
+        for tf in reversed(self.transforms):
+            x = tf.inverse(x)
+        return x
+
+    def __repr__(self):
+        return f"Chain({', '.join(map(repr, self.transforms))})"

--- a/brainstate/interop/_transforms_test.py
+++ b/brainstate/interop/_transforms_test.py
@@ -1,0 +1,139 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Unit tests for the invertible weight-layout transforms."""
+
+import brainunit as u
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest
+
+import brainstate
+from brainstate.interop._transforms import (AddScalar, Chain, Identity,
+                                            PermuteAxes, ReorderBlocks, Reshape,
+                                            SplitConcat, Transpose)
+
+
+def _arr(*shape):
+    return brainstate.random.randn(*shape)
+
+
+class TransformInvertibilityTest(absltest.TestCase):
+    """Every transform must satisfy ``inverse(forward(x)) == x``."""
+
+    def assertRoundTrip(self, tf, x):
+        np.testing.assert_allclose(np.asarray(tf.inverse(tf.forward(x))),
+                                   np.asarray(x), rtol=1e-6, atol=1e-6)
+
+    def test_identity(self):
+        x = _arr(3, 4)
+        self.assertIs(Identity().forward(x), x)
+        self.assertIs(Identity().inverse(x), x)
+        self.assertRoundTrip(Identity(), x)
+
+    def test_transpose_forward_and_roundtrip(self):
+        x = _arr(2, 3, 4)
+        tf = Transpose((2, 0, 1))
+        y = tf.forward(x)
+        self.assertEqual(y.shape, (4, 2, 3))
+        np.testing.assert_array_equal(np.asarray(y), np.transpose(np.asarray(x), (2, 0, 1)))
+        self.assertRoundTrip(tf, x)
+
+    def test_transpose_inverse_perm_is_argsort(self):
+        tf = Transpose((2, 0, 1))
+        self.assertEqual(tf.inv_perm, (1, 2, 0))
+
+    def test_permute_axes_is_transpose(self):
+        x = _arr(2, 3)
+        tf = PermuteAxes((1, 0))
+        self.assertEqual(tf.forward(x).shape, (3, 2))
+        self.assertRoundTrip(tf, x)
+
+    def test_reshape_roundtrip(self):
+        x = _arr(6)
+        tf = Reshape(forward_shape=lambda s: (1, 1, s[0]), inverse_shape=lambda s: (s[-1],))
+        y = tf.forward(x)
+        self.assertEqual(y.shape, (1, 1, 6))
+        self.assertRoundTrip(tf, x)
+
+    def test_add_scalar(self):
+        x = _arr(5)
+        tf = AddScalar(1.0)
+        np.testing.assert_allclose(np.asarray(tf.forward(x)), np.asarray(x) + 1.0, rtol=1e-6)
+        np.testing.assert_allclose(np.asarray(tf.inverse(x)), np.asarray(x) - 1.0, rtol=1e-6)
+        self.assertRoundTrip(tf, x)
+
+    def test_reorder_blocks_specific(self):
+        # four blocks [a, b, c, d]; order (0, 2, 1, 3) swaps the middle pair (self-inverse).
+        x = jnp.concatenate([jnp.full((2,), float(i)) for i in range(4)])
+        tf = ReorderBlocks(axis=0, order=(0, 2, 1, 3))
+        y = tf.forward(x)
+        np.testing.assert_array_equal(np.asarray(y[:2]), 0.0)
+        np.testing.assert_array_equal(np.asarray(y[2:4]), 2.0)
+        np.testing.assert_array_equal(np.asarray(y[4:6]), 1.0)
+        np.testing.assert_array_equal(np.asarray(y[6:]), 3.0)
+        self.assertRoundTrip(tf, x)
+
+    def test_reorder_blocks_nontrivial_order(self):
+        x = _arr(12, 5)
+        tf = ReorderBlocks(axis=0, order=(2, 0, 3, 1))
+        self.assertEqual(tf.inv_order, tuple(int(i) for i in np.argsort((2, 0, 3, 1))))
+        self.assertRoundTrip(tf, x)
+
+    def test_split_concat(self):
+        x = _arr(10, 4)
+        tf = SplitConcat(axis=0, sizes=(3, 7))
+        parts = tf.forward(x)
+        self.assertEqual(len(parts), 2)
+        self.assertEqual(parts[0].shape, (3, 4))
+        self.assertEqual(parts[1].shape, (7, 4))
+        back = tf.inverse(parts)
+        np.testing.assert_array_equal(np.asarray(back), np.asarray(x))
+
+    def test_chain_order_and_roundtrip(self):
+        x = _arr(2, 3)
+        tf = Chain(Transpose((1, 0)), AddScalar(2.0))
+        # forward = transpose then +2
+        y = tf.forward(x)
+        self.assertEqual(y.shape, (3, 2))
+        np.testing.assert_allclose(np.asarray(y),
+                                   np.transpose(np.asarray(x), (1, 0)) + 2.0, rtol=1e-6)
+        self.assertRoundTrip(tf, x)
+
+    def test_repr_smoke(self):
+        for tf in (Identity(), Transpose((1, 0)), AddScalar(1.0),
+                   ReorderBlocks(0, (1, 0)), SplitConcat(0, (1, 1)),
+                   Chain(Identity())):
+            self.assertIsInstance(repr(tf), str)
+
+
+class TransformQuantityTest(absltest.TestCase):
+    """Transforms must preserve ``brainunit.Quantity`` units."""
+
+    def test_transpose_preserves_units(self):
+        x = brainstate.random.randn(2, 3) * u.mV
+        y = Transpose((1, 0)).forward(x)
+        self.assertTrue(u.get_unit(y) == u.get_unit(x))
+        self.assertEqual(y.shape, (3, 2))
+
+    def test_reshape_preserves_units(self):
+        x = brainstate.random.randn(6) * u.mV
+        tf = Reshape(forward_shape=lambda s: (2, 3), inverse_shape=lambda s: (6,))
+        y = tf.forward(x)
+        self.assertTrue(u.get_unit(y) == u.get_unit(x))
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,8 @@ brainpy-state
 pytest
 coverage
 absl-py
+flax
+equinox
 
 # type checking
 mypy>=1.11


### PR DESCRIPTION
Add a `brainstate.interop` subpackage that converts standard-layer models
between brainstate.nn and flax.nnx / flax.linen / equinox in both directions,
transferring architecture and weights with numerical forward-equivalence.

- Public API: from_nnx/to_nnx, from_linen/to_linen, from_equinox/to_equinox,
  plus register_layer_mapping and supported_layers.
- Generic leaf-first conversion engine over a framework-neutral registry of
  bidirectional LayerMappings, with invertible weight-layout transforms.
- Layers: Linear, Embedding, LayerNorm, RMSNorm, GroupNorm, Dropout,
  Conv{1,2,3}d, BatchNorm{1,2,3}d (nnx/linen), LSTMCell, and Sequential stacks.
- Honest scope: GRUCell (Cho-2014 vs cuDNN variant), vanilla RNN / MGU / URLSTM,
  and equinox BatchNorm raise informative errors rather than wrong models.
- brainstate-internal paths are confined to _common.py; mappings stay
  framework-neutral so user models never depend on brainstate layout details.
- 69 tests (transforms, registry, round-trip + forward-equivalence per layer
  and framework, error paths) at 95% package coverage.
