### PR TITLE
feat(transform): add tqdm-free fallback for ProgressBar, make tqdm optional

### DIFF
--- a/brainstate/transform/_progress_bar.py
+++ b/brainstate/transform/_progress_bar.py
@@ -16,6 +16,9 @@
 
 import copy
 import importlib.util
+import shutil
+import sys
+import time
 from typing import Optional, Callable, Any, Tuple, Dict
 
 import jax
@@ -29,6 +32,234 @@ __all__ = [
 Index = int
 Carray = Any
 Output = Any
+
+
+class _FallbackProgressBar:
+    """
+    A minimal, dependency-free progress bar used when :mod:`tqdm` is unavailable.
+
+    This class reproduces the small slice of the :mod:`tqdm` API that
+    :class:`ProgressBarRunner` relies on (construction from an iterable,
+    :meth:`set_description`, :meth:`update`, and :meth:`close`), so it can be
+    used as a drop-in replacement. It renders a single-line, tqdm-like progress
+    display containing a description, percentage, a Unicode bar, the
+    iteration count, elapsed time, an ETA, and an iteration rate.
+
+    The renderer is terminal aware. When the output stream is an interactive
+    terminal, the line is redrawn in place using a carriage return. When the
+    output is redirected (a file, a CI log, or a notebook), each update is
+    written on its own line so no carriage-return control characters leak into
+    the captured text.
+
+    Parameters
+    ----------
+    iterable : iterable, optional
+        Iterable whose length provides ``total`` when ``total`` is not given.
+        Only its length is used; it is not consumed.
+    total : int, optional
+        Total number of iterations. Falls back to ``len(iterable)`` and finally
+        to ``None`` (an unknown-total display) when neither is available.
+    desc : str, optional
+        Description shown as a prefix (``"desc: "``).
+    file : file-like, optional
+        Output stream. Defaults to :data:`sys.stderr` (matching :mod:`tqdm`).
+    disable : bool, default False
+        When ``True`` every method becomes a no-op and nothing is written.
+    ncols : int, optional
+        Fixed total width in columns. When omitted the terminal width is queried
+        via :func:`shutil.get_terminal_size`.
+    _time : callable, optional
+        Zero-argument clock returning seconds, used for elapsed/rate/ETA. Defaults
+        to :func:`time.monotonic`. Exposed mainly to make tests deterministic.
+    **ignored
+        Any further :mod:`tqdm`-specific keyword arguments (for example
+        ``colour``, ``leave``, ``unit``, ``position``). They are accepted and
+        ignored so code written for :mod:`tqdm` does not break.
+
+    See Also
+    --------
+    ProgressBar : The public progress-bar configuration object.
+
+    Notes
+    -----
+    Only a single bar is supported; nested/positioned bars are not. The
+    iteration rate is an exponential moving average (smoothing ``0.3``) of the
+    instantaneous rate, matching the feel of :mod:`tqdm`, and falls back to the
+    overall average until enough data is available.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import io
+        >>> from brainstate.transform._progress_bar import _FallbackProgressBar
+        >>> buf = io.StringIO()
+        >>> bar = _FallbackProgressBar(total=4, desc="Train", file=buf)
+        >>> for _ in range(4):
+        ...     bar.update(1)
+        >>> bar.close()
+        >>> "4/4" in buf.getvalue()
+        True
+    """
+    __module__ = "brainstate.transform"
+
+    def __init__(
+        self,
+        iterable=None,
+        *,
+        total: Optional[int] = None,
+        desc: Optional[str] = None,
+        file=None,
+        disable: bool = False,
+        ncols: Optional[int] = None,
+        _time: Optional[Callable[[], float]] = None,
+        **ignored,
+    ):
+        if total is None and iterable is not None:
+            try:
+                total = len(iterable)
+            except TypeError:
+                total = None
+        self.total = total
+        self.n = 0
+        self.desc = desc or ''
+        self.file = file if file is not None else sys.stderr
+        self.disable = bool(disable)
+        self.ncols = ncols
+        self._time = _time if _time is not None else time.monotonic
+
+        self._start = self._time()
+        self._last_time = self._start
+        self._last_n = 0
+        self._ema_rate: Optional[float] = None
+        self._last_line_len = 0
+        self._closed = False
+
+        self._is_tty = bool(getattr(self.file, 'isatty', lambda: False)())
+        enc = getattr(self.file, 'encoding', None)
+        self._ascii = bool(enc) and 'utf' not in enc.lower()
+
+    # -- public tqdm-compatible API --
+
+    def set_description(self, desc=None, refresh: bool = True):
+        """Set the description prefix, optionally redrawing immediately."""
+        self.desc = desc or ''
+        if refresh and not self.disable and not self._closed:
+            self._render()
+
+    def update(self, n: int = 1):
+        """Advance the counter by ``n`` iterations and redraw."""
+        if self.disable or self._closed:
+            return
+        self.n += n
+        self._render()
+
+    def close(self):
+        """Render the final state and terminate the line."""
+        if self.disable or self._closed:
+            return
+        self._closed = True
+        self._render(final=True)
+
+    # -- internals --
+
+    def _update_rate(self):
+        if self.n <= self._last_n:
+            return
+        now = self._time()
+        dt = now - self._last_time
+        if dt <= 0:
+            return
+        inst = (self.n - self._last_n) / dt
+        if self._ema_rate is None:
+            self._ema_rate = inst
+        else:
+            self._ema_rate = 0.3 * inst + 0.7 * self._ema_rate
+        self._last_time = now
+        self._last_n = self.n
+
+    def _current_rate(self) -> Optional[float]:
+        if self._ema_rate is not None:
+            return self._ema_rate
+        elapsed = self._time() - self._start
+        if elapsed > 0 and self.n > 0:
+            return self.n / elapsed
+        return None
+
+    @staticmethod
+    def _format_interval(seconds: float) -> str:
+        # Guard against NaN / +-inf, then clamp negatives to zero.
+        if seconds != seconds or seconds in (float('inf'), float('-inf')):
+            return '?'
+        total = max(int(seconds), 0)
+        h, rem = divmod(total, 3600)
+        m, s = divmod(rem, 60)
+        if h:
+            return f'{h:d}:{m:02d}:{s:02d}'
+        return f'{m:02d}:{s:02d}'
+
+    def _make_bar(self, frac: float, reserved: int) -> str:
+        if self.ncols is not None:
+            cols = self.ncols
+        else:
+            cols = shutil.get_terminal_size(fallback=(80, 20)).columns
+        width = cols - reserved
+        if width <= 0:
+            return ''
+        charset = ' 123456789#' if self._ascii else ' ▏▎▍▌▋▊▉█'
+        full_char = charset[-1]
+        n_parts = len(charset) - 1
+        filled = frac * width
+        full = int(filled)
+        if full >= width:
+            return full_char * width
+        bar = full_char * full
+        idx = int((filled - full) * n_parts)
+        bar += charset[idx]
+        bar += ' ' * (width - full - 1)
+        return bar
+
+    def _format_line(self) -> str:
+        prefix = f'{self.desc}: ' if self.desc else ''
+        elapsed = self._format_interval(self._time() - self._start)
+        rate = self._current_rate()
+        rate_str = f'{rate:.2f}it/s' if rate else '?it/s'
+        if self.total:
+            frac = min(max(self.n / self.total, 0.0), 1.0)
+            pct = int(frac * 100)
+            if rate and rate > 0:
+                eta = self._format_interval((self.total - self.n) / rate)
+            else:
+                eta = '?'
+            right = f'{self.n}/{self.total} [{elapsed}<{eta}, {rate_str}]'
+            left = f'{prefix}{pct:3d}%|'
+            bar = self._make_bar(frac, len(left) + len(right) + 2)
+            return f'{left}{bar}| {right}'
+        return f'{prefix}{self.n}it [{elapsed}, {rate_str}]'
+
+    def _write(self, text: str):
+        try:
+            self.file.write(text)
+        except UnicodeEncodeError:
+            enc = getattr(self.file, 'encoding', None) or 'ascii'
+            self.file.write(text.encode(enc, errors='replace').decode(enc))
+        flush = getattr(self.file, 'flush', None)
+        if flush is not None:
+            flush()
+
+    def _render(self, final: bool = False):
+        if self.disable:
+            return
+        self._update_rate()
+        line = self._format_line()
+        if self._is_tty:
+            pad = max(self._last_line_len - len(line), 0)
+            self._write('\r' + line + ' ' * pad)
+            self._last_line_len = len(line)
+            if final:
+                self._write('\n')
+        else:
+            self._write(line + '\n')
 
 
 class ProgressBar(object):
@@ -62,6 +293,13 @@ class ProgressBar(object):
         displayed. Can be either a string or a tuple of (format_string, format_function).
     **kwargs
         Additional keyword arguments to pass to the progress bar.
+
+    Notes
+    -----
+    ``tqdm`` is an optional dependency. When it is installed, the bar is rendered
+    with :mod:`tqdm`. When it is not installed, a built-in pure-Python fallback
+    (:class:`_FallbackProgressBar`) renders an equivalent terminal progress bar,
+    so :class:`ProgressBar` works in either environment with no code changes.
 
     Examples
     --------
@@ -163,10 +401,6 @@ class ProgressBar(object):
                 assert callable(desc[1]), 'Description should be a callable.'
         self.desc = desc
 
-        # check if tqdm is installed
-        if not tqdm_installed:
-            raise ImportError("tqdm is not installed.")
-
     def init(self, n: int):
         kwargs = copy.copy(self.kwargs)
         freq = self.print_freq
@@ -212,8 +446,12 @@ class ProgressBarRunner(object):
         self.message = message
 
     def _define_tqdm(self, x: dict):
-        from tqdm.auto import tqdm
-        self.tqdm_bars[0] = tqdm(range(self.n), **self.kwargs)
+        # Read the module flag at call time so it can be monkeypatched in tests.
+        if tqdm_installed:
+            from tqdm.auto import tqdm as bar_cls
+        else:
+            bar_cls = _FallbackProgressBar
+        self.tqdm_bars[0] = bar_cls(range(self.n), **self.kwargs)
         if isinstance(self.message, str):
             self.tqdm_bars[0].set_description(self.message, refresh=False)
         else:

--- a/brainstate/transform/_progress_bar_test.py
+++ b/brainstate/transform/_progress_bar_test.py
@@ -22,12 +22,62 @@ stay fast; the assertions check the numerical loop result, which also forces the
 ``tqdm`` callbacks (define/update/close) to actually execute.
 """
 
+import contextlib
+import io
 import unittest
+from unittest import mock
 
 import jax.numpy as jnp
 
 import brainstate
 from brainstate.transform import ProgressBar
+from brainstate.transform import _progress_bar as _pbmod
+from brainstate.transform._progress_bar import _FallbackProgressBar
+
+
+class _TTYStringIO(io.StringIO):
+    """A ``StringIO`` that reports itself as an interactive terminal."""
+
+    def isatty(self):
+        return True
+
+
+class _AsciiFile:
+    """A minimal non-UTF output stream used to drive the ASCII bar charset."""
+
+    encoding = "ascii"
+
+    def __init__(self):
+        self.parts = []
+
+    def write(self, s):
+        self.parts.append(s)
+
+    def flush(self):
+        pass
+
+    def isatty(self):
+        return False
+
+    def getvalue(self):
+        return "".join(self.parts)
+
+
+def _make_clock(step=0.1, start=0.0):
+    """Return a deterministic monotonic-like clock that advances by ``step``.
+
+    The first call returns ``start``; each subsequent call advances by ``step``.
+    """
+    state = {"t": start, "first": True}
+
+    def clock():
+        if state["first"]:
+            state["first"] = False
+            return state["t"]
+        state["t"] += step
+        return state["t"]
+
+    return clock
 
 
 class TestProgressBarConstruction(unittest.TestCase):
@@ -126,6 +176,223 @@ class TestProgressBarRunnerMessages(unittest.TestCase):
         ys = brainstate.transform.for_loop(lambda x: x * 2, jnp.arange(5.0), pbar=pbar)
         ys.block_until_ready()
         self.assertEqual(ys.shape, (5,))
+
+
+class TestFallbackProgressBar(unittest.TestCase):
+    """Unit tests for the dependency-free fallback bar (``_FallbackProgressBar``)."""
+
+    def test_basic_progression_to_100(self):
+        """Driving the bar to ``total`` shows a full count and 100%."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=4, file=buf, ncols=80)
+        for _ in range(4):
+            bar.update(1)
+        bar.close()
+        out = buf.getvalue()
+        self.assertIn("4/4", out)
+        self.assertIn("100%", out)
+
+    def test_midpoint_percentage(self):
+        """Half-way progress renders ``50%``."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=10, file=buf, ncols=80)
+        bar.update(5)
+        self.assertIn(" 50%", buf.getvalue())
+
+    def test_tty_uses_carriage_return_and_single_trailing_newline(self):
+        """On a TTY: ``\\r`` redraws, no newline until ``close`` adds exactly one."""
+        buf = _TTYStringIO()
+        bar = _FallbackProgressBar(total=4, file=buf, ncols=60)
+        bar.update(1)
+        mid = buf.getvalue()
+        self.assertIn("\r", mid)
+        self.assertNotIn("\n", mid)
+        bar.update(3)
+        bar.close()
+        out = buf.getvalue()
+        self.assertTrue(out.endswith("\n"))
+        self.assertEqual(out.count("\n"), 1)
+
+    def test_non_tty_writes_newline_per_update_no_cr(self):
+        """Off a TTY: one line per update, never a carriage return."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=3, file=buf, ncols=60)
+        bar.update(1)
+        bar.update(1)
+        out = buf.getvalue()
+        self.assertNotIn("\r", out)
+        self.assertEqual(out.count("\n"), 2)
+
+    def test_rate_eta_elapsed_present_with_advancing_clock(self):
+        """An advancing clock yields a concrete rate and an elapsed<ETA field."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=10, file=buf, ncols=80, _time=_make_clock(step=0.1))
+        for _ in range(5):
+            bar.update(1)
+        last = buf.getvalue().splitlines()[-1]
+        self.assertIn("it/s", last)
+        self.assertNotIn("?it/s", last)
+        self.assertIn("<", last)
+
+    def test_rate_unknown_when_no_time_elapses(self):
+        """With a frozen clock the rate is unknown (``?it/s``)."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=10, file=buf, ncols=80, _time=lambda: 5.0)
+        bar.update(1)
+        self.assertIn("?it/s", buf.getvalue())
+
+    def test_unknown_total_branch(self):
+        """No total -> count/elapsed form with no percentage or bar."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(file=buf)
+        bar.update(3)
+        bar.close()
+        out = buf.getvalue()
+        self.assertIn("3it", out)
+        self.assertNotIn("%", out)
+
+    def test_total_inferred_from_iterable_length(self):
+        """``total`` defaults to ``len(iterable)`` when not given."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(range(7), file=buf, ncols=80)
+        bar.update(7)
+        self.assertIn("7/7", buf.getvalue())
+
+    def test_disable_produces_no_output(self):
+        """``disable=True`` makes every method a no-op."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=5, file=buf, disable=True)
+        bar.update(5)
+        bar.close()
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_description_prefix_and_set_description(self):
+        """The description is shown as a prefix and can be changed."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=4, desc="Train", file=buf, ncols=80)
+        bar.update(1)
+        self.assertIn("Train:", buf.getvalue())
+        bar.set_description("Eval")
+        self.assertIn("Eval:", buf.getvalue())
+
+    def test_unknown_tqdm_kwargs_ignored(self):
+        """tqdm-only kwargs are accepted and ignored without error."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(
+            range(3), file=buf, ncols=80,
+            colour="green", leave=False, unit="it", position=0,
+        )
+        bar.update(3)
+        bar.close()
+        self.assertIn("3/3", buf.getvalue())
+
+    def test_narrow_terminal_drops_bar_but_keeps_counts(self):
+        """A tiny ``ncols`` drops the bar yet still shows the counts."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=10, file=buf, ncols=5)
+        bar.update(5)
+        out = buf.getvalue()
+        self.assertIn("5/10", out)
+        self.assertNotIn("█", out)
+
+    def test_ascii_charset_for_non_utf_stream(self):
+        """A non-UTF stream uses the ASCII bar charset."""
+        af = _AsciiFile()
+        bar = _FallbackProgressBar(total=4, file=af, ncols=50)
+        bar.update(2)
+        bar.close()
+        out = af.getvalue()
+        self.assertIn("#", out)
+        self.assertNotIn("█", out)
+
+    def test_close_is_idempotent(self):
+        """Calling ``close`` twice does not write a second time."""
+        buf = _TTYStringIO()
+        bar = _FallbackProgressBar(total=2, file=buf, ncols=60)
+        bar.update(2)
+        bar.close()
+        first = buf.getvalue()
+        bar.close()
+        self.assertEqual(buf.getvalue(), first)
+
+    def test_update_after_close_is_noop(self):
+        """Updating after ``close`` writes nothing further."""
+        buf = io.StringIO()
+        bar = _FallbackProgressBar(total=4, file=buf, ncols=60)
+        bar.update(4)
+        bar.close()
+        snapshot = buf.getvalue()
+        bar.update(1)
+        self.assertEqual(buf.getvalue(), snapshot)
+
+    def test_format_interval(self):
+        """``_format_interval`` formats seconds, hours, and guards bad input."""
+        self.assertEqual(_FallbackProgressBar._format_interval(5), "00:05")
+        self.assertEqual(_FallbackProgressBar._format_interval(3725), "1:02:05")
+        self.assertEqual(_FallbackProgressBar._format_interval(-3), "00:00")
+        self.assertEqual(_FallbackProgressBar._format_interval(float("inf")), "?")
+        self.assertEqual(_FallbackProgressBar._format_interval(float("nan")), "?")
+
+    def test_unicode_encode_error_falls_back(self):
+        """A unicode description on an ASCII stream is replaced, not raised."""
+
+        class _StrictAsciiFile(io.StringIO):
+            encoding = "ascii"
+
+            def isatty(self):
+                return False
+
+            def write(self, s):
+                s.encode("ascii")  # raises UnicodeEncodeError on non-ascii
+                return super().write(s)
+
+        buf = _StrictAsciiFile()
+        bar = _FallbackProgressBar(total=4, desc="Δelta", file=buf, ncols=60)
+        bar.update(2)  # line carries the unicode desc -> exercises the except path
+        bar.close()
+        self.assertIn("2/4", buf.getvalue())
+
+
+class TestProgressBarFallbackIntegration(unittest.TestCase):
+    """Force the fallback path (``tqdm`` reported absent) through real loops."""
+
+    def test_construction_does_not_raise_without_tqdm(self):
+        """``ProgressBar`` constructs even when ``tqdm`` is unavailable."""
+        with mock.patch.object(_pbmod, "tqdm_installed", False):
+            ProgressBar(freq=2)
+
+    def test_for_loop_uses_fallback(self):
+        """``for_loop`` runs correctly and emits to the fallback bar."""
+        with mock.patch.object(_pbmod, "tqdm_installed", False):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                ys = brainstate.transform.for_loop(
+                    lambda x: x * 2, jnp.arange(10.0), pbar=ProgressBar(freq=2)
+                )
+                ys.block_until_ready()
+            self.assertTrue(bool(jnp.allclose(ys, jnp.arange(10.0) * 2)))
+            self.assertNotEqual(err.getvalue(), "")
+
+    def test_scan_with_dynamic_desc_uses_fallback(self):
+        """``scan`` with a ``(fmt, fn)`` desc renders through the fallback."""
+        with mock.patch.object(_pbmod, "tqdm_installed", False):
+
+            def step(c, x):
+                return c + x, c + x
+
+            def fmt(d):
+                return {"i": d["i"]}
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                _, ys = brainstate.transform.scan(
+                    step, 0.0, jnp.arange(6.0),
+                    pbar=ProgressBar(freq=2, desc=("iter {i}", fmt)),
+                )
+                ys.block_until_ready()
+            out = err.getvalue()
+            self.assertNotEqual(out, "")
+            self.assertIn("iter", out)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ keywords = [
 
 dependencies = [
     'numpy>=1.15',
-    'tqdm',
     'brainunit',
     'brainevent',
 ]
@@ -74,6 +73,9 @@ repository = 'https://github.com/chaobrain/brainstate'
 "Bug Tracker" = "https://github.com/chaobrain/brainstate/issues"
 
 [project.optional-dependencies]
+progressbar = [
+    'tqdm',
+]
 cpu = [
     'jax[cpu]>=0.6.0',
     'brainunit',
@@ -99,6 +101,7 @@ testing = [
     'pytest',
     'coverage',
     'jax>=0.6.0',
+    'tqdm',
     'brainunit',
     'brainevent',
 ]


### PR DESCRIPTION
When tqdm is not installed, ProgressBar now renders via a built-in
pure-Python _FallbackProgressBar instead of raising ImportError. The
fallback reproduces the tqdm API slice the runner uses (construction,
set_description, update, close) and draws a full tqdm-like line (bar,
percentage, count, rate, elapsed, ETA). It is TTY-aware: an updating
single line via carriage return on an interactive terminal, one line
per update when output is redirected.

tqdm is moved from required dependencies to an optional 'progressbar'
extra (and kept in the 'testing' extra so the real-tqdm path stays
covered in CI).
