### PR TITLE
fix: stop emitting jax.core.DropVar deprecation warning

### DIFF
--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -87,7 +87,6 @@ __all__ = [
 
     'trace_ctx',
     'DebugInfo',
-    'DropVar',
     'CallPrimitive',
     'Effect',
     'Effects',
@@ -140,7 +139,10 @@ if jax.__version_info__ < (0, 7, 1):
 else:
     from jax._src.interpreters.batching import make_iota, to_elt, BatchTracer, BatchTrace
 
-from jax.core import DropVar
+# NOTE: ``DropVar`` is imported (version-conditionally) in the JAX-0.10 block
+# below -- from ``jax.extend.core`` on jax>=0.10 and ``jax.core`` on older
+# releases. Do not add an unconditional ``from jax.core import DropVar`` here:
+# on jax>=0.10 that path is deprecated and emits a DeprecationWarning at import.
 
 if jax.__version_info__ < (0, 4, 38):
     from jax.core import (

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -26,6 +26,7 @@ functionality, including:
 """
 
 import unittest
+import warnings
 from functools import partial
 from unittest.mock import Mock
 
@@ -632,6 +633,45 @@ class TestModuleStructure(unittest.TestCase):
         """Test module has proper docstring."""
         self.assertIsNotNone(compat.__doc__)
         self.assertIn('Compatibility layer', compat.__doc__)
+
+    def test_all_has_no_duplicates(self):
+        """``__all__`` must not contain duplicate names.
+
+        ``DropVar`` was previously listed twice; this guards against the
+        duplicate (or any other) reappearing.
+        """
+        seen = [name for name in compat.__all__]
+        duplicates = {name for name in seen if seen.count(name) > 1}
+        self.assertEqual(duplicates, set(),
+                         f"Duplicate names in __all__: {sorted(duplicates)}")
+
+
+class TestDeprecationFreeImports(unittest.TestCase):
+    """Guard against re-introducing deprecated JAX import paths."""
+
+    def test_dropvar_available(self):
+        """``DropVar`` is exported and importable across JAX versions."""
+        self.assertTrue(hasattr(compat, 'DropVar'))
+        self.assertEqual(compat.DropVar.__name__, 'DropVar')
+
+    def test_dropvar_import_emits_no_deprecation_warning(self):
+        """Importing the compat layer must not emit a ``DropVar`` DeprecationWarning.
+
+        On jax>=0.10 ``jax.core.DropVar`` is deprecated; ``DropVar`` must be
+        sourced from ``jax.extend.core`` instead (handled by the JAX-0.10
+        version-conditional block). Reloading re-executes the module's
+        top-level imports, so any deprecated path would surface here.
+        """
+        import importlib
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            importlib.reload(compat)
+        dropvar_warnings = [
+            str(w.message) for w in caught
+            if issubclass(w.category, DeprecationWarning) and 'DropVar' in str(w.message)
+        ]
+        self.assertEqual(dropvar_warnings, [],
+                         f"Unexpected DropVar deprecation warning(s): {dropvar_warnings}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

`brainstate/_compatible_import.py` had a stray, **unconditional** `from jax.core import DropVar`. On jax>=0.10 that path is deprecated and emits a `DeprecationWarning` at import. The line was also **redundant**: `DropVar` is already imported version-conditionally in the JAX-0.10 block below (from `jax.extend.core` on jax>=0.10, `jax.core` on older releases).

## Changes
- Remove the redundant `from jax.core import DropVar` (replaced with a NOTE to prevent regression).
- De-duplicate `'DropVar'` in `__all__`.
- Add regression tests: no `DropVar` `DeprecationWarning` on import, and no duplicate names in `__all__`.

## Verification
- `ci.DropVar is jax.extend.core.DropVar` → `True` on jax 0.10.1.
- No `DropVar` deprecation warning on import.
- `_compatible_import_test.py` + `_ir_visualize_test.py` (the main `DropVar` consumer): 89 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix DropVar import handling in the JAX compatibility layer to avoid deprecation warnings and duplicate exports.

Bug Fixes:
- Ensure DropVar is imported only via supported, version-conditional JAX paths to prevent DeprecationWarning on import.
- Remove duplicate DropVar entry from the compatibility module's public export list.

Tests:
- Add regression tests to assert __all__ contains no duplicate names.
- Add regression tests to verify DropVar remains available without emitting deprecation warnings on import across JAX versions.