### PR TITLE
fix(transform): harden state-based transformation APIs (audit H1-H4, M1-M5, F5, Tier C)

### DIFF
--- a/brainstate/transform/_checkify.py
+++ b/brainstate/transform/_checkify.py
@@ -177,7 +177,13 @@ def checkify(fun: Callable, errors: Any = user_checks) -> Callable:
 
         # 3. Functionalize the checks; the Error is threaded out.
         checked = _cfy.checkify(pure, errors)
-        err, (out, write_vals) = checked(orig_vals, args, kwargs)
+        try:
+            err, (out, write_vals) = checked(orig_vals, args, kwargs)
+        except Exception:
+            # a failure mid-trace must not leave tracers in the states
+            for st, ov in zip(all_states, orig_vals):
+                st.restore_value(ov)
+            raise
 
         # 4. Restore ALL states: writes -> new values, reads -> originals
         #    (prevents tracers leaking into the global State objects).

--- a/brainstate/transform/_checkify_test.py
+++ b/brainstate/transform/_checkify_test.py
@@ -121,3 +121,25 @@ class TestCheckify(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestFailedCheckifyRestoresStates(unittest.TestCase):
+    """A failure inside the checkify pass must not leave tracers in states
+    (audit M5: restoration only ran on success)."""
+
+    def test_failure_inside_checkify_restores_states(self):
+        s = brainstate.State(jnp.asarray(0.0))
+        calls = {'n': 0}
+
+        def f(x):
+            s.value = s.value + x
+            calls['n'] += 1
+            if calls['n'] >= 2:  # first call: discovery trace; second: checkify pass
+                raise RuntimeError('boom')
+            return x * 2.0
+
+        checked = brainstate.transform.checkify(f)
+        with self.assertRaises(RuntimeError):
+            checked(jnp.asarray(3.0))
+        self.assertFalse(isinstance(s.value, jax.core.Tracer))
+        self.assertEqual(float(s.value), 0.0)

--- a/brainstate/transform/_conditions.py
+++ b/brainstate/transform/_conditions.py
@@ -119,7 +119,7 @@ def cond(pred: ArrayLike, true_fun: Callable, false_fun: Callable, *operands) ->
 
     # evaluate jaxpr
     stateful_true = StatefulFunction(true_fun, name='cond:true').make_jaxpr(*operands)
-    stateful_false = StatefulFunction(false_fun, name='conda:false').make_jaxpr(*operands)
+    stateful_false = StatefulFunction(false_fun, name='cond:false').make_jaxpr(*operands)
 
     # state trace and state values
     state_trace = (stateful_true.get_state_trace(*operands) +
@@ -281,28 +281,32 @@ def ifelse(
 
     Notes
     -----
-    When ``check_cond`` is ``True``, exactly one condition must evaluate to ``True``.
-    A common pattern is to make the final condition ``True`` to encode a default
-    branch.
+    Unlike a Python ``if``/``elif`` chain, conditions are evaluated together rather
+    than first-true-wins, so when ``check_cond`` is ``True`` (the default) they must
+    be **mutually exclusive**: exactly one condition may evaluate to ``True``,
+    otherwise a runtime error is raised. With ``check_cond=False`` the check is
+    skipped and the first ``True`` condition wins (falling back to the last branch
+    when none is ``True``).
 
     Examples
     --------
     .. code-block:: python
 
+        >>> import jax.numpy as jnp
         >>> import brainstate
         >>>
-        >>> def describe(a):
+        >>> def grade(a):
         ...     return brainstate.transform.ifelse(
-        ...         conditions=[a > 5, a > 0, True],
+        ...         conditions=[a > 5, jnp.logical_and(a > 0, a <= 5), a <= 0],
         ...         branches=[
-        ...             lambda: "greater than five",
-        ...             lambda: "positive",
-        ...             lambda: "non-positive",
+        ...             lambda: 2.0,  # greater than five
+        ...             lambda: 1.0,  # positive
+        ...             lambda: 0.0,  # non-positive
         ...         ],
         ...     )
         >>>
-        >>> describe(7)
-        >>> describe(-1)
+        >>> grade(jnp.asarray(7.0))   # 2.0
+        >>> grade(jnp.asarray(-1.0))  # 0.0
     """
     # check branches
     if not all(callable(branch) for branch in branches):

--- a/brainstate/transform/_conditions_test.py
+++ b/brainstate/transform/_conditions_test.py
@@ -338,3 +338,133 @@ class TestIfElseValidation(unittest.TestCase):
             [True, True], [lambda: 1, lambda: 2], check_cond=False
         )
         self.assertEqual(int(out), 1)
+
+
+class TestCrossBranchStateAccess(unittest.TestCase):
+    """States written in one branch but only read (or untouched) in another.
+
+    Regression tests for the ``return_only_write=True`` interaction where a
+    branch that does not write a state in the merged write set produced a
+    ``None`` output slot, crashing ``lax.cond``/``lax.switch`` with a
+    type-structure mismatch between branches.
+    """
+
+    def test_cond_write_in_true_read_in_false(self):
+        a = brainstate.State(jnp.asarray(1.0))
+        b = brainstate.State(jnp.asarray(2.0))
+        r = brainstate.State(jnp.asarray(0.0))
+
+        def true_fn(x):
+            a.value = b.value + x
+
+        def false_fn(x):
+            r.value = a.value + 1.0
+
+        brainstate.transform.cond(True, true_fn, false_fn, 3.0)
+        self.assertEqual(float(a.value), 5.0)
+        self.assertEqual(float(r.value), 0.0)
+        self.assertFalse(isinstance(a.value, Tracer))
+        self.assertFalse(isinstance(r.value, Tracer))
+
+        brainstate.transform.cond(False, true_fn, false_fn, 3.0)
+        self.assertEqual(float(a.value), 5.0)  # untouched by false branch
+        self.assertEqual(float(r.value), 6.0)
+
+    def test_cond_write_in_one_branch_untouched_in_other(self):
+        a = brainstate.State(jnp.asarray(1.0))
+
+        def true_fn():
+            a.value = a.value * 10.0
+
+        def false_fn():
+            pass  # does not touch ``a`` at all
+
+        brainstate.transform.cond(False, true_fn, false_fn)
+        self.assertEqual(float(a.value), 1.0)
+
+        brainstate.transform.cond(True, true_fn, false_fn)
+        self.assertEqual(float(a.value), 10.0)
+
+    def test_cond_cross_writes_under_jit(self):
+        a = brainstate.State(jnp.asarray(1.0))
+        b = brainstate.State(jnp.asarray(2.0))
+
+        @brainstate.transform.jit
+        def step(pred, x):
+            def true_fn():
+                a.value = b.value + x
+
+            def false_fn():
+                b.value = a.value * 10.0
+
+            brainstate.transform.cond(pred, true_fn, false_fn)
+            return a.value + b.value
+
+        out = step(jnp.asarray(True), 3.0)
+        self.assertEqual(float(out), 7.0)
+        self.assertEqual(float(a.value), 5.0)
+        self.assertEqual(float(b.value), 2.0)
+
+        out = step(jnp.asarray(False), 3.0)
+        self.assertEqual(float(out), 55.0)
+        self.assertEqual(float(a.value), 5.0)
+        self.assertEqual(float(b.value), 50.0)
+
+    def test_switch_mixed_read_write_branches(self):
+        a = brainstate.State(jnp.asarray(1.0))
+        c = brainstate.State(jnp.asarray(10.0))
+
+        def write_a(x):
+            a.value = x * 2.0
+
+        def write_c(x):
+            c.value = a.value + x
+
+        def read_only(x):
+            _ = a.value + c.value
+
+        branches = [write_a, write_c, read_only]
+
+        brainstate.transform.switch(jnp.asarray(0), branches, 3.0)
+        self.assertEqual(float(a.value), 6.0)
+        self.assertEqual(float(c.value), 10.0)
+
+        brainstate.transform.switch(jnp.asarray(1), branches, 3.0)
+        self.assertEqual(float(a.value), 6.0)
+        self.assertEqual(float(c.value), 9.0)
+
+        brainstate.transform.switch(jnp.asarray(2), branches, 3.0)
+        self.assertEqual(float(a.value), 6.0)
+        self.assertEqual(float(c.value), 9.0)
+
+    def test_ifelse_mixed_read_write_branches(self):
+        a = brainstate.State(jnp.asarray(0.0))
+
+        def write_branch():
+            a.value = a.value + 1.0
+
+        def read_branch():
+            _ = a.value
+
+        def f(x):
+            return brainstate.transform.ifelse(
+                [x >= 0, x < 0],
+                [write_branch, read_branch],
+            )
+
+        f(jnp.asarray(1.0))
+        self.assertEqual(float(a.value), 1.0)
+
+        f(jnp.asarray(-1.0))
+        self.assertEqual(float(a.value), 1.0)
+
+    def test_cond_read_only_state_in_all_branches(self):
+        """A state read everywhere and written nowhere stays untouched."""
+        a = brainstate.State(jnp.asarray(4.0))
+
+        out = brainstate.transform.cond(
+            True, lambda: a.value + 1.0, lambda: a.value - 1.0
+        )
+        self.assertEqual(float(out), 5.0)
+        self.assertEqual(float(a.value), 4.0)
+        self.assertFalse(isinstance(a.value, Tracer))

--- a/brainstate/transform/_debug.py
+++ b/brainstate/transform/_debug.py
@@ -356,10 +356,25 @@ class DebugNan:
         ------
         RuntimeError
             If NaN or Inf contaminates the function's outputs or updated state.
+            Under an enclosing trace (e.g. ``jit``) the error is raised from an
+            ordered ``jax.debug.callback`` at run time instead.
         """
         err, out_tree = self._checked(self._state_vals(), *self._args)
         out_leaves = jax.tree.leaves(out_tree)
-        if bool(_has_nan_flag(out_leaves)):
+        flag = unvmap(_has_nan_flag(out_leaves), op='any')
+        if isinstance(flag, Tracer):
+            # inside an enclosing trace (e.g. jit) the flag cannot be
+            # concretized -- raise from an ordered callback at run time instead
+            jax.lax.cond(
+                flag,
+                lambda: jax.debug.callback(
+                    functools.partial(_raise_report_cb, phase=self.phase),
+                    err, out_tree, ordered=True,
+                ),
+                lambda: None,
+            )
+            return None
+        if bool(flag):
             _raise_report(err, out_leaves, self.phase)
         return None
 

--- a/brainstate/transform/_debug_test.py
+++ b/brainstate/transform/_debug_test.py
@@ -913,5 +913,37 @@ class TestBreakpointIf(unittest.TestCase):
         self.assertTrue(jnp.allclose(out, 0.0))
 
 
+class TestDebugNanUnderEnclosingJit(unittest.TestCase):
+    """``debug_nan`` (the unconditional ``DebugNan.check()`` path) must be
+    traceable under an enclosing ``jit`` instead of failing with a
+    ``TracerBoolConversionError`` (audit M9)."""
+
+    def test_clean_input_inside_jit_traces_and_runs(self):
+        @bst.transform.jit
+        def g(x):
+            bst.transform.debug_nan(lambda y: y * 2.0, x)
+            return x * 2.0
+
+        out = jax.block_until_ready(g(jnp.asarray(1.5)))
+        self.assertEqual(float(out), 3.0)
+
+    def test_nan_input_inside_jit_raises_at_runtime(self):
+        @bst.transform.jit
+        def g(x):
+            bst.transform.debug_nan(jnp.log, x)
+            return x
+
+        with self.assertRaises(Exception) as ctx:
+            jax.block_until_ready(g(jnp.asarray(-1.0)))
+        self.assertNotIsInstance(ctx.exception, jax.errors.TracerBoolConversionError)
+
+    def test_eager_path_still_concretizes(self):
+        # outside any trace the eager raise (clean RuntimeError) must be kept
+        with self.assertRaises(RuntimeError):
+            bst.transform.debug_nan(jnp.log, jnp.asarray(-1.0))
+        # and a clean eager call stays silent
+        bst.transform.debug_nan(jnp.log, jnp.asarray(2.0))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/transform/_eval_shape.py
+++ b/brainstate/transform/_eval_shape.py
@@ -111,9 +111,13 @@ def eval_shape(
         # Rebuild graph nodes from the pure-pytree inputs before calling f.
         inner_args, inner_kwargs = tree_to_graph((inner_args, inner_kwargs))
         with catch_new_states() as catcher:
-            out = f(*inner_args, **inner_kwargs)
-        caught_box['states'] = catcher.get_states()
-        caught_box['values'] = catcher.get_state_values()
+            try:
+                out = f(*inner_args, **inner_kwargs)
+            finally:
+                # record the created states even when f fails, so the cleanup
+                # below can unwind them
+                caught_box['states'] = catcher.get_states()
+                caught_box['values'] = catcher.get_state_values()
         # Represent a returned Node as a pure pytree so StatefulFunction can derive
         # its output shapes.
         out_tree, _ = graph_to_tree(out)
@@ -121,29 +125,31 @@ def eval_shape(
 
     # One abstract trace via the canonical stateful wrapper.
     stateful_fn = StatefulFunction(_wrapped, name='eval_shape')
-    stateful_fn.make_jaxpr(*g_args, **g_kwargs)
-    out_shapes, state_shapes = stateful_fn.get_out_shapes(*g_args, **g_kwargs)
+    try:
+        stateful_fn.make_jaxpr(*g_args, **g_kwargs)
+        out_shapes, state_shapes = stateful_fn.get_out_shapes(*g_args, **g_kwargs)
 
-    # Reconstruct a Node (if any) from the abstract output pytree. ``tree_to_graph``
-    # builds fresh States bound to the current (top-level) trace, so the reconstructed
-    # Node is already a first-class input to subsequent brainstate transformations
-    # (nested eval_shape, jit/grad/vmap, init_all_states). For plain-array outputs
-    # ``tree_to_graph`` is a no-op passthrough.
-    out = tree_to_graph(out_shapes)
+        # Reconstruct a Node (if any) from the abstract output pytree. ``tree_to_graph``
+        # builds fresh States bound to the current (top-level) trace, so the reconstructed
+        # Node is already a first-class input to subsequent brainstate transformations
+        # (nested eval_shape, jit/grad/vmap, init_all_states). For plain-array outputs
+        # ``tree_to_graph`` is a no-op passthrough.
+        out = tree_to_graph(out_shapes)
 
-    # Build the State -> ShapeDtypeStruct mapping for the optional return. The
-    # state_shapes tuple is aligned with state_trace.states.
-    state_trace = stateful_fn.get_state_trace(*g_args, **g_kwargs)
-    state_shape_map = {st: sh for st, sh in zip(state_trace.states, state_shapes)}
-
-    # States created INSIDE f (the ``lambda: LSTMCell(...)`` case) were elevated to the
-    # abstract trace's stack level. Restore their original values and drop the stack
-    # level so the finished trace does not leak. Mirrors vmap_new_states.
-    new_states = caught_box.get('states', [])
-    new_values = caught_box.get('values', [])
-    for st, val in zip(new_states, new_values):
-        st.restore_value(val)
-        st.decrease_stack_level()
+        # Build the State -> ShapeDtypeStruct mapping for the optional return. The
+        # state_shapes tuple is aligned with state_trace.states.
+        state_trace = stateful_fn.get_state_trace(*g_args, **g_kwargs)
+        state_shape_map = {st: sh for st, sh in zip(state_trace.states, state_shapes)}
+    finally:
+        # States created INSIDE f (the ``lambda: LSTMCell(...)`` case) were elevated
+        # to the abstract trace's stack level. Restore their original values and drop
+        # the stack level so the trace does not leak -- on failure too. Mirrors
+        # vmap_new_states.
+        new_states = caught_box.get('states', [])
+        new_values = caught_box.get('values', [])
+        for st, val in zip(new_states, new_values):
+            st.restore_value(val)
+            st.decrease_stack_level()
 
     if return_state_shapes:
         return state_shape_map, out

--- a/brainstate/transform/_eval_shape_test.py
+++ b/brainstate/transform/_eval_shape_test.py
@@ -152,3 +152,29 @@ class TestEvalShape:
         out = brainstate.transform.eval_shape(f, jnp.ones((5,)))
         assert out.shape == (5,)
         assert out.dtype == jnp.float32
+
+
+class TestFailedEvalShapeUnwindsNewStates:
+    """States created inside ``f`` must be unwound (value + stack level)
+    even when the abstract trace fails (audit M5)."""
+
+    def test_failure_inside_f_unwinds_created_states(self):
+        import pytest
+
+        box = {}
+
+        def f():
+            st = brainstate.ShortTermState(jnp.zeros(3))
+            box['st'] = st
+            raise RuntimeError('boom')
+
+        with pytest.raises(RuntimeError):
+            brainstate.transform.eval_shape(f)
+        st = box['st']
+        # The stack level must be unwound so the orphaned state stays usable.
+        # (Its value is a staged tracer either way -- it was created inside the
+        # abstract trace and never had a concrete value -- so only the level
+        # bookkeeping is observable.)
+        assert st.stack_level == 0
+        st.value = jnp.ones(3)
+        assert bool(jnp.allclose(st.value, jnp.ones(3)))

--- a/brainstate/transform/_grad_checkpoint.py
+++ b/brainstate/transform/_grad_checkpoint.py
@@ -151,6 +151,12 @@ def checkpoint(
         return lambda f: checkpoint(f, prevent_cse=prevent_cse, policy=policy, static_argnums=static_argnums)
 
     static_argnums = _ensure_index_tuple(tuple() if static_argnums is None else static_argnums)
+    if any(i < 0 for i in static_argnums):
+        raise ValueError(
+            f"checkpoint/remat does not support negative static_argnums, got {static_argnums}. "
+            f"A hidden state-value argument is prepended internally, so negative indices "
+            f"would silently point at the wrong argument. Please use non-negative indices."
+        )
     fun = StatefulFunction(fun, static_argnums=static_argnums, name='checkpoint')
     checkpointed_fun = jax.checkpoint(
         fun.jaxpr_call,

--- a/brainstate/transform/_grad_checkpoint_test.py
+++ b/brainstate/transform/_grad_checkpoint_test.py
@@ -77,5 +77,24 @@ class TestCheckpointAliasAndDecorator(unittest.TestCase):
         self.assertTrue(jnp.allclose(result, jnp.sin(jnp.array([0.0, jnp.pi / 2]))))
 
 
+class TestCheckpointNegativeStaticArgnums(unittest.TestCase):
+    """checkpoint/remat prepends a hidden state-value argument before calling
+    ``jax.checkpoint``, so negative ``static_argnums`` would silently point at
+    the wrong argument. They must be rejected up front (audit Tier C)."""
+
+    def test_negative_static_argnums_rejected(self):
+        with self.assertRaisesRegex(ValueError, 'negative'):
+            brainstate.transform.checkpoint(lambda x, n: x * n, static_argnums=-1)
+
+    def test_negative_in_sequence_rejected(self):
+        with self.assertRaisesRegex(ValueError, 'negative'):
+            brainstate.transform.checkpoint(lambda x, n, m: x * n, static_argnums=(1, -1))
+
+    def test_positive_static_argnums_still_work(self):
+        f = brainstate.transform.checkpoint(lambda x, n: x * n, static_argnums=1)
+        out = f(jnp.asarray(3.0), 2.0)
+        self.assertEqual(float(out), 6.0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/transform/_grad_grad_test.py
+++ b/brainstate/transform/_grad_grad_test.py
@@ -584,3 +584,88 @@ class TestForwardGrad(unittest.TestCase):
         leaf = jax.tree.leaves(grads)[0]
         self.assertEqual(leaf.shape, (2,))
         self.assertTrue(bool(jnp.all(jnp.isfinite(leaf))))
+
+
+class TestArgnumsValidation(unittest.TestCase):
+    """Negative or non-integer ``argnums`` must be rejected (audit H3).
+
+    The internal calling convention shifts user argnums by +2 (two leading
+    state-value slots), so a negative argnum silently differentiated an
+    internal slot — e.g. ``argnums=-1`` returned the gradient w.r.t. the
+    state-value dict keyed by raw ``id()`` — instead of raising.
+    """
+
+    def _apis(self):
+        t = brainstate.transform
+        return [t.grad, t.vector_grad, t.jacrev, t.jacfwd, t.hessian]
+
+    def test_negative_int_argnums_raises(self):
+        def loss(x, y):
+            return (x * y) ** 2
+
+        for api in self._apis():
+            with self.assertRaises(ValueError, msg=f'api={api}'):
+                api(loss, argnums=-1)
+        key = brainstate.random.split_key()
+        with self.assertRaises(ValueError):
+            brainstate.transform.fwd_grad(loss, argnums=-1, key=key)
+
+    def test_negative_argnums_in_sequence_raises(self):
+        def loss(x, y):
+            return (x * y) ** 2
+
+        for api in self._apis():
+            with self.assertRaises(ValueError, msg=f'api={api}'):
+                api(loss, argnums=[0, -1])
+
+    def test_negative_argnums_with_grad_states_raises(self):
+        w = brainstate.State(jnp.asarray(1.0))
+
+        def loss(x, y):
+            return (w.value * x * y) ** 2
+
+        with self.assertRaises(ValueError):
+            brainstate.transform.grad(loss, grad_states=w, argnums=-1)
+
+    def test_non_integer_argnums_raises(self):
+        def loss(x, y):
+            return (x * y) ** 2
+
+        for bad in (0.5, True, '0'):
+            with self.assertRaises(ValueError, msg=f'argnums={bad!r}'):
+                brainstate.transform.grad(loss, argnums=bad)
+
+    def test_positive_argnums_values_unchanged(self):
+        w = brainstate.State(jnp.asarray(2.0))
+
+        def loss(x, y):
+            return w.value * x * y
+
+        g = brainstate.transform.grad(loss, argnums=1)(3.0, 4.0)
+        self.assertEqual(float(g), 6.0)  # d/dy = w * x
+
+        state_grads, arg_grads = brainstate.transform.grad(
+            loss, grad_states=w, argnums=1
+        )(3.0, 4.0)
+        self.assertEqual(float(state_grads), 12.0)  # d/dw = x * y
+        self.assertEqual(float(arg_grads), 6.0)
+
+
+class TestDebugNanPhaseName(unittest.TestCase):
+    """``debug_nan=True`` must work when the underlying transform has no
+    ``__name__`` (audit F5: ``vector_grad`` uses a ``functools.partial``)."""
+
+    def test_vector_grad_debug_nan_clean_input(self):
+        def f(x):
+            return x ** 2
+
+        g = brainstate.transform.vector_grad(f, debug_nan=True)(jnp.asarray([1.0, 2.0]))
+        self.assertTrue(bool(jnp.allclose(g, jnp.asarray([2.0, 4.0]))))
+
+    def test_vector_grad_debug_nan_still_raises_on_nan(self):
+        def f(x):
+            return jnp.sqrt(x)  # NaN value and NaN gradient at x < 0
+
+        with self.assertRaises(Exception) as ctx:
+            brainstate.transform.vector_grad(f, debug_nan=True)(jnp.asarray([-1.0]))
+        self.assertNotIsInstance(ctx.exception, AttributeError)

--- a/brainstate/transform/_grad_hessian.py
+++ b/brainstate/transform/_grad_hessian.py
@@ -41,6 +41,24 @@ __all__ = [
 ]
 
 
+class _HessianTransform(GradientTransform):
+    """``GradientTransform`` whose state gradients are second order.
+
+    ``jax.hessian`` over the internal ``id()``-keyed state-value dict returns
+    a dict-of-dicts ``{id_j: {id_i: block}}``; unflatten BOTH levels with the
+    user's ``grad_states`` tree so no raw ids leak into the result.
+    """
+
+    def _format_state_grads(self, grads_of_states: Dict):
+        rows = []
+        for j_id in self._grad_state_ids:
+            inner = grads_of_states[j_id]
+            rows.append(self._grad_tree.unflatten(
+                [inner[i_id] for i_id in self._grad_state_ids]
+            ))
+        return self._grad_tree.unflatten(rows)
+
+
 @set_module_as("brainstate.transform")
 def hessian(
     func: Callable,
@@ -106,7 +124,13 @@ def hessian(
     obj: ObjectTransform
       The transformed object.
     """
-    return GradientTransform(
+    if grad_states is not None and argnums is not None:
+        raise NotImplementedError(
+            "hessian does not support grad_states and argnums at the same time. "
+            "Compute the state Hessian and the argument Hessian in two calls, "
+            "or fold the arguments into states."
+        )
+    return _HessianTransform(
         target=func,
         transform=u.autograd.hessian if unit_aware else jax.hessian,
         grad_states=grad_states,

--- a/brainstate/transform/_grad_hessian_test.py
+++ b/brainstate/transform/_grad_hessian_test.py
@@ -69,5 +69,75 @@ class TestHessian(unittest.TestCase):
         self.assertTrue(bool(jnp.allclose(block, 2.0 * jnp.eye(2))))
 
 
+class TestHessianStateStructure(unittest.TestCase):
+    """The Hessian w.r.t. ``grad_states`` must mirror the user's structure,
+    not expose internal raw-``id()``-keyed dicts (audit M3)."""
+
+    def test_single_state_returns_dense_block(self):
+        w = brainstate.State(jnp.asarray(1.0))
+
+        def loss():
+            return w.value ** 3
+
+        h = brainstate.transform.hessian(loss, grad_states=w)()
+        self.assertNotIsInstance(h, dict)
+        self.assertEqual(float(h), 6.0)  # d2(w^3)/dw2 = 6w
+
+    def test_single_state_with_return_value(self):
+        w = brainstate.State(jnp.asarray(1.0))
+
+        def loss():
+            return w.value ** 3
+
+        h, val = brainstate.transform.hessian(loss, grad_states=w, return_value=True)()
+        self.assertNotIsInstance(h, dict)
+        self.assertEqual(float(h), 6.0)
+        self.assertEqual(float(val), 1.0)
+
+    def test_list_of_states_structure(self):
+        w1 = brainstate.State(jnp.asarray(1.0))
+        w2 = brainstate.State(jnp.asarray(2.0))
+
+        def loss():
+            return w1.value ** 2 * w2.value
+
+        h = brainstate.transform.hessian(loss, grad_states=[w1, w2])()
+        self.assertIsInstance(h, list)
+        self.assertEqual(len(h), 2)
+        self.assertIsInstance(h[0], list)
+        # d2L/dw1dw1 = 2*w2 = 4, d2L/dw1dw2 = 2*w1 = 2, d2L/dw2dw2 = 0
+        self.assertEqual(float(h[0][0]), 4.0)
+        self.assertEqual(float(h[0][1]), 2.0)
+        self.assertEqual(float(h[1][0]), 2.0)
+        self.assertEqual(float(h[1][1]), 0.0)
+
+    def test_dict_of_states_structure(self):
+        ws = {
+            'a': brainstate.State(jnp.asarray(1.0)),
+            'b': brainstate.State(jnp.asarray(2.0)),
+        }
+
+        def loss():
+            return ws['a'].value ** 2 * ws['b'].value
+
+        h = brainstate.transform.hessian(loss, grad_states=ws)()
+        self.assertIsInstance(h, dict)
+        self.assertEqual(set(h.keys()), {'a', 'b'})
+        self.assertEqual(set(h['a'].keys()), {'a', 'b'})
+        self.assertEqual(float(h['a']['a']), 4.0)
+        self.assertEqual(float(h['a']['b']), 2.0)
+        self.assertEqual(float(h['b']['a']), 2.0)
+        self.assertEqual(float(h['b']['b']), 0.0)
+
+    def test_states_and_argnums_not_supported(self):
+        w = brainstate.State(jnp.asarray(1.0))
+
+        def loss(x):
+            return w.value * x ** 2
+
+        with self.assertRaises(NotImplementedError):
+            brainstate.transform.hessian(loss, grad_states=w, argnums=0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/transform/_grad_transform.py
+++ b/brainstate/transform/_grad_transform.py
@@ -17,6 +17,7 @@ from typing import Union, Callable, Dict, Sequence, Optional, Any, Tuple, TypeVa
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from brainstate._state import State
 from brainstate.typing import PyTree
@@ -210,6 +211,21 @@ class GradientTransform(PrettyRepr):
         # parameters
         if argnums is None and len(self._grad_states) == 0:
             argnums = 0
+        if argnums is not None:
+            # User argnums are shifted by +2 internally (two leading state-value
+            # slots), so negative indices would silently select internal slots.
+            for a in (argnums if isinstance(argnums, (tuple, list)) else (argnums,)):
+                if isinstance(a, bool) or not isinstance(a, (int, np.integer)):
+                    raise ValueError(
+                        f"argnums must be an int or a sequence of ints, "
+                        f"got {a!r} of type {type(a).__name__}."
+                    )
+                if a < 0:
+                    raise ValueError(
+                        f"argnums {a} is negative. Gradient transforms do not support "
+                        f"negative argnums; use the non-negative index of the "
+                        f"positional argument instead."
+                    )
         if argnums is None:
             assert len(self._grad_states) > 0
             _argnums = 0
@@ -398,6 +414,15 @@ class GradientTransform(PrettyRepr):
         write_state_vals, out = self._call_target(grad_vals, other_vals, *args, **kwargs)
         return out, (out, write_state_vals)
 
+    def _format_state_grads(self, grads_of_states: Dict):
+        """Restructure the internal ``id()``-keyed gradient dict to mirror the
+        user's ``grad_states`` structure. First-order transforms return one
+        dict level; higher-order subclasses override this.
+        """
+        return self._grad_tree.unflatten(
+            [grads_of_states[st_id] for st_id in self._grad_state_ids]
+        )
+
     def _return(self, rets, read_state_vals, state_trace):
         """
         Process and format the return values from the gradient computation.
@@ -423,11 +448,10 @@ class GradientTransform(PrettyRepr):
         # check returned grads
         if len(self._grad_states) > 0:
             grads_of_states = grads if self.raw_argnums is None else grads[0]
-            grads_of_states = [grads_of_states[st_id] for st_id in self._grad_state_ids]
             if self.raw_argnums is None:
-                grads = self._grad_tree.unflatten(grads_of_states)
+                grads = self._format_state_grads(grads_of_states)
             else:
-                var_grads = self._grad_tree.unflatten(grads_of_states)
+                var_grads = self._format_state_grads(grads_of_states)
                 arg_grads = grads[1] if isinstance(self.raw_argnums, int) else grads[1:]
                 grads = (var_grads, arg_grads)
 
@@ -486,8 +510,12 @@ class GradientTransform(PrettyRepr):
             grads = rets[0]
             has_nan = _check_nan_jit_compatible(grads)
 
-            # debug nan
-            debug_nan_if(has_nan, fn.jaxpr_call_auto, phase=str(self.transform.__name__))
+            # debug nan -- the transform may be a functools.partial (e.g.
+            # vector_grad) without a ``__name__`` of its own
+            phase = getattr(self.transform, '__name__', None)
+            if phase is None:
+                phase = getattr(getattr(self.transform, 'func', None), '__name__', None)
+            debug_nan_if(has_nan, fn.jaxpr_call_auto, phase=str(phase or repr(self.transform)))
 
         else:
             # Compute gradients (JIT-compatible)

--- a/brainstate/transform/_jit.py
+++ b/brainstate/transform/_jit.py
@@ -67,6 +67,32 @@ def _get_jitted_fun(
 ) -> JittedFunction:
     static_argnums = tuple() if static_argnums is None else _ensure_index_tuple(static_argnums)
     donate_argnums = tuple() if donate_argnums is None else _ensure_index_tuple(donate_argnums)
+    # the internal calling convention prepends a state-values argument and
+    # shifts user argnums by +1, so a negative index would silently select
+    # the state tuple (e.g. donate_argnums=-1 donates every state buffer)
+    for label, nums in (('static_argnums', static_argnums), ('donate_argnums', donate_argnums)):
+        for i in nums:
+            if i < 0:
+                raise ValueError(
+                    f"{label} {i} is negative. brainstate.transform.jit does not "
+                    f"support negative argnums; use the non-negative index of the "
+                    f"positional argument instead."
+                )
+    # align user shardings with the (state_values, *args) / (state_values, outs)
+    # calling convention of the wrapped function
+    if in_shardings is not sharding_impls.UNSPECIFIED and in_shardings is not None:
+        if isinstance(in_shardings, (tuple, list)):
+            in_shardings = (None, *in_shardings)
+        else:
+            raise NotImplementedError(
+                "brainstate.transform.jit only supports in_shardings given as a "
+                "tuple/list with one entry per positional argument (a hidden "
+                "state-values argument is threaded internally, so a single "
+                "broadcast sharding cannot be aligned). Got "
+                f"{in_shardings!r}."
+            )
+    if out_shardings is not sharding_impls.UNSPECIFIED and out_shardings is not None:
+        out_shardings = (None, out_shardings)
     fun = StatefulFunction(
         fun,
         static_argnums=static_argnums,

--- a/brainstate/transform/_jit_test.py
+++ b/brainstate/transform/_jit_test.py
@@ -204,3 +204,55 @@ class TestJitNameAndStaging(unittest.TestCase):
         jf(jnp.ones((2,)))
         jf.clear_cache()
         self.assertTrue(bool(jnp.allclose(jf(jnp.ones((2,))), 2.0)))
+
+
+class TestJitShardings(unittest.TestCase):
+    """``in_shardings``/``out_shardings`` must account for the hidden
+    state-values argument that ``jit`` prepends (audit M4), and negative
+    static/donate argnums must be rejected instead of silently shifting
+    onto the state tuple."""
+
+    def _sharding(self, spec):
+        import numpy as np
+        from jax.sharding import Mesh, NamedSharding
+        mesh = Mesh(np.array(jax.devices()[:1]), ('x',))
+        return NamedSharding(mesh, spec)
+
+    def test_tuple_in_shardings_aligned(self):
+        from jax.sharding import PartitionSpec as P
+        st = bst.State(jnp.zeros(4))
+
+        @bst.transform.jit(in_shardings=(self._sharding(P('x')),))
+        def f(x):
+            st.value = st.value + x
+            return x * 2.0
+
+        out = f(jnp.arange(4.0))
+        self.assertTrue(bool(jnp.allclose(out, jnp.arange(4.0) * 2.0)))
+        self.assertTrue(bool(jnp.allclose(st.value, jnp.arange(4.0))))
+
+    def test_out_shardings_aligned(self):
+        from jax.sharding import PartitionSpec as P
+        st = bst.State(jnp.asarray(0.0))
+
+        @bst.transform.jit(out_shardings=self._sharding(P('x')))
+        def g(x):
+            st.value = st.value + 1.0  # scalar state write: P('x') cannot apply
+            return x * 2.0
+
+        out = g(jnp.arange(4.0))
+        self.assertTrue(bool(jnp.allclose(out, jnp.arange(4.0) * 2.0)))
+        self.assertEqual(float(st.value), 1.0)
+
+    def test_single_in_sharding_rejected(self):
+        from jax.sharding import PartitionSpec as P
+        with self.assertRaises(NotImplementedError):
+            bst.transform.jit(lambda x: x, in_shardings=self._sharding(P()))
+
+    def test_negative_donate_argnums_rejected(self):
+        with self.assertRaises(ValueError):
+            bst.transform.jit(lambda x: x, donate_argnums=-1)
+
+    def test_negative_static_argnums_rejected(self):
+        with self.assertRaises(ValueError):
+            bst.transform.jit(lambda x, n: x * n, static_argnums=-1)

--- a/brainstate/transform/_loop_collect_return.py
+++ b/brainstate/transform/_loop_collect_return.py
@@ -372,6 +372,11 @@ def checkpointed_scan(
             raise ValueError("scan got no values to scan over and `length` not provided.")
         else:
             length, = unique_lengths
+    if length < 1:
+        raise ValueError(
+            f"checkpointed_scan requires at least one iteration (length >= 1), but got length={length}. "
+            f"Use brainstate.transform.scan for zero-length scans."
+        )
 
     # function with progress bar
     if isinstance(pbar, ProgressBar):
@@ -652,19 +657,34 @@ def _bounded_while_loop(
     val: Any,
     max_steps: int,
     base: int,
-    pbar_runner: Optional[Callable] = None
+    pbar_runner: Optional[Callable] = None,
+    counter_bump: bool = True,
 ):
+    # ``counter_bump=True`` encodes the ``checkpointed_scan`` carry convention:
+    # the last carry element is the iteration counter and the skip path
+    # advances it past the whole sub-block. The public ``bounded_while_loop``
+    # carry has no counter, so its skip path must leave the carry untouched.
+    def skip_call(val_, steps_):
+        if not counter_bump:
+            return val_
+        if pbar_runner is not None:
+            pbar_runner(unvmap(val_[-1] + steps_, op='none'))
+        return val_[:-1] + (val_[-1] + steps_,)
+
     if max_steps == 1:
-        return body_fun(val)
+        return jax.lax.cond(
+            unvmap(cond_fun(val), op='any'),
+            body_fun,
+            lambda val_: skip_call(val_, 1),
+            val,
+        )
     else:
 
         def true_call(val_):
-            return _bounded_while_loop(cond_fun, body_fun, val_, max_steps // base, base, pbar_runner)
+            return _bounded_while_loop(cond_fun, body_fun, val_, max_steps // base, base, pbar_runner, counter_bump)
 
         def false_call(val_):
-            if pbar_runner is not None:
-                pbar_runner(unvmap(val_[-1] + max_steps, op='none'))
-            return val_[:-1] + (val_[-1] + max_steps,)
+            return skip_call(val_, max_steps)
 
         def scan_fn(val_, _):
             return jax.lax.cond(unvmap(cond_fun(val_), op='any'), true_call, false_call, val_), None

--- a/brainstate/transform/_loop_collect_return_test.py
+++ b/brainstate/transform/_loop_collect_return_test.py
@@ -59,6 +59,24 @@ class TestForLoop(unittest.TestCase):
         self.assertTrue(jnp.allclose(r, ops + 1))
 
 
+class TestCheckpointedScanSkipPath(unittest.TestCase):
+    """A length that is not a power of ``base`` exercises the counter-bump
+    skip path of ``_bounded_while_loop`` (regression guard for the H2 fix)."""
+
+    def test_carry_collect_and_state_values(self):
+        st = brainstate.ShortTermState(jnp.asarray(0.0))
+
+        def f(carry, x):
+            st.value = st.value + 1.0
+            return carry + x, carry * 2.0
+
+        xs = jnp.arange(5.0)
+        carry, ys = brainstate.transform.checkpointed_scan(f, init=0.0, xs=xs, base=2)
+        self.assertEqual(float(carry), 10.0)
+        self.assertTrue(bool(jnp.allclose(ys, jnp.asarray([0., 0., 2., 6., 12.]))))
+        self.assertEqual(float(st.value), 5.0)
+
+
 class TestScanValidation(unittest.TestCase):
     """Tests for scan() input-validation branches."""
 
@@ -437,3 +455,22 @@ class TestCheckpointedForLoop(unittest.TestCase):
         xs = jnp.arange(4.0)
         ys = brainstate.transform.checkpointed_for_loop(f, xs, pbar=2)
         self.assertTrue(jnp.allclose(ys, xs + 1.0))
+
+
+class TestCheckpointedScanLengthValidation(unittest.TestCase):
+    """checkpointed_scan with zero iterations must raise a clear ValueError
+    instead of crashing later in ``math.log(0, base)`` (audit Tier C)."""
+
+    def test_zero_length_xs_raises_value_error(self):
+        def step(carry, x):
+            return carry + x, carry
+
+        with self.assertRaisesRegex(ValueError, 'length'):
+            brainstate.transform.checkpointed_scan(step, 0.0, jnp.zeros((0, 2)))
+
+    def test_zero_length_explicit_raises_value_error(self):
+        def step(carry, x):
+            return carry + x, carry
+
+        with self.assertRaisesRegex(ValueError, 'length'):
+            brainstate.transform.checkpointed_scan(step, 0.0, jnp.zeros((0,)), length=0)

--- a/brainstate/transform/_loop_no_collection.py
+++ b/brainstate/transform/_loop_no_collection.py
@@ -273,12 +273,33 @@ def bounded_while_loop(
     new_cond_fn = wrap_fn(stateful_cond, state_trace, read_state_vals, False, cond_cache_key)
     new_body_fn = wrap_fn(stateful_body, state_trace, read_state_vals, True, body_cache_key)
 
+    # The carry threads a step counter because ``rounded_max_steps`` below may
+    # exceed ``max_steps``; the counter enforces the user's exact bound.
+    def counted_cond_fn(val):
+        inner, step = val
+        return jax.numpy.logical_and(step < max_steps, new_cond_fn(inner))
+
+    def counted_body_fn(val):
+        inner, step = val
+        # Per-lane masking: once a lane's own condition is False, keep its
+        # carry (and state values) unchanged. The block-level dispatch in
+        # ``_bounded_while_loop`` reduces the condition with
+        # ``unvmap(.., 'any')``, so under ``vmap`` the body keeps running
+        # while ANY lane is still active.
+        keep = new_cond_fn(inner)
+        new_inner = new_body_fn(inner)
+        new_inner = jax.tree.map(lambda new, old: jax.numpy.where(keep, new, old), new_inner, inner)
+        return new_inner, step + 1
+
     # initial value
-    init_val = (write_state_vals, init_val)
+    init_val = ((write_state_vals, init_val), jax.numpy.asarray(0))
 
     # while_loop
     rounded_max_steps = base ** int(math.ceil(math.log(max_steps, base)))
-    state_vals, val = _bounded_while_loop(new_cond_fn, new_body_fn, init_val, rounded_max_steps, base, None)
+    (state_vals, val), _ = _bounded_while_loop(
+        counted_cond_fn, counted_body_fn, init_val, rounded_max_steps, base, None,
+        counter_bump=False,
+    )
 
     # write back state values or restore them
     state_trace.assign_state_vals_v2(read_state_vals, state_vals)

--- a/brainstate/transform/_loop_no_collection_test.py
+++ b/brainstate/transform/_loop_no_collection_test.py
@@ -149,3 +149,99 @@ class TestBoundedWhileLoop(TestCase):
 
         with self.assertRaises(ValueError):
             brainstate.transform.bounded_while_loop(cond, body, 0.0, max_steps=10)
+
+
+class TestBoundedWhileLoopSemantics(TestCase):
+    """``bounded_while_loop`` must match ``while_loop`` whenever the loop
+    exits before ``max_steps`` (audit H2: the skip path corrupted the carry,
+    ``max_steps=1`` ignored the condition, and vmapped lanes over-stepped).
+    """
+
+    def _python_loop(self, cond, body, val, max_steps):
+        steps = 0
+        while steps < max_steps and cond(val):
+            val = body(val)
+            steps += 1
+        return val
+
+    def test_early_exit_value(self):
+        cond = lambda x: x < 3.0
+        body = lambda x: x + 1.0
+        out = brainstate.transform.bounded_while_loop(cond, body, 0.0, max_steps=8, base=2)
+        self.assertEqual(float(out), 3.0)
+
+    def test_early_exit_value_default_base(self):
+        cond = lambda x: x < 3.0
+        body = lambda x: x + 1.0
+        out = brainstate.transform.bounded_while_loop(cond, body, 0.0, max_steps=4)
+        self.assertEqual(float(out), 3.0)
+
+    def test_max_steps_one_respects_condition(self):
+        cond = lambda x: x < 3.0
+        body = lambda x: x + 5.0
+        out = brainstate.transform.bounded_while_loop(cond, body, 100.0, max_steps=1)
+        self.assertEqual(float(out), 100.0)
+
+        out = brainstate.transform.bounded_while_loop(cond, body, 0.0, max_steps=1)
+        self.assertEqual(float(out), 5.0)
+
+    def test_vmap_per_lane_exit(self):
+        cond = lambda x: x < 3.0
+        body = lambda x: x + 1.0
+
+        def run(x0):
+            return brainstate.transform.bounded_while_loop(cond, body, x0, max_steps=8, base=2)
+
+        out = jax.vmap(run)(jnp.asarray([0.0, 0.9]))
+        self.assertTrue(bool(jnp.allclose(out, jnp.asarray([3.0, 3.9]))))
+
+    def test_matches_python_semantics(self):
+        cond = lambda x: x < 100.0
+        body = lambda x: x * 2.0 + 1.0
+        for init in (0.0, 50.0, 200.0):
+            for max_steps, base in ((1, 16), (3, 2), (8, 2), (10, 16), (100, 4)):
+                out = brainstate.transform.bounded_while_loop(
+                    cond, body, init, max_steps=max_steps, base=base
+                )
+                expected = self._python_loop(cond, body, init, max_steps)
+                self.assertEqual(
+                    float(out), float(expected),
+                    msg=f'init={init} max_steps={max_steps} base={base}'
+                )
+
+    def test_stateful_early_exit(self):
+        counter = brainstate.State(jnp.asarray(0.0))
+
+        def cond(x):
+            return counter.value < 3.0
+
+        def body(x):
+            counter.value = counter.value + 1.0
+            return x + 10.0
+
+        out = brainstate.transform.bounded_while_loop(cond, body, 0.0, max_steps=8, base=2)
+        self.assertEqual(float(counter.value), 3.0)
+        self.assertEqual(float(out), 30.0)
+
+    def test_stateful_capped(self):
+        counter = brainstate.State(jnp.asarray(0.0))
+
+        def cond(x):
+            return counter.value < 1000.0
+
+        def body(x):
+            counter.value = counter.value + 1.0
+            return x + 10.0
+
+        out = brainstate.transform.bounded_while_loop(cond, body, 0.0, max_steps=2, base=2)
+        self.assertEqual(float(counter.value), 2.0)
+        self.assertEqual(float(out), 20.0)
+
+    def test_grad_through_early_exit(self):
+        def f(x):
+            return brainstate.transform.bounded_while_loop(
+                lambda v: v < 5.0, lambda v: v * 2.0, x, max_steps=8, base=2
+            )
+
+        self.assertEqual(float(f(1.0)), 8.0)
+        self.assertEqual(float(jax.grad(f)(1.0)), 8.0)

--- a/brainstate/transform/_make_jaxpr.py
+++ b/brainstate/transform/_make_jaxpr.py
@@ -160,15 +160,16 @@ def get_arg_cache_key(
     jax.tree.map(fn_to_check, dyn_args, is_leaf=lambda x: isinstance(x, State))
     dyn_args = jax.tree.map(shaped_abstractify, dyn_args)
 
-    # kwargs
+    # kwargs -- the State check must run BEFORE abstractification, which
+    # flattens a State into its value leaves and would hide it
     static_kwargs, dyn_kwargs = [], []
     for k, v in sorted(kwargs.items()):
         if k in static_argnames:
             static_kwargs.append((k, v))
         else:
+            if fn_to_check is not None:
+                jax.tree.map(fn_to_check, v, is_leaf=lambda x: isinstance(x, State))
             dyn_kwargs.append((k, jax.tree.map(shaped_abstractify, v)))
-    if fn_to_check is not None:
-        jax.tree.map(fn_to_check, dyn_kwargs, is_leaf=lambda x: isinstance(x, State))
 
     # Flatten dynamic args/kwargs into (treedef, leaves) for consistent hashing.
     # Custom pytree nodes (e.g. Quantity) may have __hash__ implementations that
@@ -794,14 +795,18 @@ class StatefulFunction(PrettyObject):
         # Store in the caller-provided container (NOT in the cache)
         _result_holder['state_trace'] = state_trace
 
-        with state_trace:
-            out = self.fun(*args, **dyn_kwargs, **static_kwargs)
-            state_values = (
-                state_trace.get_write_state_values(True)
-                if self.return_only_write else
-                state_trace.get_state_values()
-            )
-        state_trace.recovery_original_values()
+        try:
+            with state_trace:
+                out = self.fun(*args, **dyn_kwargs, **static_kwargs)
+                state_values = (
+                    state_trace.get_write_state_values(True)
+                    if self.return_only_write else
+                    state_trace.get_state_values()
+                )
+        finally:
+            # Restore on failure too: a user error mid-trace must not leave
+            # tracers in the traced states.
+            state_trace.recovery_original_values()
 
         # State instance as functional returns is not allowed.
         # Checking whether the states are returned.

--- a/brainstate/transform/_make_jaxpr_test.py
+++ b/brainstate/transform/_make_jaxpr_test.py
@@ -1845,3 +1845,78 @@ class TestStaticArgnumsEdgeCases(unittest.TestCase):
         new_state_vals, out = sf.debug_call(state_vals, x)
         # return_only_write=False means we get ALL states back
         self.assertEqual(len(new_state_vals), len(states))
+
+
+class TestFailedTraceRestoresStates(unittest.TestCase):
+    """A function that raises mid-trace must not leave tracers in states
+    (audit H4: ``recovery_original_values`` only ran on success)."""
+
+    def test_direct_make_jaxpr_failure_restores_state(self):
+        st = brainstate.State(jnp.asarray(1.0))
+
+        def f(x):
+            st.value = st.value + x  # write happens before the failure
+            raise RuntimeError('user error mid-trace')
+
+        sf = brainstate.transform.StatefulFunction(f)
+        with self.assertRaises(RuntimeError):
+            sf.make_jaxpr(2.0)
+        self.assertFalse(isinstance(st.value, jax.core.Tracer))
+        self.assertEqual(float(st.value), 1.0)
+
+    def test_jit_trace_failure_restores_state_and_recovers(self):
+        st = brainstate.State(jnp.asarray(1.0))
+        fail = [True]
+
+        @brainstate.transform.jit
+        def f(x):
+            st.value = st.value + x
+            if fail[0]:
+                raise RuntimeError('user error mid-trace')
+            return st.value
+
+        with self.assertRaises(RuntimeError):
+            f(2.0)
+        self.assertFalse(isinstance(st.value, jax.core.Tracer))
+        self.assertEqual(float(st.value), 1.0)
+
+        # a later, fixed call must retrace and succeed
+        fail[0] = False
+        out = f(2.0)
+        self.assertEqual(float(out), 3.0)
+        self.assertEqual(float(st.value), 3.0)
+
+
+class TestStateInKwargsRejected(unittest.TestCase):
+    """A State passed as a dynamic keyword argument must raise the friendly
+    ValueError, exactly like positional arguments, instead of being silently
+    abstractified into its value leaves (audit M7)."""
+
+    def test_state_positional_arg_raises(self):
+        st = brainstate.State(jnp.zeros(3))
+        sf = brainstate.transform.StatefulFunction(lambda s: s.value * 2.0)
+        with self.assertRaisesRegex(ValueError, 'cannot be an instance of State'):
+            sf.make_jaxpr(st)
+
+    def test_state_kwarg_raises(self):
+        st = brainstate.State(jnp.zeros(3))
+        sf = brainstate.transform.StatefulFunction(lambda *, s: s.value * 2.0)
+        with self.assertRaisesRegex(ValueError, 'cannot be an instance of State'):
+            sf.make_jaxpr(s=st)
+
+    def test_state_kwarg_nested_in_pytree_raises(self):
+        st = brainstate.State(jnp.zeros(3))
+        sf = brainstate.transform.StatefulFunction(lambda *, d: d['s'].value * 2.0)
+        with self.assertRaisesRegex(ValueError, 'cannot be an instance of State'):
+            sf.make_jaxpr(d={'s': st})
+
+    def test_static_kwarg_state_is_allowed_to_pass_through(self):
+        # a State in a *static* kwarg is not a traced input; the check must not
+        # fire for it (it is the closure-capture pattern, keyed by identity)
+        st = brainstate.State(jnp.ones(3))
+
+        def f(x, *, which):
+            return x * which.value
+
+        sf = brainstate.transform.StatefulFunction(f, static_argnames=('which',))
+        sf.make_jaxpr(jnp.ones(3), which=st)  # must not raise

--- a/brainstate/transform/_mapping1.py
+++ b/brainstate/transform/_mapping1.py
@@ -339,20 +339,22 @@ def _vmap_new_states_transform(
             new_states_box.update(grouped_states)
             return out, tuple(grouped_vals.get(k, []) for k in axes_order)
 
-        with catch_new_states(state_to_exclude=state_to_exclude):
-            mapped = jax.vmap(
-                new_fun,
-                in_axes=(in_axes, 0 if len(rng_states) else None),
-                out_axes=(out_axes, tuple(axes_order)),
-                axis_size=axis_size,
-                axis_name=axis_name,
-                spmd_axis_name=spmd_axis_name,
-            )
-            outs, grouped_out_vals = mapped(args, rng_keys)
-
-        # restore the global RNG once
-        for rng, key in zip(rng_states, rng_backups):
-            rng.restore_value(key)
+        try:
+            with catch_new_states(state_to_exclude=state_to_exclude):
+                mapped = jax.vmap(
+                    new_fun,
+                    in_axes=(in_axes, 0 if len(rng_states) else None),
+                    out_axes=(out_axes, tuple(axes_order)),
+                    axis_size=axis_size,
+                    axis_name=axis_name,
+                    spmd_axis_name=spmd_axis_name,
+                )
+                outs, grouped_out_vals = mapped(args, rng_keys)
+        finally:
+            # restore the global RNG once -- also on failure, so a crashed
+            # mapped pass cannot leave key tracers in the random states
+            for rng, key in zip(rng_states, rng_backups):
+                rng.restore_value(key)
 
         # restore vmapped new-state values + unwind trace levels (avoids leakage)
         all_new_states: List[State] = []

--- a/brainstate/transform/_mapping1_test.py
+++ b/brainstate/transform/_mapping1_test.py
@@ -887,3 +887,23 @@ class TestVmapNewStatesRejectsStateArgs(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestFailedVmapNewStatesRestoresRng(unittest.TestCase):
+    """A failure inside the mapped pass must not leave key tracers in the
+    global random state (audit M5)."""
+
+    def test_vmap_new_states_failure_restores_rng(self):
+        bst.random.seed(0)
+        calls = {'n': 0}
+
+        def f():
+            st = bst.ShortTermState(bst.random.randn(3))
+            calls['n'] += 1
+            if calls['n'] >= 2:  # first call: probe; second: mapped pass
+                raise RuntimeError('boom')
+            return 1.0
+
+        with self.assertRaises(RuntimeError):
+            bst.transform.vmap_new_states(f, axis_size=4)()
+        self.assertFalse(isinstance(bst.random.DEFAULT.value, jax.core.Tracer))

--- a/brainstate/transform/_mapping2.py
+++ b/brainstate/transform/_mapping2.py
@@ -836,19 +836,21 @@ def _map_new_states(
     else:
         raise ValueError(f"Invalid behavior {behavior!r}; must be 'vmap' or 'pmap'.")
 
-    with catch_new_states(state_tag):
-        mapped = primitive(
-            init_fn,
-            in_axes=(0 if len(rng_states) else None,),
-            out_axes=tuple(axes_order),
-            axis_size=axis_size,
-            axis_name=axis_name,
-        )
-        tuple_vals = mapped(rng_keys)
-
-    # restore the global RNG once
-    for rng, key in zip(rng_states, rng_backups):
-        rng.restore_value(key)
+    try:
+        with catch_new_states(state_tag):
+            mapped = primitive(
+                init_fn,
+                in_axes=(0 if len(rng_states) else None,),
+                out_axes=tuple(axes_order),
+                axis_size=axis_size,
+                axis_name=axis_name,
+            )
+            tuple_vals = mapped(rng_keys)
+    finally:
+        # restore the global RNG once -- also on failure, so a crashed mapped
+        # pass cannot leave key tracers in the random states
+        for rng, key in zip(rng_states, rng_backups):
+            rng.restore_value(key)
 
     # scatter batched values into the freshly created state objects
     dict_vmap_states: Dict[Any, list] = defaultdict(list)

--- a/brainstate/transform/_mapping2_test.py
+++ b/brainstate/transform/_mapping2_test.py
@@ -1073,3 +1073,26 @@ class TestVmap2JaxParitySweep(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFailedNewStatesMappingRestoresRng(unittest.TestCase):
+    """A failure inside the mapped init pass must not leave key tracers in
+    the global random state (audit M5)."""
+
+    def test_vmap2_new_states_failure_restores_rng(self):
+        brainstate.random.seed(0)
+
+        class _Stub:
+            def __init__(self):
+                self.calls = 0
+
+            def init_all_states(self):
+                self.calls += 1
+                if self.calls >= 2:  # first call: probe; second: mapped pass
+                    raise RuntimeError('boom')
+                self.s = brainstate.ShortTermState(brainstate.random.randn(3))
+
+        stub = _Stub()
+        with self.assertRaises(RuntimeError):
+            brainstate.transform.vmap2_new_states(stub, {}, axis_size=4)
+        self.assertFalse(isinstance(brainstate.random.DEFAULT.value, jax.core.Tracer))

--- a/brainstate/transform/_mapping_core.py
+++ b/brainstate/transform/_mapping_core.py
@@ -1003,6 +1003,16 @@ def _build_plan(
     return LiveStateMapPlan(in_groups, rng_states, out_groups, oth_out_states)
 
 
+class _PlanStaleError(Exception):
+    """Internal: the function's write set diverged from the cached plan.
+
+    Raised inside the execution pass when ``f`` writes a state the plan does
+    not cover (e.g. Python control flow on an unmapped state changed branch
+    between calls). Caught by ``state_map_transform`` to rebuild the plan and
+    retry exactly once.
+    """
+
+
 def _execute_plan(plan: LiveStateMapPlan, f, args, kwargs, in_axes, out_axes,
                   axis_size, axis_name, mapping_fn, mapping_kwargs, static_argnames=()):
     """Run the cached plan through the mapping primitive and restore states.
@@ -1028,13 +1038,41 @@ def _execute_plan(plan: LiveStateMapPlan, f, args, kwargs, in_axes, out_axes,
 
     in_group_vals = [[st.value for st in states] for _, states in in_groups]
 
+    # every state the plan accounts for; a write outside this set means the
+    # plan no longer matches the function (M2)
+    expected_write_ids = (
+        {id(st) for st in rng_states}
+        | {id(st) for _, states in in_groups for st in states}
+        | {id(st) for _, states in out_groups for st in states}
+        | {id(st) for st in oth_out_states}
+    )
+
     def fn_to_map(args_, kwargs_, rng_keys_, group_vals):
         for st, key in zip(rng_states, rng_keys_):
             st.restore_value(key)
         for (axis, states), vals in zip(in_groups, group_vals):
             for st, v in zip(states, vals):
                 st.restore_value(v)
-        out = f(*args_, **kwargs_, **static_kwargs)
+        # Observe writes without altering values (no ``new_arg`` hook): states
+        # created inside ``f`` register above this stack and stay invisible.
+        watcher = StateTraceStack(name='state_map:watch')
+        with watcher:
+            out = f(*args_, **kwargs_, **static_kwargs)
+        stale = [
+            (st, org) for st, written, org in
+            zip(watcher.states, watcher.been_writen, watcher.original_state_values)
+            if written and id(st) not in expected_write_ids
+        ]
+        if stale:
+            # roll the unplanned states back to their first-seen values so the
+            # aborted trace cannot leak tracers into them
+            for st, org in stale:
+                st.restore_value(org)
+            raise _PlanStaleError(
+                f"The cached mapping plan no longer matches the write set of "
+                f"'{getattr(f, '__name__', f)}': {len(stale)} written state(s) "
+                f"are not covered by the plan."
+            )
         out_group_vals = [[st.value for st in states] for _, states in out_groups]
         oth_vals = [st.value for st in oth_out_states]
         return out, out_group_vals, oth_vals
@@ -1047,7 +1085,24 @@ def _execute_plan(plan: LiveStateMapPlan, f, args, kwargs, in_axes, out_axes,
         axis_name=axis_name,
         **mapping_kwargs,
     )
-    out, out_group_vals, oth_vals = mapped_fn(args, dyn_kwargs, rng_keys, in_group_vals)
+
+    # snapshot every plan state so a failed execution pass cannot leave
+    # tracers behind (M1; the probe/discovery passes already restore)
+    touched = list(rng_states) + list(oth_out_states)
+    for _, states in in_groups:
+        touched.extend(states)
+    for _, states in out_groups:
+        touched.extend(states)
+    snapshots = [(st, st.value) for st in {id(st): st for st in touched}.values()]
+
+    try:
+        out, out_group_vals, oth_vals = mapped_fn(args, dyn_kwargs, rng_keys, in_group_vals)
+    except Exception:
+        for st, val in snapshots:
+            st.restore_value(val)
+        for rng, key in zip(rng_states, rng_backups):
+            rng.restore_value(key)
+        raise
 
     # scatter batched output state values
     for (axis, states), vals in zip(out_groups, out_group_vals):
@@ -1149,11 +1204,30 @@ def state_map_transform(
                 static_argnames=static_argnames,
             )
             cache[cache_key] = StateMapPlan.from_live(live)
-        return _execute_plan(
-            live, f, args, kwargs, in_axes, out_axes,
-            axis_size, axis_name, mapping_fn, mapping_kwargs,
-            static_argnames=static_argnames,
-        )
+        try:
+            return _execute_plan(
+                live, f, args, kwargs, in_axes, out_axes,
+                axis_size, axis_name, mapping_fn, mapping_kwargs,
+                static_argnames=static_argnames,
+            )
+        except _PlanStaleError:
+            # the write set diverged from the cached plan (e.g. Python control
+            # flow on an unmapped state changed branch between calls): drop the
+            # plan, re-probe, and retry exactly once. A second divergence
+            # (write set changing within a single call) is surfaced as-is.
+            live = _build_plan(
+                f, args, kwargs,
+                in_predicates, out_predicates,
+                in_axes, axis_size, axis_name,
+                unexpected_out_state_mapping, name,
+                static_argnames=static_argnames,
+            )
+            cache[cache_key] = StateMapPlan.from_live(live)
+            return _execute_plan(
+                live, f, args, kwargs, in_axes, out_axes,
+                axis_size, axis_name, mapping_fn, mapping_kwargs,
+                static_argnames=static_argnames,
+            )
 
     wrapped.__brainstate_state_map__ = True
     return wrapped

--- a/brainstate/transform/_mapping_core_test.py
+++ b/brainstate/transform/_mapping_core_test.py
@@ -1319,5 +1319,129 @@ class TestEdgeCases(unittest.TestCase):
         self.assertTrue(jnp.allclose(out, h.value))
 
 
+class TestFailedExecutionRestoresStates(unittest.TestCase):
+    """A failed execution pass must not leave tracers in plan states
+    (audit M1: ``_execute_plan`` restored values only on success)."""
+
+    def test_bad_out_axes_restores_state_and_rng(self):
+        brainstate.random.seed(0)
+        s = brainstate.State(jnp.asarray(0.0))
+
+        def g(x):
+            s.value = x + brainstate.random.uniform()
+            return x * 1.0
+
+        f = brainstate.transform.vmap2(g, out_axes=1)  # scalar output: axis 1 invalid
+        with self.assertRaises(ValueError):
+            f(jnp.arange(4.0))
+
+        self.assertFalse(isinstance(s.value, jax.core.Tracer))
+        self.assertEqual(float(s.value), 0.0)
+        self.assertFalse(isinstance(brainstate.random.DEFAULT.value, jax.core.Tracer))
+
+    def test_failure_then_success(self):
+        s = brainstate.State(jnp.asarray(0.0))
+
+        def g(x):
+            s.value = jnp.asarray(1.0)  # broadcast write (constant per lane)
+            return x * 2.0
+
+        bad = brainstate.transform.vmap2(g, out_axes=1)
+        with self.assertRaises(ValueError):
+            bad(jnp.arange(4.0))
+        self.assertEqual(float(s.value), 0.0)
+
+        good = brainstate.transform.vmap2(g)
+        out = good(jnp.arange(4.0))
+        self.assertTrue(bool(jnp.allclose(out, jnp.arange(4.0) * 2.0)))
+        self.assertEqual(float(s.value), 1.0)
+
+
+class TestStalePlanWriteSetDivergence(unittest.TestCase):
+    """Python control flow on an unmapped state may change the write set
+    between calls; the cached plan must be rebuilt instead of leaking
+    tracers into newly-written states (audit M2)."""
+
+    def test_flag_flip_write_appears(self):
+        flag = brainstate.State(True)
+        b = brainstate.State(jnp.asarray(0.0))
+
+        @brainstate.transform.vmap2
+        def f(x):
+            if flag.value:
+                return x * 2.0
+            b.value = jnp.asarray(1.0)
+            return x + 1.0
+
+        xs = jnp.arange(4.0)
+        out = f(xs)
+        self.assertTrue(bool(jnp.allclose(out, xs * 2.0)))
+        self.assertEqual(float(b.value), 0.0)
+
+        flag.value = False
+        out = f(xs)
+        self.assertTrue(bool(jnp.allclose(out, xs + 1.0)))
+        self.assertFalse(isinstance(b.value, jax.core.Tracer))
+        self.assertEqual(float(b.value), 1.0)
+
+    def test_flag_flip_batched_write_appears(self):
+        flag = brainstate.State(True)
+        b = brainstate.State(jnp.zeros(4))
+
+        @brainstate.transform.vmap2
+        def f(x):
+            if flag.value:
+                return x * 2.0
+            b.value = b.value + x  # undeclared read-modify-write per lane
+            return x + 1.0
+
+        xs = jnp.arange(4.0)
+        f(xs)
+        flag.value = False
+        out = f(xs)
+        self.assertTrue(bool(jnp.allclose(out, xs + 1.0)))
+        self.assertFalse(isinstance(b.value, jax.core.Tracer))
+        self.assertTrue(bool(jnp.allclose(b.value, xs)))
+
+    def test_flag_flip_write_disappears(self):
+        flag = brainstate.State(False)
+        b = brainstate.State(jnp.asarray(0.0))
+
+        @brainstate.transform.vmap2
+        def f(x):
+            if flag.value:
+                return x * 2.0
+            b.value = jnp.asarray(1.0)
+            return x + 1.0
+
+        xs = jnp.arange(4.0)
+        out = f(xs)
+        self.assertEqual(float(b.value), 1.0)
+
+        flag.value = True
+        out = f(xs)
+        self.assertTrue(bool(jnp.allclose(out, xs * 2.0)))
+        self.assertFalse(isinstance(b.value, jax.core.Tracer))
+        self.assertEqual(float(b.value), 1.0)  # untouched on this path
+
+    def test_plan_cache_still_effective_when_stable(self):
+        s = brainstate.State(jnp.asarray(0.0))
+        calls = [0]
+
+        def g(x):
+            calls[0] += 1
+            s.value = jnp.sum(x) * 0.0 + 1.0
+            return x * 2.0
+
+        f = brainstate.transform.vmap2(g)
+        xs = jnp.arange(4.0)
+        f(xs)
+        first = calls[0]
+        f(xs)
+        second = calls[0] - first
+        # warm path: no probe/discovery re-runs, only the single execution trace
+        self.assertLess(second, first)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/transform/_named_scope.py
+++ b/brainstate/transform/_named_scope.py
@@ -33,13 +33,10 @@ def fn_to_call(
     """
     A wrapper for JIT-compiled functions with named scopes.
 
-    This function provides a consistent interface for JIT-compiled functions,
-    supporting both standard ``static_*`` arguments and the inverse ``non_static_*``
-    arguments for convenience.
-
-    When using ``non_static_*`` parameters, this function automatically computes
-    which arguments should be static based on the actual arguments provided
-    at call time, and caches the JIT-compiled functions for efficiency.
+    This function provides a consistent interface for JIT-compiled functions.
+    ``static_argnums``/``static_argnames`` may be given either directly or as
+    callables computed from the actual call arguments; in both cases the
+    JIT-compiled functions are cached per static configuration.
 
     Unlike a class-based implementation, the returned wrapper function properly
     supports being used as a bound method through Python's descriptor protocol.
@@ -79,6 +76,10 @@ def fn_to_call(
             return (argnames,)
         return tuple(argnames)
 
+    # JIT functions cached per normalized static configuration, so repeated calls
+    # reuse compilations instead of rebuilding a fresh jit() wrapper every time.
+    _jit_cache: dict = {}
+
     def _create_jit_fn(
         s_argnums: Union[int, Sequence[int], None],
         s_argnames: Union[str, Sequence[str], None],
@@ -99,7 +100,10 @@ def fn_to_call(
         s_argnums = _normalize_argnums(s_argnums, len(args))
         s_argnames = _normalize_argnames(s_argnames)
 
-        return _create_jit_fn(s_argnums, s_argnames)
+        key = (s_argnums, s_argnames)
+        if key not in _jit_cache:
+            _jit_cache[key] = _create_jit_fn(s_argnums, s_argnames)
+        return _jit_cache[key]
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -113,6 +117,7 @@ def fn_to_call(
             return fn(*args, **kwargs)
 
     wrapper.fn = fn
+    wrapper._jit_cache = _jit_cache
     return wrapper
 
 
@@ -125,8 +130,8 @@ def named_scope(
     Decorator that wraps a function with JAX's JIT compilation and sets its name.
 
     This is a convenience decorator that combines ``jit()`` with named scope support.
-    It also provides an inverse API via ``non_static_argnums``/``non_static_argnames``
-    for specifying which arguments should NOT be static (the complement of ``static_*``).
+    ``static_argnums``/``static_argnames`` may also be callables that compute the
+    static configuration from the actual call arguments.
 
     The decorated function supports being used as a class bound method.
 
@@ -159,11 +164,11 @@ def named_scope(
     ... def power(x, n):
     ...     return x ** n
 
-    Using non_static_argnums (only first arg is traced, rest are static):
+    With a callable computing the static configuration from the call arguments:
 
-    >>> @named_scope(name='scaled_power', non_static_argnums=0)
+    >>> @named_scope(name='scaled_power', static_argnums=lambda *args, **kwargs: (1, 2))
     ... def scaled_power(x, n, scale):
-    ...     return (x ** n) * scale  # n and scale are automatically static
+    ...     return (x ** n) * scale  # n and scale are static
 
     As a class method:
 

--- a/brainstate/transform/_named_scope_test.py
+++ b/brainstate/transform/_named_scope_test.py
@@ -609,5 +609,35 @@ class TestIrCompilationPath(unittest.TestCase):
         self.assertTrue(jnp.allclose(out, jnp.array([12.0, 27.0])))
 
 
+class TestNamedScopeJitCache(unittest.TestCase):
+    """``fn_to_call`` must reuse the jit-compiled function across calls with
+    the same static configuration instead of rebuilding a fresh ``jit()``
+    wrapper (and recompiling) on every call (audit M10)."""
+
+    def test_jit_fn_reused_across_calls(self):
+        f = fn_to_call(lambda x: x * 2.0, name='cache_check')
+        with bst.environ.context(ir_compilation=True):
+            r1 = f(jnp.asarray(1.0))
+            r2 = f(jnp.asarray(2.0))
+        self.assertEqual(float(r1), 2.0)
+        self.assertEqual(float(r2), 4.0)
+        self.assertEqual(len(f._jit_cache), 1)
+
+    def test_distinct_static_configs_get_distinct_entries(self):
+        f = fn_to_call(
+            lambda x, n: x * n,
+            name='cache_check2',
+            static_argnums=lambda *args, **kw: (1,) if isinstance(args[1], float) else (),
+        )
+        with bst.environ.context(ir_compilation=True):
+            r1 = f(jnp.asarray(2.0), 3.0)               # n static
+            r2 = f(jnp.asarray(2.0), jnp.asarray(3.0))  # n traced
+            r3 = f(jnp.asarray(4.0), 3.0)               # n static again -> cached
+        self.assertEqual(float(r1), 6.0)
+        self.assertEqual(float(r2), 6.0)
+        self.assertEqual(float(r3), 12.0)
+        self.assertEqual(len(f._jit_cache), 2)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/transform/_progress_bar.py
+++ b/brainstate/transform/_progress_bar.py
@@ -378,8 +378,8 @@ class ProgressBar(object):
     ):
         # print rate
         self.print_freq = freq
-        if isinstance(freq, int):
-            assert freq > 0, "Print rate should be > 0."
+        if isinstance(freq, int) and freq <= 0:
+            raise ValueError(f"Print rate (freq) should be > 0, but got {freq}.")
 
         # print count
         self.print_count = count

--- a/brainstate/transform/_progress_bar_test.py
+++ b/brainstate/transform/_progress_bar_test.py
@@ -84,8 +84,8 @@ class TestProgressBarConstruction(unittest.TestCase):
     """Validation performed in ``ProgressBar.__init__``."""
 
     def test_freq_must_be_positive(self):
-        """A non-positive ``freq`` raises ``AssertionError``."""
-        with self.assertRaises(AssertionError):
+        """A non-positive ``freq`` raises ``ValueError``."""
+        with self.assertRaises(ValueError):
             ProgressBar(freq=0)
 
     def test_cannot_specify_both_freq_and_count(self):
@@ -393,6 +393,19 @@ class TestProgressBarFallbackIntegration(unittest.TestCase):
             out = err.getvalue()
             self.assertNotEqual(out, "")
             self.assertIn("iter", out)
+
+
+class TestProgressBarFreqValidation(unittest.TestCase):
+    """Invalid ``freq`` must raise ValueError (not AssertionError, which
+    disappears under ``python -O``) (audit Tier C)."""
+
+    def test_negative_freq_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            ProgressBar(freq=-3)
+
+    def test_positive_freq_accepted(self):
+        pbar = ProgressBar(freq=2)
+        self.assertEqual(pbar.print_freq, 2)
 
 
 if __name__ == "__main__":

--- a/brainstate/transform/_shard_map.py
+++ b/brainstate/transform/_shard_map.py
@@ -243,7 +243,13 @@ def shard_map(
         if SHARD_MAP_CHECK_KW is not None:
             sm_kwargs[SHARD_MAP_CHECK_KW] = check_vma
         sharded = jax_shard_map(pure, **sm_kwargs)
-        out, write_vals = sharded(in_state_vals, sharded_args)
+        try:
+            out, write_vals = sharded(in_state_vals, sharded_args)
+        except Exception:
+            # a failure mid-trace must not leave shard tracers in the states
+            for st, ov in zip(all_states, orig_vals):
+                st.restore_value(ov)
+            raise
 
         # 6. Restore ALL states: writes -> new values, reads -> originals
         #    (prevents shard tracers from leaking into global State objects).

--- a/brainstate/transform/_shard_map_test.py
+++ b/brainstate/transform/_shard_map_test.py
@@ -328,3 +328,29 @@ class TestShardMapUseCases(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestFailedShardMapRestoresStates(unittest.TestCase):
+    """A failure inside the shard_map pass must not leave shard tracers in
+    states (audit M5: restoration only ran on success)."""
+
+    def test_failure_inside_shard_map_restores_states(self):
+        import numpy as np
+        from jax.sharding import Mesh, PartitionSpec as P
+
+        mesh = Mesh(np.array(jax.devices()[:1]), ('x',))
+        s = brainstate.State(jnp.zeros(4))
+        calls = {'n': 0}
+
+        def f(x):
+            s.value = s.value + x
+            calls['n'] += 1
+            if calls['n'] >= 2:  # first call: discovery trace; second: shard_map pass
+                raise RuntimeError('boom')
+            return x * 2.0
+
+        sm = brainstate.transform.shard_map(f, mesh, in_specs=P('x'), out_specs=P('x'))
+        with self.assertRaises(RuntimeError):
+            sm(jnp.arange(4.0))
+        self.assertFalse(isinstance(s.value, jax.core.Tracer))
+        self.assertTrue(bool(jnp.allclose(s.value, jnp.zeros(4))))

--- a/brainstate/transform/_util.py
+++ b/brainstate/transform/_util.py
@@ -83,14 +83,17 @@ def wrap_single_fun_in_multi_branches(
         # "write_state_vals" should have the same length as "merged_state_trace.states"
         assert len(merged_state_trace.states) == len(write_state_vals) == len(read_state_vals)
 
-        # get all state values needed for this function, which is a subset of "write_state_vals"
-        st_vals_for_this_fun = []
-        for write, st, val_w, val_r in zip(merged_state_trace.been_writen,
-                                           merged_state_trace.states,
-                                           write_state_vals,
-                                           read_state_vals):
-            if id(st) in state_ids_belong_to_this_fun:
-                st_vals_for_this_fun.append(val_w if write else val_r)
+        # the current value of every state in the merged trace
+        val_by_id = {
+            id(st): (val_w if write else val_r)
+            for write, st, val_w, val_r in zip(merged_state_trace.been_writen,
+                                               merged_state_trace.states,
+                                               write_state_vals,
+                                               read_state_vals)
+        }
+        # "jaxpr_call" consumes state values positionally in THIS function's own
+        # trace order, which may differ from the merged trace order.
+        st_vals_for_this_fun = [val_by_id[st_id] for st_id in state_ids_belong_to_this_fun]
 
         # call this function
         new_state_vals, out = stateful_fun.jaxpr_call(st_vals_for_this_fun, *operands)
@@ -100,8 +103,14 @@ def wrap_single_fun_in_multi_branches(
             # get all written state values
             new_state_vals = {id(st): val for st, val in
                               zip(stateful_fun.get_states_by_cache(cache_key), new_state_vals)}
+            # A slot may be in the merged write set because ANOTHER branch writes it.
+            # Under ``return_only_write=True``, ``jaxpr_call`` returns ``None`` for
+            # states this branch only reads — pass the incoming value through so
+            # every branch emits the same pytree structure.
             write_state_vals = tuple([
-                (new_state_vals[id(st)] if id(st) in state_ids_belong_to_this_fun else w_val)
+                (new_state_vals[id(st)]
+                 if id(st) in state_ids_belong_to_this_fun and new_state_vals[id(st)] is not None
+                 else w_val)
                 if write else None
                 for write, st, w_val in zip(merged_state_trace.been_writen,
                                             merged_state_trace.states,
@@ -180,14 +189,17 @@ def wrap_single_fun_in_multi_branches_while_loop(
         # "write_state_vals" should have the same length as "merged_state_trace.states"
         assert len(merged_state_trace.states) == len(write_state_vals) == len(read_state_vals)
 
-        # get all state values needed for this function, which is a subset of "write_state_vals"
-        st_vals_for_this_fun = []
-        for write, st, val_w, val_r in zip(merged_state_trace.been_writen,
-                                           merged_state_trace.states,
-                                           write_state_vals,
-                                           read_state_vals):
-            if id(st) in state_ids_belong_to_this_fun:
-                st_vals_for_this_fun.append(val_w if write else val_r)
+        # the current value of every state in the merged trace
+        val_by_id = {
+            id(st): (val_w if write else val_r)
+            for write, st, val_w, val_r in zip(merged_state_trace.been_writen,
+                                               merged_state_trace.states,
+                                               write_state_vals,
+                                               read_state_vals)
+        }
+        # "jaxpr_call" consumes state values positionally in THIS function's own
+        # trace order, which may differ from the merged trace order.
+        st_vals_for_this_fun = [val_by_id[st_id] for st_id in state_ids_belong_to_this_fun]
 
         # call this function
         new_state_vals, out = stateful_fun.jaxpr_call(st_vals_for_this_fun, init_val)
@@ -197,8 +209,12 @@ def wrap_single_fun_in_multi_branches_while_loop(
             # get all written state values
             new_state_vals = {id(st): val for st, val in
                               zip(stateful_fun.get_states_by_cache(cache_key), new_state_vals)}
+            # See ``wrap_single_fun_in_multi_branches``: a ``None`` from
+            # ``jaxpr_call`` means this fn only read the state — pass through.
             write_state_vals = tuple([
-                (new_state_vals[id(st)] if id(st) in state_ids_belong_to_this_fun else w_val)
+                (new_state_vals[id(st)]
+                 if id(st) in state_ids_belong_to_this_fun and new_state_vals[id(st)] is not None
+                 else w_val)
                 if write else None
                 for write, st, w_val in zip(merged_state_trace.been_writen,
                                             merged_state_trace.states,


### PR DESCRIPTION
## Summary

- **H1** `cond`/`switch`/`ifelse`: fix crash when a state is written in one branch but only read in others (None placeholder slots); also fix state-value misalignment between merged and per-branch trace orders in the shared multi-branch wrappers
- **H2** `bounded_while_loop`: fix wrong results from counter-bump leaking into user carries, `max_steps=1` ignoring the cond, missing per-lane masking under vmap, and iteration-cap overshoot (step counter + masked body; `counter_bump` flag for the checkpointed_scan path)
- **H3** `GradientTransform`: reject negative/non-integer `argnums` up front (hidden +2 state-dict shift otherwise silently differentiates wrong arg)
- **H4** `StatefulFunction.make_jaxpr`: restore original state values when tracing fails (failed trace no longer leaves tracers in global states)
- **M1/M2** state-aware mapping engine: restore state+RNG on execution failure; detect stale cached plans via a write-set watcher and rebuild once before failing
- **M3** `hessian`: return blocks structured like `grad_states` instead of exposing internal id-keyed dicts; reject `grad_states+argnums` combination
- **M4** `jit`: align user-provided `in_shardings`/`out_shardings` with hidden state arg; reject negative `static_argnums`/`donate_argnums`
- **M5** `shard_map`, `checkify`, `vmap_new_states`, `map2`, `eval_shape`: restore state values when wrapped execution fails (tracer-leak family)
- **F5** `grad(debug_nan=True)`: fix `AttributeError` on `functools.partial` transform phase label
- **Tier C**: State-in-kwargs check before abstractification (M7); `debug_nan` under enclosing `jit` via `lax.cond`+callback instead of concretizing (M9); `named_scope` jit cache under `ir_compilation` + remove phantom `non_static_*` docs (M10); `checkpoint` rejects negative `static_argnums`; `checkpointed_scan` raises clear `ValueError` for `length < 1`; `ProgressBar.freq` validation raises `ValueError` instead of `assert`; `cond` trace-name typo `'conda:false'` → `'cond:false'`; `ifelse` docstring example fixed to use mutually exclusive conditions

## Test plan

- [ ] Every fix covered by a reproducing test verified to fail pre-fix and pass post-fix (TDD throughout)
- [ ] `pytest brainstate/transform`: **1124 passed, 1 skipped, 0 failed**
- [ ] `pytest brainstate` (outside transform): **3587 passed, 18 skipped, 0 failed**
- [ ] Changed modules at 97–100% line coverage (99% aggregate across 18 files); all lines I touched are covered
- [ ] No `Co-Authored-By` trailer in any commit