### PR TITLE
build: bump minimal JAX version to 0.7.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.13"]
-        jax-version: ["0.6.0", "0.7.0", "0.8.0", "0.9.0", ""]
+        jax-version: ["0.7.0", "0.8.0", "0.9.0", ""]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,22 +77,22 @@ progressbar = [
     'tqdm',
 ]
 cpu = [
-    'jax[cpu]>=0.6.0',
+    'jax[cpu]>=0.7.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
 cuda12 = [
-    'jax[cuda12]>=0.6.0',
+    'jax[cuda12]>=0.7.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
 cuda13 = [
-    'jax[cuda13]>=0.6.0',
+    'jax[cuda13]>=0.7.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
 tpu = [
-    'jax[tpu]>=0.6.0',
+    'jax[tpu]>=0.7.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
@@ -100,7 +100,7 @@ testing = [
     'absl-py',
     'pytest',
     'coverage',
-    'jax>=0.6.0',
+    'jax>=0.7.0',
     'tqdm',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-jax>=0.6.0
+jax>=0.7.0
 jaxlib
 brainunit>=0.3.0
 brainevent


### PR DESCRIPTION
## Summary

Raise the minimum supported JAX version from `>=0.6.0` to `>=0.7.0` across all dependency declarations.

## Changes

- **pyproject.toml** — `optional-dependencies` groups `cpu`, `cuda12`, `cuda13`, `tpu`, and `testing`
- **requirements.txt** — base `jax` pin

This is a purely declarative packaging change. No source code references the old `0.6.0` floor, and the test suite already runs against newer JAX (locally validated against `jax==0.10.1`, which satisfies the new floor). A smoke test (`State` + `brainstate.random` + `brainstate.transform.jit`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)