### PR TITLE
fix(graph): merge_context index_ref, check_valid_context, pop_states aliasing

### DIFF
--- a/brainstate/graph/_context.py
+++ b/brainstate/graph/_context.py
@@ -112,7 +112,10 @@ def merge_context() -> Iterator[Tuple[MergeContext, dict]]:
     unflatten_ctx = MergeContext(index_ref)
     GRAPH_CONTEXT.index_ref_stack.append(unflatten_ctx)
     try:
-        yield unflatten_ctx, dict(unflatten_ctx.index_ref)
+        # Yield the *live* table (not a snapshot copy) so callers can inspect the
+        # accumulated ``index -> rebuilt object`` mapping after the block, exactly
+        # as ``split_context`` exposes its live ``ref_index``.
+        yield unflatten_ctx, index_ref
     finally:
         GRAPH_CONTEXT.index_ref_stack.pop()
         del unflatten_ctx.index_ref

--- a/brainstate/graph/_context_test.py
+++ b/brainstate/graph/_context_test.py
@@ -102,6 +102,22 @@ class TestSplitMergeContextIdentity(absltest.TestCase):
             self.assertIsNotNone(mctx)
         self.assertFalse(hasattr(mctx, 'index_ref'))
 
+    def test_merge_context_exposes_live_index_ref(self):
+        """``merge_context`` must yield the *live* index_ref table.
+
+        Regression: it previously yielded ``dict(unflatten_ctx.index_ref)`` — a
+        snapshot taken at yield time (empty) and disconnected from the table that
+        ``treefy_merge`` actually populates. This is now symmetric with
+        ``split_context``, which yields its live ``RefMap``.
+        """
+        m = brainstate.nn.Linear(2, 3)
+        graphdef, state = brainstate.graph.treefy_split(m)
+        with brainstate.graph.merge_context() as (ctx, index_ref):
+            rebuilt = ctx.treefy_merge(graphdef, state)
+        # The yielded table is populated and contains the rebuilt root object.
+        self.assertGreater(len(index_ref), 0)
+        self.assertIn(id(rebuilt), {id(v) for v in index_ref.values()})
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/graph/_node.py
+++ b/brainstate/graph/_node.py
@@ -28,7 +28,7 @@ from brainstate._state import State, TreefyState
 from brainstate.typing import Key
 from brainstate.util import PrettyObject
 from ._operations import treefy_split, treefy_merge
-from ._walk import register_graph_node_type
+from ._walk import register_graph_node_type, iter_leaf
 
 __all__ = ['Node']
 
@@ -128,9 +128,28 @@ class Node(PrettyObject, metaclass=GraphNodeMeta):
         return treefy_merge(graphdef, state)
 
     def check_valid_context(self, error_msg: Callable[[], str]) -> None:
-        """Raise :class:`TraceContextError` if the current trace context is invalid."""
-        if not self._trace_state.is_valid():
-            raise TraceContextError(error_msg())
+        """Raise :class:`TraceContextError` if the node's trace context is invalid.
+
+        A graph node carries no trace state of its own; the only objects that
+        track a JAX trace level are the :class:`~brainstate.State`\\ s it holds.
+        The node is therefore valid exactly when every reachable ``State`` is
+        valid. If any contained ``State`` was created at an incompatible trace
+        level, ``error_msg()`` is raised.
+
+        Parameters
+        ----------
+        error_msg : callable
+            Zero-argument callable returning the error message; evaluated lazily
+            only when a violation is detected.
+
+        Raises
+        ------
+        TraceContextError
+            If any ``State`` reachable from this node has an invalid trace.
+        """
+        for _, value in iter_leaf(self):
+            if isinstance(value, State) and not value._trace_state.is_valid():
+                raise TraceContextError(error_msg())
 
 
 # -------------------------------

--- a/brainstate/graph/_node_test.py
+++ b/brainstate/graph/_node_test.py
@@ -697,5 +697,41 @@ class TestNodeRepr(unittest.TestCase):
         self.assertIsNone(node.__pretty_repr_item__('inv', 5))
 
 
+class TestCheckValidContext(unittest.TestCase):
+    """``Node.check_valid_context`` regression coverage.
+
+    Graph nodes carry no ``_trace_state`` of their own (only ``State`` objects
+    do), so the method previously crashed with ``AttributeError``. It must
+    instead validate the trace context of the states reachable from the node.
+    """
+
+    def test_does_not_raise_attribute_error_on_real_module(self):
+        m = brainstate.nn.Linear(2, 3)
+        # In a valid (non-traced) context this returns None, never AttributeError.
+        self.assertIsNone(m.check_valid_context(lambda: 'should not raise'))
+
+    def test_plain_node_with_state(self):
+        class Plain(Node):
+            def __init__(self):
+                self.w = brainstate.ParamState(jnp.zeros(3))
+
+        self.assertIsNone(Plain().check_valid_context(lambda: 'ok'))
+
+    def test_stateless_node(self):
+        class Empty(Node):
+            def __init__(self):
+                self.tag = 'x'
+
+        self.assertIsNone(Empty().check_valid_context(lambda: 'ok'))
+
+    def test_nested_states_are_validated(self):
+        class Outer(Node):
+            def __init__(self):
+                self.inner = brainstate.nn.Linear(2, 3)
+                self.p = brainstate.ParamState(jnp.zeros(1))
+
+        self.assertIsNone(Outer().check_valid_context(lambda: 'ok'))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/graph/_operation_test.py
+++ b/brainstate/graph/_operation_test.py
@@ -1147,5 +1147,57 @@ class TestCloneAndGraphdef(unittest.TestCase):
         self.assertEqual(gd, gd2)
 
 
+class TestPopStatesSharedAliases(absltest.TestCase):
+    """``pop_states`` must fully detach shared/tied states.
+
+    Regression: a matched ``State`` was deduped by id and only its *first*
+    reference was popped, leaving later aliases dangling on the node.
+    """
+
+    def test_pop_removes_all_aliases_plain_node(self):
+        class Two(brainstate.graph.Node):
+            def __init__(self, s):
+                self.a = s
+                self.b = s  # shared
+
+        s = brainstate.ParamState(jnp.zeros(1))
+        t = Two(s)
+        popped = brainstate.graph.pop_states(t, brainstate.ParamState)
+        # Recorded exactly once (deduped by identity)...
+        self.assertEqual(len(popped.to_flat()), 1)
+        # ...and *both* aliases removed, so the node retains no state.
+        self.assertFalse(hasattr(t, 'a'))
+        self.assertFalse(hasattr(t, 'b'))
+        self.assertEqual(len(brainstate.graph.states(t)), 0)
+
+    def test_pop_removes_tied_weights(self):
+        class Foo(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bar = brainstate.nn.Linear(2, 2)
+                self.baz = brainstate.nn.Linear(2, 2)
+                self.baz.weight = self.bar.weight  # tied
+
+        node = Foo()
+        popped = brainstate.graph.pop_states(node, brainstate.ParamState)
+        self.assertEqual(len(popped.to_flat()), 1)
+        self.assertFalse(hasattr(node.bar, 'weight'))
+        self.assertFalse(hasattr(node.baz, 'weight'))
+        self.assertEqual(len(brainstate.graph.states(node)), 0)
+
+    def test_pop_unshared_state_unaffected(self):
+        """A non-shared state still pops normally (no regression)."""
+        class One(brainstate.graph.Node):
+            def __init__(self):
+                self.p = brainstate.ParamState(jnp.zeros(2))
+                self.q = brainstate.ShortTermState(jnp.zeros(2))
+
+        n = One()
+        popped = brainstate.graph.pop_states(n, brainstate.ParamState)
+        self.assertEqual(len(popped.to_flat()), 1)
+        self.assertFalse(hasattr(n, 'p'))
+        self.assertTrue(hasattr(n, 'q'))
+
+
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/graph/_operations.py
+++ b/brainstate/graph/_operations.py
@@ -295,7 +295,16 @@ def _graph_pop(node, id_to_index, path_parts, flatted_state_dicts, predicates) -
         if _is_node(value):
             _graph_pop(value, id_to_index, (*path_parts, name), flatted_state_dicts, predicates)
             continue
-        if not _is_node_leaf(value) or id(value) in id_to_index:
+        if not _is_node_leaf(value):
+            continue
+        if id(value) in id_to_index:
+            # This ``State`` was already matched and popped via another
+            # (shared/tied) reference. Detach this alias too so the popped state
+            # leaves no dangling reference behind, but do not record it twice
+            # (it is deduplicated by identity). States are only ever entered into
+            # ``id_to_index`` when popped, so membership here means "popped".
+            if _is_graph_node(node):
+                impl.pop_key(node, name)
             continue
         node_path = (*path_parts, name)
         for state_dict, predicate in zip(flatted_state_dicts, predicates):


### PR DESCRIPTION
## Summary

Audit of `brainstate.graph` surfaced three correctness bugs, each reproduced with a regression test before fixing.

### BUG 1 — `merge_context` yields a disconnected, empty `index_ref`
`_context.py::merge_context` yielded `dict(unflatten_ctx.index_ref)` — a snapshot taken at yield time (empty) and disconnected from the table `treefy_merge` actually populates. Asymmetric with `split_context`, which yields its live `RefMap` (consumed by `graph_to_tree` after the block). **Fix:** yield the live dict.

### BUG 2 — `Node.check_valid_context` raises `AttributeError`
`_node.py::Node.check_valid_context` read `self._trace_state`, but graph nodes (incl. `nn.Linear`, `nn.Module`) carry no `_trace_state` — only `State` objects do — so it raised `AttributeError` for every node. (Currently only reached as dead code via `check_consistent_aliasing`, but it is broken public API.) **Fix:** a node's validity is the conjunction of the trace validity of the `State`s reachable from it; iterate them and raise `TraceContextError` on any invalid one.

### BUG 3 — `pop_states` leaves dangling aliases for shared/tied states
`_operations.py::_graph_pop` deduplicated a matched `State` by identity and popped only its **first** reference; later aliases were skipped and survived. After popping a tied weight (`baz.weight = bar.weight`), `bar.weight` was removed but `baz.weight` remained, leaving the node half-mutated. **Fix:** detach every alias of a popped state, while still recording it once.

### Withdrawn after investigation
A suspected `KeyError`-vs-`ValueError` contract gap on missing `StateLeafEdge` paths turned out to be unreachable: `TreefyState` is itself a JAX pytree, so `StateLeafEdge` is never produced by `flatten` (dead code). No change.

## Testing
- New regression tests: 8, all green.
- `brainstate/graph/` — 192 passed
- `brainstate/transform/` — 1136 passed
- `brainstate/nn/` — 1773 passed (14 pre-existing unrelated skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix multiple graph correctness issues and add regression coverage for context merging, node trace validation, and popping shared states.

Bug Fixes:
- Ensure merge_context yields the live index_ref table so callers see the populated mapping after tree reconstruction.
- Fix Node.check_valid_context to validate the trace context of contained State objects instead of accessing a missing node trace field.
- Update graph state popping to detach all aliases of a popped State, preventing dangling references on nodes.

Tests:
- Add regression tests for pop_states handling of shared aliases and tied weights while preserving unrelated state pops.
- Add regression tests ensuring Node.check_valid_context works on modules, plain nodes, stateless nodes, and nested states.
- Add regression test confirming merge_context exposes a live, populated index_ref mapping.