### PR TITLE
fix: resolve all issues from the cross-module audit (dev/issues.md)

### DIFF
--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -418,10 +418,9 @@ def to_concrete_aval(aval):
         >>> concrete = to_concrete_aval(arr)
         # Returns the concrete array value
     """
-    aval = jax.typeof(aval)
     if isinstance(aval, Tracer):
-        return aval.to_concrete_value()
-    return aval
+        return aval
+    return jax.typeof(aval)
 
 
 def is_jit_primitive(eqn: JaxprEqn) -> bool:

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -377,16 +377,41 @@ else:
         """
 
         def wrapper(fun: T) -> T:
+            # Copy each piece of metadata independently. A single shared
+            # try/except would abandon every remaining attribute the moment one
+            # copy failed (e.g. a read-only __dict__ on a builtin), leaving the
+            # wrapper with a partially-populated, inconsistent set of metadata.
             try:
                 name = fun_name(wrapped)
-                doc = getattr(wrapped, "__doc__", "") or ""
+            except Exception:
+                name = getattr(wrapped, "__name__", "<unknown>")
+            try:
                 fun.__dict__.update(getattr(wrapped, "__dict__", {}))
+            except Exception:
+                pass
+            try:
                 fun.__annotations__ = getattr(wrapped, "__annotations__", {})
+            except Exception:
+                pass
+            try:
                 fun.__name__ = name if namestr is None else namestr.format(fun=name)
+            except Exception:
+                pass
+            try:
                 fun.__module__ = getattr(wrapped, "__module__", "<unknown module>")
+            except Exception:
+                pass
+            try:
+                doc = getattr(wrapped, "__doc__", "") or ""
                 fun.__doc__ = (doc if docstr is None
                                else docstr.format(fun=name, doc=doc, **kwargs))
-                fun.__qualname__ = getattr(wrapped, "__qualname__", fun.__name__)
+            except Exception:
+                pass
+            try:
+                fun.__qualname__ = getattr(wrapped, "__qualname__", getattr(fun, "__name__", name))
+            except Exception:
+                pass
+            try:
                 fun.__wrapped__ = wrapped
             except Exception:
                 pass

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -424,6 +424,42 @@ class TestFunctionWrapping(unittest.TestCase):
         # Should handle missing attributes without crashing
         self.assertTrue(callable(wrapper))
 
+    def test_a1_partial_failure_does_not_drop_remaining_metadata(self):
+        """Appendix item 1: a failure copying one attribute must not abort the
+        rest. With a single shared try/except, a read-only ``__name__`` on the
+        wrapper aborted ``__doc__``/``__qualname__``/``__wrapped__`` too."""
+
+        def original():
+            """Original doc."""
+            pass
+
+        original.custom_marker = "kept"
+
+        class FunkyWrapper:
+            """A callable whose ``__name__`` cannot be assigned."""
+            __doc__ = None  # settable on the instance
+
+            def __init__(self):
+                self.__dict__ = {}
+
+            def __call__(self):
+                pass
+
+            # __name__ assignment raises -> the early-failing attribute
+            def __setattr__(self, key, value):
+                if key == "__name__":
+                    raise AttributeError("read-only __name__")
+                object.__setattr__(self, key, value)
+
+        fun = FunkyWrapper()
+        result = compat.wraps(original)(fun)
+
+        # __name__ copy failed, but the later attributes must still be applied.
+        self.assertEqual(result.__doc__, "Original doc.")
+        self.assertIs(result.__wrapped__, original)
+        # __dict__ (copied before __name__) must also be preserved.
+        self.assertEqual(result.custom_marker, "kept")
+
 
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and boundary conditions."""

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -460,6 +460,45 @@ class TestFunctionWrapping(unittest.TestCase):
         # __dict__ (copied before __name__) must also be preserved.
         self.assertEqual(result.custom_marker, "kept")
 
+    def test_wraps_tolerates_unsettable_wrapper_metadata(self):
+        """``wraps`` must not crash when *every* metadata copy fails.
+
+        Each metadata copy is wrapped in its own ``try/except`` so a wrapper that
+        rejects attribute assignment (``__slots__ = ()`` -> no ``__dict__`` and no
+        settable ``__name__``/``__doc__``/``__module__``/``__qualname__``/
+        ``__annotations__``) is returned unchanged rather than raising. The
+        wrapped object's name lookup also raises here, exercising the name
+        fallback path.
+        """
+        from functools import partial
+
+        class _NoName:
+            """A callable whose ``__name__`` lookup raises (not AttributeError)."""
+
+            @property
+            def __name__(self):
+                raise RuntimeError("name lookup boom")
+
+            def __call__(self, *args, **kwargs):
+                return None
+
+        # Wrap in a partial so ``fun_name`` recurses into ``_NoName`` (raising),
+        # while ``getattr(partial, "__name__", default)`` itself succeeds -> the
+        # name-fallback branch runs without re-raising.
+        wrapped = partial(_NoName())
+
+        class _Unsettable:
+            __slots__ = ()  # no __dict__; every attribute assignment raises
+
+            def __call__(self, *args, **kwargs):
+                return None
+
+        fun = _Unsettable()
+        # Must not raise despite every metadata copy failing.
+        result = compat.wraps(wrapped)(fun)
+        self.assertIs(result, fun)
+        self.assertTrue(callable(result))
+
 
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and boundary conditions."""

--- a/brainstate/_compatible_import_test.py
+++ b/brainstate/_compatible_import_test.py
@@ -91,10 +91,27 @@ class TestJAXVersionCompatibility(unittest.TestCase):
         result = compat.to_concrete_aval(arr)
         self.assertIsNotNone(result)
 
-        # # Test with scalar
-        # scalar = 42.0
-        # result = compat.to_concrete_aval(scalar)
-        # self.assertEqual(result, scalar)
+        # Test with scalar: a concrete (non-Tracer) input is converted to its
+        # abstract value via ``jax.typeof``; it is NOT returned unchanged.
+        scalar = 42.0
+        result = compat.to_concrete_aval(scalar)
+        self.assertNotIsInstance(result, compat.Tracer)
+        self.assertEqual(result, jax.typeof(scalar))
+
+    def test_to_concrete_aval_returns_tracer_for_traced_input(self):
+        """``to_concrete_aval`` returns the Tracer itself for a traced input."""
+        captured = {}
+
+        def fn(x):
+            captured['result'] = compat.to_concrete_aval(x)
+            captured['is_tracer'] = isinstance(captured['result'], compat.Tracer)
+            captured['is_same'] = captured['result'] is x
+            return x
+
+        # Trace ``fn`` so that ``x`` is a Tracer inside the call.
+        jax.make_jaxpr(fn)(jnp.array([1.0, 2.0, 3.0]))
+        self.assertTrue(captured['is_tracer'])
+        self.assertTrue(captured['is_same'])
 
 
 class TestUtilityFunctions(unittest.TestCase):

--- a/brainstate/_deprecation.py
+++ b/brainstate/_deprecation.py
@@ -144,13 +144,14 @@ class DeprecatedModule:
                             return getattr(module, name)
                         else:
                             # For other module paths, use standard import
-                            module_parts = source.split('.')
                             module = __import__(source, fromlist=[name])
                             return getattr(module, name)
                     except (ImportError, AttributeError) as e:
-                        # Fallback to replacement module
+                        # Fallback to replacement module. Use the property so a
+                        # string ``_replacement_module`` is lazily imported first;
+                        # the raw attribute may still be an unresolved module path.
                         try:
-                            return getattr(self._replacement_module, name)
+                            return getattr(self.replacement_module, name)
                         except AttributeError:
                             raise AttributeError(
                                 f"Module '{self._deprecated_name}' has no attribute '{name}'. "
@@ -162,8 +163,9 @@ class DeprecatedModule:
                     try:
                         return getattr(source, name)
                     except AttributeError:
-                        # Fallback to replacement module
-                        return getattr(self._replacement_module, name)
+                        # Fallback to replacement module. Use the property so a
+                        # string ``_replacement_module`` is resolved lazily.
+                        return getattr(self.replacement_module, name)
             else:
                 # Attribute not in scoped APIs
                 available_apis = ', '.join(self.__all__ or [])

--- a/brainstate/_deprecation.py
+++ b/brainstate/_deprecation.py
@@ -118,6 +118,13 @@ class DeprecatedModule:
 
     def __getattr__(self, name):
         """Forward attribute access to replacement module with deprecation warning."""
+        # Short-circuit all leading-underscore names (dunders and single-underscore
+        # internals). These are probed routinely by inspect/copy/pickle/IPython/pytest
+        # and must not trigger deprecation warnings, misleading AttributeErrors, or
+        # copy.copy recursion. Forwarding them is never the intended public-API use.
+        if name.startswith('_'):
+            raise AttributeError(name)
+
         self._warn_deprecation(name)
 
         # Check if we have scoped APIs

--- a/brainstate/_deprecation_test.py
+++ b/brainstate/_deprecation_test.py
@@ -2345,5 +2345,63 @@ class TestDunderAndInternalNameShortCircuit(unittest.TestCase):
         self.assertIs(func, brainstate.nn.relu)
 
 
+class TestScopedFallbackUsesLazyReplacement(unittest.TestCase):
+    """Appendix items 2 & 3: scoped string-source fallback resolves the
+    replacement module via the lazy property, and the standard-import path for
+    non-brainstate sources still works after removing the dead `module_parts`."""
+
+    def test_a3_string_fallback_resolves_lazy_replacement_module(self):
+        """When a scoped string source fails to import, the fallback must resolve
+        a string `_replacement_module` lazily (not getattr a raw string)."""
+        # replacement_module is a *string* path (lazy import). The scoped API
+        # 'pi' points at a bogus module path that fails to import, forcing the
+        # except-branch fallback to look it up on the replacement module.
+        proxy = DeprecatedModule(
+            deprecated_name='test.lazy_fallback',
+            replacement_module='math',  # lazy: a string, not yet imported
+            replacement_name='math',
+            scoped_apis={'pi': 'nonexistent.module.path'},
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # Before the fix this raised AttributeError: 'str' object has no
+            # attribute 'pi' (getattr on the raw string). Now it resolves math.pi.
+            import math
+            self.assertEqual(proxy.pi, math.pi)
+
+    def test_a3_module_object_fallback_uses_replacement(self):
+        """The module-object source branch also falls back via the property."""
+        import math
+
+        class OnlyE:
+            e = math.e
+
+        proxy = DeprecatedModule(
+            deprecated_name='test.objfallback',
+            replacement_module='math',  # lazy string
+            replacement_name='math',
+            scoped_apis={'pi': OnlyE},  # object source lacking 'pi'
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # 'pi' is absent on OnlyE -> fallback must resolve math.pi.
+            self.assertEqual(proxy.pi, math.pi)
+
+    def test_a2_standard_import_path_still_works(self):
+        """Removing the unused `module_parts` does not break non-brainstate
+        string sources resolved via __import__."""
+        import os
+
+        proxy = DeprecatedModule(
+            deprecated_name='test.stdimport',
+            replacement_module='os',
+            replacement_name='os',
+            scoped_apis={'getpid': 'os'},  # non-'brainstate.' source path
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertIs(proxy.getpid, os.getpid)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/_deprecation_test.py
+++ b/brainstate/_deprecation_test.py
@@ -2263,3 +2263,87 @@ class TestDeprecatedInit(unittest.TestCase):
 
             # Check that a deprecation warning was issued
             self.assertTrue(any(issubclass(warning.category, DeprecationWarning) for warning in w))
+
+
+class TestDunderAndInternalNameShortCircuit(unittest.TestCase):
+    """Regression tests: leading-underscore names must not be forwarded/warned (M2).
+
+    Probing tools (inspect/copy/pickle/IPython/pytest) routinely access dunder and
+    single-underscore attributes. These must raise a plain AttributeError without
+    emitting DeprecationWarnings, raising misleading "Available attributes" errors,
+    or causing copy.copy RecursionError.
+    """
+
+    def setUp(self):
+        """Reset warning filters before each test."""
+        warnings.resetwarnings()
+
+    def test_dunder_probe_emits_no_warning(self):
+        """hasattr for dunder/internal probes must not emit a DeprecationWarning."""
+        for proxy in (brainstate.functional, brainstate.augment, brainstate.compile):
+            with self.subTest(proxy=proxy.__name__):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    # Names probed by inspect/copy/IPython/pytest.
+                    self.assertFalse(hasattr(proxy, '__wrapped__'))
+                    self.assertFalse(hasattr(proxy, '__deepcopy__'))
+                    self.assertFalse(
+                        hasattr(proxy, '_ipython_canary_method_should_not_exist_')
+                    )
+
+                    dep_warnings = [
+                        warning for warning in w
+                        if issubclass(warning.category, DeprecationWarning)
+                    ]
+                    self.assertEqual(
+                        dep_warnings, [],
+                        f"Unexpected DeprecationWarning(s) for underscore probes: "
+                        f"{[str(x.message) for x in dep_warnings]}"
+                    )
+
+    def test_underscore_access_raises_plain_attribute_error(self):
+        """Accessing a missing underscore name raises AttributeError without the
+        misleading 'Available attributes' message used for public APIs."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with self.assertRaises(AttributeError) as context:
+                _ = brainstate.augment.__wrapped__
+            # Should be the bare name, not the scoped-API guidance message.
+            self.assertNotIn('Available attributes', str(context.exception))
+
+    def test_copy_copy_does_not_recurse(self):
+        """copy.copy on a proxy must not raise RecursionError (M2)."""
+        import copy
+        for proxy in (brainstate.functional, brainstate.augment, brainstate.compile):
+            with self.subTest(proxy=proxy.__name__):
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    try:
+                        copy.copy(proxy)
+                    except RecursionError as e:
+                        self.fail(f"copy.copy raised RecursionError: {e}")
+
+    def test_public_api_access_still_warns_once_and_forwards(self):
+        """A normal public-API access still emits exactly one warning and forwards
+        the correct object (the short-circuit must not break real APIs)."""
+        proxy = brainstate.functional
+        # Clear cached warn-state so the access deterministically warns once,
+        # since these module-level proxies are shared singletons across tests.
+        proxy._warned_attrs.pop('relu', None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            func = proxy.relu
+
+            dep_warnings = [
+                warning for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+                and 'brainstate.functional' in str(warning.message)
+            ]
+            self.assertEqual(len(dep_warnings), 1)
+        # Forwarding must still work.
+        self.assertTrue(callable(func))
+        self.assertIs(func, brainstate.nn.relu)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -336,7 +336,7 @@ class State(Generic[A], PrettyObject):
     _hooks_manager: HookManager
     _name: Optional[str]
     _value: PyTree
-    _been_writen: bool  # useful in `unflatten` and `flatten` graph processing
+    _been_writen: bool = False  # useful in `unflatten` and `flatten` graph processing
     tag: Optional[Set[str]]
 
     def __init__(
@@ -369,8 +369,8 @@ class State(Generic[A], PrettyObject):
             sets up internal attributes, and records the state initialization.
         """
         tag = metadata.pop('tag', None)
-        if isinstance(tag, str):
-            tag = set([tag])
+        if tag is not None:
+            tag = {tag} if isinstance(tag, str) else set(tag)
 
         # avoid using self._setattr to avoid the check
         vars(self)['_trace_state'] = StateJaxTracer()
@@ -754,7 +754,7 @@ class State(Generic[A], PrettyObject):
         attributes['_level'] = TRACE_CONTEXT.get_trace_stack_level()
         attributes['_trace_state'] = StateJaxTracer()
         attributes['_source_info'] = source_info_util.current()
-        attributes.pop('_been_writen', None)
+        attributes['_been_writen'] = False
         # update the metadata
         vars(obj).update(attributes)
         return obj
@@ -1350,8 +1350,11 @@ class HiddenGroupState(HiddenState):
 
     def __init__(self, value: ArrayLike, **kwargs):
         value, name2index = self._check_value(value)
-        self.name2index = name2index
+        # NOTE: create `_trace_state` (in the super().__init__) BEFORE assigning
+        # structural attributes, otherwise the trace-guarded ``__setattr__`` reads
+        # a not-yet-existing ``_trace_state`` when jax-tracer checking is enabled.
         ShortTermState.__init__(self, value, **kwargs)
+        self._setattr_no_check('name2index', name2index)
 
     @property
     def varshape(self) -> Tuple[int, ...]:
@@ -1442,12 +1445,18 @@ class HiddenGroupState(HiddenState):
         The value of the hidden state.
         """
         if isinstance(item, int):
-            assert item < self.value.shape[-1], (f'Index {item} out of range. '
-                                                 f'The maximum index is {self.value.shape[-1] - 1}.')
+            if item >= self.value.shape[-1] or item < -self.value.shape[-1]:
+                raise IndexError(
+                    f'Index {item} out of range. '
+                    f'The maximum index is {self.value.shape[-1] - 1}.'
+                )
             return self.value[..., item]
         elif isinstance(item, str):
-            assert item in self.name2index, (f'Hidden state name {item} not found. '
-                                             f'Please check the hidden state names.')
+            if item not in self.name2index:
+                raise KeyError(
+                    f'Hidden state name {item} not found. '
+                    f'Please check the hidden state names.'
+                )
             index = self.name2index[item]
             return self.value[..., index]
         else:
@@ -1480,27 +1489,46 @@ class HiddenGroupState(HiddenState):
         """
         if isinstance(val, (tuple, list)):
             val = {i: v for i, v in enumerate(val)}
-        assert isinstance(val, dict), (
-            f'Currently, {self.__class__.__name__}.set_value() only supports '
-            f'dictionary of hidden states. But we got {type(val)}.'
-        )
+        if not isinstance(val, dict):
+            raise TypeError(
+                f'Currently, {self.__class__.__name__}.set_value() only supports '
+                f'dictionary of hidden states. But we got {type(val)}.'
+            )
         indices = []
         values = []
         for k, v in val.items():
             if isinstance(k, str):
                 k = self.name2index[k]
-            assert isinstance(k, int), (
-                f'Key {k} should be int or str. '
-                f'But we got {type(k)}.'
-            )
-            assert v.shape == self.varshape, (
-                f'The shape of the hidden state should be {self.varshape}. '
-                f'But we got {v.shape}.'
-            )
+            if not isinstance(k, int):
+                raise TypeError(
+                    f'Key {k} should be int or str. '
+                    f'But we got {type(k)}.'
+                )
+            if not (0 <= k < self.num_state):
+                raise ValueError(
+                    f'Index {k} out of range. '
+                    f'The number of hidden states is {self.num_state}.'
+                )
+            if v.shape != self.varshape:
+                raise ValueError(
+                    f'The shape of the hidden state should be {self.varshape}. '
+                    f'But we got {v.shape}.'
+                )
             indices.append(k)
             values.append(v)
         values = u.math.stack(values, axis=-1)
-        self.value = self.value.at[..., indices].set(values)
+        # Coerce the stored value's magnitude to a JAX array so the ``.at[...]``
+        # scatter works even when the state was constructed from numpy (which is
+        # explicitly accepted by ``_check_value``). brainunit's ``u.math`` has no
+        # scatter helper, so strip the unit, update the JAX magnitude, re-attach.
+        val_arr = self.value
+        unit = u.get_unit(val_arr)
+        mag = jax.numpy.asarray(u.get_magnitude(val_arr))
+        if unit.dim.is_dimensionless:
+            new_mag = jax.numpy.asarray(u.get_magnitude(values))
+        else:
+            new_mag = jax.numpy.asarray(u.Quantity(values).to(unit).mantissa)
+        self.value = u.maybe_decimal(u.Quantity(mag.at[..., indices].set(new_mag), unit=unit))
 
 
 class HiddenTreeState(HiddenGroupState):
@@ -1613,11 +1641,14 @@ class HiddenTreeState(HiddenGroupState):
         **kwargs
     ):
         value, name2unit, name2index = self._check_value(value)
-        self.name2unit: Dict[str, u.Unit] = name2unit
-        self.name2index: Dict[str, int] = name2index
-        self.index2unit: Dict[int, u.Unit] = {i: v for i, v in enumerate(name2unit.values())}
-        self.index2name: Dict[int, str] = {v: k for k, v in name2index.items()}
+        # Create `_trace_state` (via super().__init__) BEFORE assigning structural
+        # attributes, so the trace-guarded `__setattr__` doesn't read a missing
+        # `_trace_state` when jax-tracer checking is enabled (see L2).
         ShortTermState.__init__(self, value, **kwargs)
+        self._setattr_no_check('name2unit', name2unit)
+        self._setattr_no_check('name2index', name2index)
+        self._setattr_no_check('index2unit', {i: v for i, v in enumerate(name2unit.values())})
+        self._setattr_no_check('index2name', {v: k for k, v in name2index.items()})
 
     @property
     def varshape(self) -> Tuple[int, ...]:
@@ -1672,10 +1703,11 @@ class HiddenTreeState(HiddenGroupState):
         """
         if isinstance(value, (tuple, list)):
             value = {str(i): v for i, v in enumerate(value)}
-        assert isinstance(value, dict), (
-            f'Currently, {self.__class__.__name__} only supports '
-            f'dictionary/sequence of hidden states. But we got {type(value)}.'
-        )
+        if not isinstance(value, dict):
+            raise TypeError(
+                f'Currently, {self.__class__.__name__} only supports '
+                f'dictionary/sequence of hidden states. But we got {type(value)}.'
+            )
         shapes = []
         for k, v in value.items():
             if not isinstance(v, (np.ndarray, jax.Array, u.Quantity)):
@@ -1694,7 +1726,10 @@ class HiddenTreeState(HiddenGroupState):
             )
         name2unit = {k: u.get_unit(v) for k, v in value.items()}
         name2index = {k: i for i, k in enumerate(value.keys())}
-        value = u.math.stack([u.get_magnitude(v) for v in value.values()], axis=-1)
+        # Force a JAX array (not numpy): the single-array storage invariant the JIT
+        # machinery relies on must hold even for numpy-backed inputs (M6), otherwise
+        # ``set_value``'s ``.at[...]`` scatter would crash on a numpy ``value``.
+        value = jax.numpy.asarray(u.math.stack([u.get_magnitude(v) for v in value.values()], axis=-1))
         return value, name2unit, name2index
 
     def get_value(self, item: str | int) -> ArrayLike:
@@ -1709,12 +1744,20 @@ class HiddenTreeState(HiddenGroupState):
             - If str, the name of the hidden state.
         """
         if isinstance(item, int):
-            assert item < self.value.shape[-1], (f'Index {item} out of range. '
-                                                 f'The maximum index is {self.value.shape[-1] - 1}.')
+            if item >= self.value.shape[-1] or item < -self.value.shape[-1]:
+                raise IndexError(
+                    f'Index {item} out of range. '
+                    f'The maximum index is {self.value.shape[-1] - 1}.'
+                )
+            if item < 0:
+                item += self.value.shape[-1]
             val = self.value[..., item]
         elif isinstance(item, str):
-            assert item in self.name2index, (f'Hidden state name {item} not found. '
-                                             f'Please check the hidden state names.')
+            if item not in self.name2index:
+                raise KeyError(
+                    f'Hidden state name {item} not found. '
+                    f'Please check the hidden state names.'
+                )
             item = self.name2index[item]
             val = self.value[..., item]
         else:
@@ -1751,17 +1794,31 @@ class HiddenTreeState(HiddenGroupState):
         """
         if isinstance(val, (tuple, list)):
             val = {i: v for i, v in enumerate(val)}
-        assert isinstance(val, dict), (f'Currently, {self.__class__.__name__}.set_value() only supports '
-                                       f'dictionary of hidden states. But we got {type(val)}.')
+        if not isinstance(val, dict):
+            raise TypeError(
+                f'Currently, {self.__class__.__name__}.set_value() only supports '
+                f'dictionary of hidden states. But we got {type(val)}.'
+            )
         indices = []
         values = []
         for index, v in val.items():
             if isinstance(index, str):
                 index = self.name2index[index]
-            assert isinstance(index, int), (f'Key {index} should be int or str. '
-                                            f'But we got {type(index)}.')
-            assert v.shape == self.varshape, (f'The shape of the hidden state should be {self.varshape}. '
-                                              f'But we got {v.shape}.')
+            if not isinstance(index, int):
+                raise TypeError(
+                    f'Key {index} should be int or str. '
+                    f'But we got {type(index)}.'
+                )
+            if not (0 <= index < self.num_state):
+                raise ValueError(
+                    f'Index {index} out of range. '
+                    f'The number of hidden states is {self.num_state}.'
+                )
+            if v.shape != self.varshape:
+                raise ValueError(
+                    f'The shape of the hidden state should be {self.varshape}. '
+                    f'But we got {v.shape}.'
+                )
             indices.append(index)
             values.append(u.Quantity(v).to(self.index2unit[index]).mantissa)
         if len(indices) == 0:
@@ -1774,7 +1831,9 @@ class HiddenTreeState(HiddenGroupState):
         else:
             indices = np.asarray(indices)
             values = u.math.stack(values, axis=-1)
-        self.value = self.value.at[..., indices].set(values)
+        # `values` are dimensionless mantissas (units stripped above), so coerce the
+        # stored value to a JAX array to support `.at[...]` even if it was numpy (M3/M6).
+        self.value = jax.numpy.asarray(self.value).at[..., indices].set(values)
 
 
 class ParamState(LongTermState):
@@ -1897,7 +1956,8 @@ class StateDictManager(DictManager):
         Assign the value for each element according to the given ``data``.
         """
         for arg in args:
-            assert isinstance(arg, dict), 'Must be an instance of dict.'
+            if not isinstance(arg, dict):
+                raise TypeError('Must be an instance of dict.')
             for k, v in arg.items():
                 self._set_elem(k, v)
 
@@ -1934,7 +1994,8 @@ class StateDictManager(DictManager):
         return {k: v.value for k, v in self.items()}
 
     def _check_elem(self, elem):
-        assert isinstance(elem, State), f'must be instance of {State}'
+        if not isinstance(elem, State):
+            raise TypeError(f'must be instance of {State}')
 
     def _set_elem(self, key: Any, value: Any) -> None:
         self[key].value = value
@@ -2247,6 +2308,12 @@ class StateTraceStack(Generic[A]):
                     self.been_writen.append(False)
                 if been_writen:
                     self.write_its_value(st)
+        # L4: propagate the released-originals invariant from every merged source so a
+        # later recovery_original_values() correctly raises instead of silently writing
+        # abstract avals back into real states.
+        self._originals_released = self._originals_released or any(
+            getattr(t, '_originals_released', False) for t in traces
+        )
         return self
 
     def get_read_states(self, replace_writen: bool = False) -> Tuple[State, ...]:
@@ -2587,8 +2654,19 @@ class TreefyState(Generic[A], PrettyObject):
         return metadata
 
 
+# M5: identity-compared, non-value-identifying metadata that must NOT enter the static
+# pytree aux. `_source_info` (a SourceInfo wrapping a traceback) and `_hooks_manager`
+# (a HookManager holding an RLock/weakrefs) use identity-based __eq__/__hash__, so
+# baking them into the treedef makes two logically-identical TreefyStates compare
+# unequal — causing spurious JIT recompilation and `jax.tree.map` "Mismatch custom
+# node data" errors. They are re-minted with fresh defaults on unflatten.
+_AUX_EXCLUDE = ('_source_info', '_hooks_manager')
+
+
 def _state_ref_flatten(x: TreefyState[Any], *, with_keys: bool):
-    metadata = tuple(x.get_metadata().items())
+    metadata = tuple(
+        (k, v) for k, v in x.get_metadata().items() if k not in _AUX_EXCLUDE
+    )
     if with_keys:
         node = (jax.tree_util.GetAttrKey('value'), x.value)
     else:
@@ -2600,7 +2678,12 @@ def _state_ref_unflatten(
     static: Tuple[type[State[A]], Tuple[Tuple[str, Any], ...]],
     children: Tuple[A],
 ) -> TreefyState[A]:
-    return TreefyState(type=static[0], value=children[0], **dict(static[1]))
+    # Re-mint the diagnostics/hooks dropped from the aux so the rebuilt TreefyState
+    # (and any State produced via to_state()/update_from_ref()) stays complete.
+    meta = dict(static[1])
+    meta.setdefault('_source_info', source_info_util.current())
+    meta.setdefault('_hooks_manager', HookManager())
+    return TreefyState(type=static[0], value=children[0], **meta)
 
 
 jax.tree_util.register_pytree_with_keys(

--- a/brainstate/_state.py
+++ b/brainstate/_state.py
@@ -401,8 +401,18 @@ class State(Generic[A], PrettyObject):
         # record the state initialization
         record_state_init(self)
 
-        # Execute init hooks
-        self._execute_init_hooks(value, metadata)
+        # Execute init hooks.
+        # Only user-facing metadata is exposed to hooks: the internal
+        # bookkeeping fields (the value itself, the trace level, the source
+        # info, the hook manager and the written flag) are stripped so that
+        # ``ctx.init_metadata`` carries just ``_name``/``tag`` and any custom
+        # keyword arguments the user supplied. The value is already passed as
+        # the dedicated ``value`` argument, so duplicating it here is needless.
+        init_metadata = {
+            k: v for k, v in metadata.items()
+            if k not in ('_value', '_level', '_source_info', '_hooks_manager', '_been_writen')
+        }
+        self._execute_init_hooks(value, init_metadata)
 
     if not TYPE_CHECKING:
         def __setattr__(self, name: str, value: Any) -> None:
@@ -755,6 +765,11 @@ class State(Generic[A], PrettyObject):
         attributes['_trace_state'] = StateJaxTracer()
         attributes['_source_info'] = source_info_util.current()
         attributes['_been_writen'] = False
+        # Give the copy its own hook manager. ``vars(self).copy()`` is a shallow
+        # copy, so without this the original and the copy would share the same
+        # HookManager instance: registering/removing a hook on one would silently
+        # mutate the other. Hooks are per-state behaviour and must not alias.
+        attributes['_hooks_manager'] = HookManager()
         # update the metadata
         vars(obj).update(attributes)
         return obj
@@ -820,6 +835,10 @@ class State(Generic[A], PrettyObject):
             This method uses jax.tree.leaves to flatten any nested structure in the state value,
             and jax.numpy.size to compute the size of each leaf node.
         """
+        # A state poisoned by a dead trace has no meaningful element count; the
+        # sentinel would otherwise be treated as a single leaf and report ``1``.
+        # Raise the same descriptive error a normal read would.
+        self._check_invalidated()
         sizes = [jax.numpy.size(val) for val in jax.tree.leaves(self._value)]
         return sum(sizes)
 
@@ -843,17 +862,29 @@ class State(Generic[A], PrettyObject):
         trace_state = self._trace_state
         level = self._level
         source_info = self._source_info
+        # keep our own hook manager: hooks are per-state behaviour and adopting
+        # ``other``'s manager would alias it between the two states (a hook
+        # registered on one would fire on the other). ``other``'s manager stays
+        # with ``other``.
+        hooks_manager = self._hooks_manager
 
         # copy other metadata
         other_vars = vars(other).copy()
         del other_vars['_trace_state']
         del other_vars['_level']
         del other_vars['_source_info']
+        other_vars.pop('_hooks_manager', None)
 
         # update the metadata
         vars_dict = vars(self)
         vars_dict.clear()
-        vars_dict.update(other_vars, _trace_state=trace_state, _level=level, _source_info=source_info)
+        vars_dict.update(
+            other_vars,
+            _trace_state=trace_state,
+            _level=level,
+            _source_info=source_info,
+            _hooks_manager=hooks_manager,
+        )
 
     # Hook execution methods
 
@@ -1662,10 +1693,12 @@ class HiddenTreeState(HiddenGroupState):
         """
         The number of hidden states.
         """
-        assert self.value.shape[-1] == len(self.name2index), (
-            f'The number of hidden states '
-            f'is not equal to the number of hidden state names.'
-        )
+        if self.value.shape[-1] != len(self.name2index):
+            raise ValueError(
+                f'The number of hidden states ({self.value.shape[-1]}) '
+                f'is not equal to the number of hidden state names '
+                f'({len(self.name2index)}).'
+            )
         return self.value.shape[-1]
 
     def _check_value(
@@ -2097,7 +2130,18 @@ class StateTraceStack(Generic[A]):
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        TRACE_CONTEXT.state_stack.pop()
+        # Only pop ourselves. A plain unconditional ``pop()`` corrupts an
+        # unrelated stack if these context managers are entered/exited out of
+        # LIFO order, or if ``__exit__`` runs twice. Verify the top is ``self``
+        # before removing it.
+        stack = TRACE_CONTEXT.state_stack
+        if not stack or stack[-1] is not self:
+            raise RuntimeError(
+                f"{type(self).__name__} is being exited out of order: it is not "
+                f"on top of the trace stack. State trace contexts must be exited "
+                f"in the reverse order they were entered (last-in, first-out)."
+            )
+        stack.pop()
         # print('pop', [s.name for s in TRACE_CONTEXT.state_stack])
 
     def read_its_value(self, state: State) -> None:

--- a/brainstate/_state_hook_core.py
+++ b/brainstate/_state_hook_core.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import threading
 import weakref
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
@@ -84,6 +85,11 @@ class Hook:
     """
 
     _id_counter = 0
+    # Guards the read-modify-write of ``_id_counter`` below. Without it, two
+    # threads constructing hooks concurrently can read the same counter value
+    # and be assigned duplicate ``hook_id``s (and duplicate default names),
+    # breaking the stable ordering used by ``__lt__``.
+    _id_lock = threading.Lock()
 
     def __init__(
         self,
@@ -108,13 +114,18 @@ class Hook:
         if not callable(callback):
             raise HookRegistrationError(f"Hook callback must be callable, got {type(callback)}")
 
+        # Atomically reserve a unique id so concurrent constructions never
+        # collide on hook_id or the default name.
+        with Hook._id_lock:
+            hook_id = Hook._id_counter
+            Hook._id_counter += 1
+
         self.callback = callback
         self.priority = priority
-        self.name = name or f"hook_{Hook._id_counter}"
+        self.name = name or f"hook_{hook_id}"
         self.enabled = enabled
         self._error_count = 0
-        self.hook_id = Hook._id_counter
-        Hook._id_counter += 1
+        self.hook_id = hook_id
 
     def execute(self, context: HookContext) -> Optional[Any]:
         """Execute the hook callback with the given context.

--- a/brainstate/_state_hook_core_test.py
+++ b/brainstate/_state_hook_core_test.py
@@ -104,6 +104,36 @@ class TestHook(unittest.TestCase):
         h.enabled = False
         self.assertIn("disabled", repr(h))
 
+    def test_sequential_ids_unique(self):
+        """Sequentially constructed hooks get distinct ids."""
+        hooks = [Hook(callback=lambda ctx: None) for _ in range(50)]
+        ids = [h.hook_id for h in hooks]
+        self.assertEqual(len(set(ids)), len(ids))
+
+    def test_a12_concurrent_construction_unique_ids(self):
+        """Concurrent Hook construction never assigns duplicate ids (atomic counter)."""
+        import threading
+
+        hooks = []
+        lock = threading.Lock()
+        start = threading.Barrier(8)
+
+        def worker():
+            start.wait()  # maximise contention on the id counter
+            local = [Hook(callback=lambda ctx: None) for _ in range(100)]
+            with lock:
+                hooks.extend(local)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        ids = [h.hook_id for h in hooks]
+        self.assertEqual(len(hooks), 800)
+        self.assertEqual(len(set(ids)), len(ids), "duplicate hook_id assigned under concurrency")
+
 
 class TestHookHandle(unittest.TestCase):
     """Validate HookHandle enable/disable/remove lifecycle via a real State."""

--- a/brainstate/_state_hook_manager.py
+++ b/brainstate/_state_hook_manager.py
@@ -262,7 +262,19 @@ class HookManager:
         Returns
         -------
         True if hooks are registered, False otherwise
+
+        Raises
+        ------
+        ValueError
+            If ``hook_type`` is not a recognised hook type.
         """
+        # Validate the type up front so the result never depends on whether any
+        # hooks happen to be registered: an invalid type must always raise,
+        # rather than returning False on the (no-hooks) fast path and raising
+        # ValueError once hooks exist.
+        if hook_type is not None and hook_type not in allowed_hook_types:
+            raise ValueError(f"Invalid hook type: {hook_type}")
+
         # Fast path without lock for common case
         if not self._has_hooks:
             return False

--- a/brainstate/_state_hook_manager_test.py
+++ b/brainstate/_state_hook_manager_test.py
@@ -459,6 +459,27 @@ class TestHookManagerCoverage(TestCase):
             mgr.execute_read_hooks(1, self.ref)
         self.assertFalse(mgr.has_hooks('read'))
 
+    # --- A13: has_hooks(invalid) is not state-dependent ---
+    def test_a13_has_hooks_invalid_type_raises_when_empty(self):
+        """An invalid hook type raises ValueError even with no hooks registered."""
+        mgr = HookManager()
+        with self.assertRaises(ValueError):
+            mgr.has_hooks('bogus')
+
+    def test_a13_has_hooks_invalid_type_raises_when_nonempty(self):
+        """An invalid hook type raises ValueError when hooks are registered too."""
+        mgr = HookManager()
+        mgr.register_hook('read', lambda ctx: None)
+        with self.assertRaises(ValueError):
+            mgr.has_hooks('bogus')
+
+    def test_a13_has_hooks_valid_types_ok(self):
+        """Valid hook types and None never raise."""
+        mgr = HookManager()
+        self.assertFalse(mgr.has_hooks())
+        for t in ('read', 'write_before', 'write_after', 'restore', 'init'):
+            self.assertFalse(mgr.has_hooks(t))
+
 
 if __name__ == '__main__':
     import unittest

--- a/brainstate/_state_test.py
+++ b/brainstate/_state_test.py
@@ -349,10 +349,10 @@ class TestHiddenGroupState(unittest.TestCase):
         value = np.random.randn(10, 10, 3)
         state = brainstate.HiddenGroupState(value)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(IndexError):
             state.get_value(5)  # Out of range
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(KeyError):
             state.get_value('invalid')  # Invalid name
 
     def test_hidden_group_state_set_value_dict(self):
@@ -391,7 +391,7 @@ class TestHiddenGroupState(unittest.TestCase):
         value = np.random.randn(10, 10, 3)
         state = brainstate.HiddenGroupState(value)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             state.set_value({0: np.ones((5, 5))})  # Wrong shape
 
     def test_hidden_group_state_name2index(self):
@@ -2335,7 +2335,7 @@ class TestStateDictManagerCoverage(unittest.TestCase):
 
     def test_add_unique_value_rejects_non_state(self):
         """add_unique_value validates the element via _check_elem and rejects non-States."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.mgr.add_unique_value('bad', 123)
 
     def test_add_unique_value_accepts_state(self):
@@ -2362,7 +2362,7 @@ class TestStateDictManagerCoverage(unittest.TestCase):
 
     def test_assign_values_requires_dict(self):
         """assign_values rejects non-dict arguments."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.mgr.assign_values([('short', jnp.ones((2,)))])
 
     def test_split_values_by_type(self):
@@ -2595,3 +2595,135 @@ class TestNewStateCatcherGetByTag(unittest.TestCase):
         with brainstate.catch_new_states('mytag') as catcher:
             brainstate.State(jnp.zeros(1))
         self.assertEqual(len(catcher.get_by_tag('other')), 0)
+
+
+class TestStateAuditRegressions(unittest.TestCase):
+    """Regression tests for the _state.py audit fixes (M3-M6, L1-L5)."""
+
+    # --- M3 / M6: set_value works on numpy-backed values ---
+    def test_m6_hidden_group_state_numpy_set_value(self):
+        s = brainstate.HiddenGroupState(np.random.randn(4, 3))
+        self.assertIsInstance(s.value, np.ndarray)  # stored as numpy
+        s.set_value({0: np.ones((4,))})  # must NOT raise AttributeError on .at
+        self.assertIsInstance(s.value, jax.Array)
+        np.testing.assert_allclose(np.asarray(s.get_value(0)), np.ones((4,)))
+
+    def test_m3_hidden_tree_state_numpy_quantity_set_value(self):
+        t = brainstate.HiddenTreeState({'v': np.ones((4, 3)) * u.mV,
+                                        'i': np.ones((4, 3)) * u.mA})
+        t.set_value({'v': np.ones((4, 3)) * 2.0 * u.mV})
+        got = t.get_value('v')
+        self.assertEqual(u.get_unit(got), u.mV)
+        np.testing.assert_allclose(np.asarray(u.get_magnitude(got)), np.full((4, 3), 2.0))
+
+    def test_m6_hidden_tree_state_stored_as_jax(self):
+        t = brainstate.HiddenTreeState({'v': np.ones((4, 3)) * u.mV})
+        self.assertIsInstance(t.value, jax.Array)
+
+    # --- M4: out-of-range integer index rejected, not silently dropped ---
+    def test_m4_hidden_group_state_out_of_range_raises(self):
+        s = brainstate.HiddenGroupState(jnp.zeros((4, 3)))
+        with self.assertRaises(ValueError):
+            s.set_value({10: jnp.ones((4,))})
+        with self.assertRaises(ValueError):
+            s.set_value({-1: jnp.ones((4,))})
+
+    def test_m4_hidden_tree_state_out_of_range_raises(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)), 'i': jnp.ones((4, 3))})
+        with self.assertRaises(ValueError):
+            t.set_value({5: jnp.ones((4, 3))})
+
+    # --- L5: validation raises concrete exceptions (survive python -O) ---
+    def test_l5_set_value_non_dict_raises_typeerror(self):
+        s = brainstate.HiddenGroupState(jnp.zeros((4, 3)))
+        with self.assertRaises(TypeError):
+            s.set_value(123)
+
+    def test_l5_get_value_negative_out_of_range_raises(self):
+        s = brainstate.HiddenGroupState(jnp.zeros((4, 3)))
+        with self.assertRaises(IndexError):
+            s.get_value(-99)
+
+    def test_l5_state_dict_manager_assign_values_non_dict(self):
+        mgr = brainstate.StateDictManager()
+        with self.assertRaises(TypeError):
+            mgr.assign_values(123)
+
+    # --- L1: copy() keeps _been_writen = False (not absent) ---
+    def test_l1_copy_preserves_been_writen(self):
+        c = brainstate.ParamState(jnp.ones(3)).copy()
+        self.assertIs(c._been_writen, False)
+        self.assertIs(c.to_state_ref().to_state()._been_writen, False)
+
+    def test_l1_class_default_been_writen(self):
+        # even a bare object.__new__ instance can read the flag
+        obj = object.__new__(brainstate.ParamState)
+        self.assertIs(obj._been_writen, False)
+
+    # --- L2: construct etrace states under jax-tracer checking ---
+    def test_l2_construct_under_tracer_check(self):
+        with brainstate.check_state_jax_tracer():
+            brainstate.HiddenGroupState(np.random.randn(4, 3))
+            brainstate.HiddenTreeState({'v': np.ones((4, 3)) * u.mV})
+
+    # --- L3: list/tuple tag normalized to a set; add_tag works ---
+    def test_l3_list_tag_normalized(self):
+        s = brainstate.ShortTermState(jnp.zeros(3), tag=['a', 'b'])
+        self.assertEqual(s.tag, {'a', 'b'})
+        s.add_tag('c')
+        self.assertEqual(s.tag, {'a', 'b', 'c'})
+
+    def test_l3_tag_via_catch_new_states(self):
+        with brainstate.catch_new_states('caught'):
+            s = brainstate.ShortTermState(jnp.zeros(3), tag=['a', 'b'])
+        self.assertIn('caught', s.tag)
+
+    # --- M5: TreefyState treedef excludes identity-compared metadata ---
+    def test_m5_identical_states_same_treedef(self):
+        p1 = brainstate.ParamState(jnp.ones(3))
+        p2 = brainstate.ParamState(jnp.zeros(3))
+        self.assertEqual(jax.tree_util.tree_structure(p1.to_state_ref()),
+                         jax.tree_util.tree_structure(p2.to_state_ref()))
+
+    def test_m5_tree_map_over_two_states(self):
+        p1 = brainstate.ParamState(jnp.ones(3))
+        p2 = brainstate.ParamState(jnp.full((3,), 2.0))
+        r = jax.tree.map(lambda a, b: a + b, p1.to_state_ref(), p2.to_state_ref())
+        np.testing.assert_allclose(np.asarray(r.value), np.full(3, 3.0))
+
+    def test_m5_rebuilt_ref_has_source_info_and_hooks(self):
+        p = brainstate.ParamState(jnp.ones(3))
+        rebuilt = jax.tree.map(lambda x: x, p.to_state_ref())
+        st = rebuilt.to_state()  # must not raise AttributeError on _source_info
+        self.assertTrue(hasattr(st, '_source_info'))
+        self.assertTrue(hasattr(st, '_hooks_manager'))
+
+    def test_m5_jit_traces_once_for_identical_models(self):
+        calls = {'n': 0}
+
+        @jax.jit
+        def f(ref):
+            calls['n'] += 1
+            return ref
+
+        f(brainstate.ParamState(jnp.ones(3)).to_state_ref())
+        f(brainstate.ParamState(jnp.zeros(3)).to_state_ref())
+        self.assertEqual(calls['n'], 1)  # no recompile for structurally-identical refs
+
+    # --- L4: merge propagates _originals_released ---
+    def test_l4_merge_propagates_originals_released(self):
+        from brainstate._state import StateTraceStack
+        a = StateTraceStack()
+        b = StateTraceStack()
+        b._originals_released = True
+        merged = StateTraceStack().merge(a, b)
+        self.assertTrue(merged._originals_released)
+
+    def test_l4_merge_all_live_stays_false(self):
+        from brainstate._state import StateTraceStack
+        merged = StateTraceStack().merge(StateTraceStack(), StateTraceStack())
+        self.assertFalse(merged._originals_released)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainstate/_state_test.py
+++ b/brainstate/_state_test.py
@@ -2724,6 +2724,94 @@ class TestStateAuditRegressions(unittest.TestCase):
         merged = StateTraceStack().merge(StateTraceStack(), StateTraceStack())
         self.assertFalse(merged._originals_released)
 
+    # --- A4: init hooks receive only user-facing metadata, not internals ---
+    def test_a4_init_hook_metadata_excludes_internals(self):
+        captured = {}
+
+        def hook(ctx):
+            captured.update(ctx.init_metadata)
+
+        handle = brainstate.register_state_hook('init', hook)
+        try:
+            brainstate.State(jnp.array([1, 2, 3]), name='nm', tag='tg')
+        finally:
+            handle.remove()
+        # internal bookkeeping fields must NOT leak into init_metadata
+        for leaked in ('_value', '_level', '_source_info', '_hooks_manager', '_been_writen'):
+            self.assertNotIn(leaked, captured)
+        # user-facing metadata is still present
+        self.assertEqual(captured['_name'], 'nm')
+        self.assertIn('tg', captured['tag'])
+
+    # --- A6: copy()/copy_from() do not alias the hook manager ---
+    def test_a6_copy_has_independent_hook_manager(self):
+        s = brainstate.State(jnp.ones(3))
+        c = s.copy()
+        self.assertIsNot(s._hooks_manager, c._hooks_manager)
+        # registering on the copy must not affect the original
+        c.register_hook('read', lambda ctx: None)
+        self.assertTrue(c.has_hooks('read'))
+        self.assertFalse(s.has_hooks('read'))
+
+    def test_a6_copy_from_keeps_own_hook_manager(self):
+        dst = brainstate.State(jnp.ones(3))
+        src = brainstate.State(jnp.zeros(3))
+        dst_mgr = dst._hooks_manager
+        dst.copy_from(src)
+        # dst keeps its own manager; it is not aliased to src's
+        self.assertIs(dst._hooks_manager, dst_mgr)
+        self.assertIsNot(dst._hooks_manager, src._hooks_manager)
+        src.register_hook('read', lambda ctx: None)
+        self.assertFalse(dst.has_hooks('read'))
+
+    # --- A7: numel() on a poisoned state raises rather than returning 1 ---
+    def test_a7_numel_normal(self):
+        s = brainstate.State(jnp.ones((3, 4)))
+        self.assertEqual(s.numel(), 12)
+
+    def test_a7_numel_poisoned_raises(self):
+        from brainstate._state import TraceContextError
+        s = brainstate.State(jnp.ones((2, 2)))
+        s._invalidate_trace_value()
+        with self.assertRaises(TraceContextError):
+            s.numel()
+
+    # --- A8: num_state validates via raise (survives python -O) ---
+    def test_a8_num_state_mismatch_raises_valueerror(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)), 'i': jnp.ones((4, 3))})
+        # corrupt the invariant: drop one name without changing the array
+        t.name2index.pop('i')
+        with self.assertRaises(ValueError):
+            _ = t.num_state
+
+    # --- A10: StateTraceStack.__exit__ only pops itself ---
+    def test_a10_exit_out_of_order_raises_and_preserves_stack(self):
+        from brainstate._state import StateTraceStack, TRACE_CONTEXT
+        outer = StateTraceStack(name='outer')
+        inner = StateTraceStack(name='inner')
+        depth0 = len(TRACE_CONTEXT.state_stack)
+        outer.__enter__()
+        inner.__enter__()
+        try:
+            # exiting `outer` while `inner` is on top is out-of-order: must raise
+            with self.assertRaises(RuntimeError):
+                outer.__exit__(None, None, None)
+            # inner must still be on top (stack not corrupted)
+            self.assertIs(TRACE_CONTEXT.state_stack[-1], inner)
+        finally:
+            # unwind cleanly in correct LIFO order
+            inner.__exit__(None, None, None)
+            outer.__exit__(None, None, None)
+        self.assertEqual(len(TRACE_CONTEXT.state_stack), depth0)
+
+    def test_a10_normal_nested_exit_ok(self):
+        from brainstate._state import StateTraceStack, TRACE_CONTEXT
+        depth0 = len(TRACE_CONTEXT.state_stack)
+        with StateTraceStack(name='a'):
+            with StateTraceStack(name='b'):
+                self.assertEqual(len(TRACE_CONTEXT.state_stack), depth0 + 2)
+        self.assertEqual(len(TRACE_CONTEXT.state_stack), depth0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/_state_test.py
+++ b/brainstate/_state_test.py
@@ -2813,5 +2813,121 @@ class TestStateAuditRegressions(unittest.TestCase):
         self.assertEqual(len(TRACE_CONTEXT.state_stack), depth0)
 
 
+class TestHiddenStateSetGetBranches(unittest.TestCase):
+    """Cover the validation/unit branches of HiddenGroupState and HiddenTreeState.
+
+    These exercise the error-raising and alternate branches inside
+    ``set_value`` / ``get_value`` / ``_check_value`` that the happy-path tests
+    above do not reach.
+    """
+
+    # --- HiddenGroupState.set_value: key that is neither int nor str ---
+    def test_group_set_value_non_int_str_key_raises(self):
+        s = brainstate.HiddenGroupState(jnp.zeros((4, 3)))
+        with self.assertRaises(TypeError) as ctx:
+            s.set_value({1.5: jnp.ones((4,))})  # float key -> not int, not str
+        msg = str(ctx.exception)
+        self.assertIn('should be int or str', msg)
+        self.assertIn('1.5', msg)
+
+    # --- HiddenGroupState.set_value: non-dimensionless (unit-carrying) else branch ---
+    def test_group_set_value_with_unit_uses_quantity_branch(self):
+        # A unit-carrying group state forces the ``else`` branch that converts
+        # the new values through ``u.Quantity(...).to(unit)`` before scattering.
+        s = brainstate.HiddenGroupState(jnp.ones((4, 3)) * u.mV)
+        self.assertFalse(u.get_unit(s.value).dim.is_dimensionless)
+        s.set_value({0: jnp.full((4,), 5.0) * u.mV})
+        got = s.get_value(0)
+        self.assertEqual(u.get_unit(got), u.mV)
+        np.testing.assert_allclose(np.asarray(u.get_magnitude(got)), np.full((4,), 5.0))
+        # untouched columns keep their original value
+        np.testing.assert_allclose(np.asarray(u.get_magnitude(s.get_value(1))), np.ones((4,)))
+
+    def test_group_set_value_dimensionless_uses_if_branch(self):
+        # Dimensionless companion so the ``if`` (true) side of the same branch
+        # is also exercised; the value is updated without unit conversion.
+        s = brainstate.HiddenGroupState(jnp.zeros((4, 3)))
+        self.assertTrue(u.get_unit(s.value).dim.is_dimensionless)
+        s.set_value({2: jnp.full((4,), 7.0)})
+        np.testing.assert_allclose(np.asarray(s.get_value(2)), np.full((4,), 7.0))
+
+    # --- HiddenTreeState._check_value: value that is neither dict nor sequence ---
+    def test_tree_check_value_non_dict_sequence_raises(self):
+        with self.assertRaises(TypeError) as ctx:
+            brainstate.HiddenTreeState(123)  # int -> not dict, not tuple/list
+        msg = str(ctx.exception)
+        self.assertIn('HiddenTreeState', msg)
+        self.assertIn('dictionary/sequence', msg)
+
+    # --- HiddenTreeState.get_value: integer index out of range ---
+    def test_tree_get_value_int_out_of_range_raises(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)) * u.mV,
+                                        'i': jnp.ones((4, 3)) * u.mA})
+        with self.assertRaises(IndexError) as ctx:
+            t.get_value(99)
+        self.assertIn('out of range', str(ctx.exception))
+
+    # --- HiddenTreeState.get_value: negative (in-range) integer index ---
+    def test_tree_get_value_negative_index(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)) * u.mV,
+                                        'i': jnp.full((4, 3), 2.0) * u.mA})
+        neg = t.get_value(-1)            # wraps to the last hidden state
+        last = t.get_value(t.num_state - 1)
+        self.assertEqual(u.get_unit(neg), u.mA)
+        np.testing.assert_allclose(np.asarray(u.get_magnitude(neg)),
+                                   np.asarray(u.get_magnitude(last)))
+
+    # --- HiddenTreeState.get_value: string name not present ---
+    def test_tree_get_value_unknown_name_raises(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)) * u.mV})
+        with self.assertRaises(KeyError) as ctx:
+            t.get_value('does_not_exist')
+        self.assertIn('not found', str(ctx.exception))
+
+    # --- HiddenTreeState.set_value: value that is neither dict nor sequence ---
+    def test_tree_set_value_non_dict_sequence_raises(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)) * u.mV})
+        with self.assertRaises(TypeError) as ctx:
+            t.set_value(123)
+        msg = str(ctx.exception)
+        self.assertIn('set_value', msg)
+        self.assertIn('dictionary of hidden states', msg)
+
+    # --- HiddenTreeState.set_value: key that is neither int nor str ---
+    def test_tree_set_value_non_int_str_key_raises(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)) * u.mV,
+                                        'i': jnp.ones((4, 3)) * u.mA})
+        with self.assertRaises(TypeError) as ctx:
+            t.set_value({1.5: jnp.ones((4, 3)) * u.mV})  # float key
+        msg = str(ctx.exception)
+        self.assertIn('should be int or str', msg)
+        self.assertIn('1.5', msg)
+
+    # --- HiddenTreeState.get_value: string name that IS present (false side of the
+    #     name-not-found check) ---
+    def test_tree_get_value_known_name(self):
+        t = brainstate.HiddenTreeState({'v': jnp.full((4, 3), 3.0) * u.mV,
+                                        'i': jnp.ones((4, 3)) * u.mA})
+        got = t.get_value('v')
+        self.assertEqual(u.get_unit(got), u.mV)
+        np.testing.assert_allclose(np.asarray(u.get_magnitude(got)), np.full((4, 3), 3.0))
+
+    # --- HiddenTreeState.set_value: value with the wrong shape ---
+    def test_tree_set_value_wrong_shape_raises(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)) * u.mV})
+        with self.assertRaises(ValueError) as ctx:
+            t.set_value({0: jnp.ones((9, 9)) * u.mV})
+        self.assertIn('shape of the hidden state', str(ctx.exception))
+
+    # --- HiddenTreeState.set_value: value with the correct shape (false side of the
+    #     shape check) ---
+    def test_tree_set_value_correct_shape_updates(self):
+        t = brainstate.HiddenTreeState({'v': jnp.ones((4, 3)) * u.mV})
+        t.set_value({0: jnp.full((4, 3), 6.0) * u.mV})
+        got = t.get_value('v')
+        self.assertEqual(u.get_unit(got), u.mV)
+        np.testing.assert_allclose(np.asarray(u.get_magnitude(got)), np.full((4, 3), 6.0))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/_testing.py
+++ b/brainstate/_testing.py
@@ -152,14 +152,20 @@ def assert_vmap_equal(
     *batched_args,
     rtol: float = DEFAULT_RTOL,
     atol: float = DEFAULT_ATOL,
+    **kwargs,
 ) -> Any:
     """Assert ``vmap(fn)`` over axis 0 matches an explicit Python loop.
 
     Every positional argument is mapped over its leading axis (``in_axes=0``).
+    Any keyword arguments are passed through to ``fn`` unchanged (i.e. not
+    mapped) in both the vmapped and the looped calls, so callers can supply
+    static configuration the same way they do for ``assert_jit_equal``.
     """
-    vmapped = brainstate.transform.vmap(fn, in_axes=0)(*batched_args)
+    vmapped = brainstate.transform.vmap(
+        lambda *a: fn(*a, **kwargs), in_axes=0
+    )(*batched_args)
     n = u.math.shape(batched_args[0])[0]
-    looped = [fn(*[jnp.take(a, i, axis=0) for a in batched_args]) for i in range(n)]
+    looped = [fn(*[jnp.take(a, i, axis=0) for a in batched_args], **kwargs) for i in range(n)]
     stacked = jax.tree.map(lambda *xs: jnp.stack(xs), *looped)
     _assert_tree_allclose(vmapped, stacked, rtol=rtol, atol=atol)
     return vmapped
@@ -187,7 +193,7 @@ def assert_transform_compatible(
     if "grad" in transforms:
         assert_grad_finite(fn, *args, argnums=grad_argnums, **kwargs)
     if "vmap" in transforms:
-        assert_vmap_equal(fn, *args, rtol=rtol, atol=atol)
+        assert_vmap_equal(fn, *args, rtol=rtol, atol=atol, **kwargs)
     return True
 
 

--- a/brainstate/_testing_test.py
+++ b/brainstate/_testing_test.py
@@ -74,6 +74,31 @@ class TestTransformHelpers(unittest.TestCase):
         """Umbrella helper runs jit by default."""
         _testing.assert_transform_compatible(lambda x: x + 1.0, jnp.ones((4, 8)))
 
+    def test_a14_vmap_equal_forwards_kwargs(self):
+        """assert_vmap_equal forwards keyword arguments to fn (not mapped)."""
+
+        def fn(r, *, scale=1.0):
+            return r.sum() * scale
+
+        # With the bug, scale was dropped on the vmap branch and the helper
+        # would compute with scale=1.0 internally; here both vmapped and looped
+        # calls must see scale=3.0, so they agree.
+        _testing.assert_vmap_equal(fn, jnp.arange(12.0).reshape(4, 3), scale=3.0)
+
+    def test_a14_transform_compatible_vmap_forwards_kwargs(self):
+        """assert_transform_compatible passes **kwargs to the vmap branch."""
+        seen = {}
+
+        def fn(x, *, bias=0.0):
+            seen["bias"] = bias
+            return x + bias
+
+        _testing.assert_transform_compatible(
+            fn, jnp.ones((4, 8)), transforms=("vmap",), bias=2.5
+        )
+        # The kwarg actually reached fn rather than being silently dropped.
+        self.assertEqual(seen["bias"], 2.5)
+
 
 class TestPytreeRoundtrip(unittest.TestCase):
     """Validate pytree flatten/unflatten roundtrip helper."""

--- a/brainstate/environ.py
+++ b/brainstate/environ.py
@@ -236,6 +236,9 @@ def reset(*, env: Optional[EnvironmentState] = None) -> None:
         env.settings.clear()
         env.contexts.clear()
         env.functions.clear()
+        # Also drop the per-key locks: leaving them behind keeps stale
+        # RLock objects around for keys that no longer have any settings.
+        env.locks.clear()
         # Re-initialize with default precision
         env.settings[PRECISION] = DEFAULT_PRECISION
 
@@ -1515,7 +1518,7 @@ def dctype(*, env: Optional[EnvironmentState] = None) -> DTypeLike:
     return _get_complex(_get_precision(env=env))
 
 
-def tolerance(*, env: Optional[EnvironmentState] = None) -> jnp.ndarray:
+def tolerance(*, env: Optional[EnvironmentState] = None) -> np.ndarray:
     """
     Get numerical tolerance based on current precision.
 
@@ -1529,8 +1532,10 @@ def tolerance(*, env: Optional[EnvironmentState] = None) -> jnp.ndarray:
 
     Returns
     -------
-    jnp.ndarray
-        Tolerance value as a scalar array.
+    np.ndarray
+        Tolerance value as a scalar array whose dtype matches the requested
+        precision (float64 for 64-bit, float32 for 32-bit, float16 otherwise),
+        independent of JAX's global x64 configuration.
 
     Examples
     --------
@@ -1571,12 +1576,19 @@ def tolerance(*, env: Optional[EnvironmentState] = None) -> jnp.ndarray:
     """
     precision = get_precision(env=env)
 
+    # Build the constant with NumPy so the requested precision's dtype is always
+    # honoured. ``jnp.array(1e-12, dtype=np.float64)`` is silently downcast to
+    # float32 whenever JAX's global x64 flag is disabled -- which is the default
+    # -- so a custom env with ``precision=64`` would otherwise hand back a
+    # float32 tolerance, contradicting both the requested precision and the
+    # documented value. NumPy faithfully preserves float64 regardless of JAX's
+    # global config, and the resulting scalar still broadcasts against JAX arrays.
     if precision == 64:
-        return jnp.array(1e-12, dtype=np.float64)
+        return np.asarray(1e-12, dtype=np.float64)
     elif precision == 32:
-        return jnp.array(1e-5, dtype=np.float32)
+        return np.asarray(1e-5, dtype=np.float32)
     else:
-        return jnp.array(1e-2, dtype=np.float16)
+        return np.asarray(1e-2, dtype=np.float16)
 
 
 def register_default_behavior(

--- a/brainstate/environ_test.py
+++ b/brainstate/environ_test.py
@@ -1415,5 +1415,41 @@ class TestEnvironContextCoverage(unittest.TestCase):
         self.assertEqual(brainstate.environ.get('boom_key', env=self.env), 'base')
 
 
+class TestEnvironAuditAppendix(unittest.TestCase):
+    """Appendix items 15 & 17 for environ.py."""
+
+    def test_a15_reset_custom_env_clears_locks(self):
+        """reset(env=custom) must also clear the per-key locks defaultdict."""
+        env = bst.environ.EnvironmentState()
+        bst.environ.set(some_key='v', env=env)
+        # Touch get() so a per-key lock is materialised in the defaultdict.
+        bst.environ.get('some_key', env=env)
+        self.assertGreater(len(env.locks), 0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            bst.environ.reset(env=env)
+        self.assertEqual(len(env.locks), 0)
+
+    def test_a17_tolerance_dtype_honours_env_precision(self):
+        """tolerance(env=...) returns a dtype matching the env precision even
+        when JAX's global x64 flag is off (the default)."""
+        env64 = bst.environ.EnvironmentState()
+        bst.environ.set(precision=64, env=env64)
+        tol = bst.environ.tolerance(env=env64)
+        self.assertEqual(tol.dtype, np.float64)
+        self.assertAlmostEqual(float(tol), 1e-12, places=14)
+
+        env32 = bst.environ.EnvironmentState()
+        bst.environ.set(precision=32, env=env32)
+        tol32 = bst.environ.tolerance(env=env32)
+        self.assertEqual(tol32.dtype, np.float32)
+        self.assertAlmostEqual(float(tol32), 1e-5, places=7)
+
+        env16 = bst.environ.EnvironmentState()
+        bst.environ.set(precision=16, env=env16)
+        tol16 = bst.environ.tolerance(env=env16)
+        self.assertEqual(tol16.dtype, np.float16)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/graph/_context.py
+++ b/brainstate/graph/_context.py
@@ -20,14 +20,14 @@ A :func:`split_context` shares one growing ``ref_index`` across several
 split objects collapse to the same global index. The paired
 :func:`merge_context` shares the inverse ``index_ref`` table across
 :meth:`MergeContext.treefy_merge` calls so those references rebuild as one
-object. The context stacks are thread-local.
+object. Each call owns its own table, so concurrent split/merge on separate
+threads stay isolated.
 """
 
 from __future__ import annotations
 
 import contextlib
 import dataclasses
-import threading
 from typing import Any, Iterator, Tuple, TypeVar
 
 from typing_extensions import Unpack
@@ -49,21 +49,6 @@ A = TypeVar('A')
 
 
 @dataclasses.dataclass
-class GraphContext(threading.local):
-    """Thread-local stacks of active split/merge contexts.
-
-    Inheriting from ``threading.local`` ensures each thread has its own
-    independent context stacks, making nested transforms safe under parallelism.
-    """
-
-    ref_index_stack: list[SplitContext] = dataclasses.field(default_factory=list)
-    index_ref_stack: list[MergeContext] = dataclasses.field(default_factory=list)
-
-
-GRAPH_CONTEXT = GraphContext()
-
-
-@dataclasses.dataclass
 class SplitContext:
     """Context for splitting graph nodes, tracking shared references."""
 
@@ -80,11 +65,9 @@ def split_context() -> Iterator[Tuple[SplitContext, RefMap[Any, Index]]]:
     """Context manager for splitting multiple graph nodes sharing a reference index."""
     index_ref: RefMap[Any, Index] = RefMap()
     flatten_ctx = SplitContext(index_ref)
-    GRAPH_CONTEXT.ref_index_stack.append(flatten_ctx)
     try:
         yield flatten_ctx, index_ref
     finally:
-        GRAPH_CONTEXT.ref_index_stack.pop()
         del flatten_ctx.ref_index
 
 
@@ -110,12 +93,10 @@ def merge_context() -> Iterator[Tuple[MergeContext, dict]]:
     """Context manager for merging multiple graph nodes sharing a reference index."""
     index_ref: dict[Index, Any] = {}
     unflatten_ctx = MergeContext(index_ref)
-    GRAPH_CONTEXT.index_ref_stack.append(unflatten_ctx)
     try:
         # Yield the *live* table (not a snapshot copy) so callers can inspect the
         # accumulated ``index -> rebuilt object`` mapping after the block, exactly
         # as ``split_context`` exposes its live ``ref_index``.
         yield unflatten_ctx, index_ref
     finally:
-        GRAPH_CONTEXT.index_ref_stack.pop()
         del unflatten_ctx.index_ref

--- a/brainstate/graph/_convert.py
+++ b/brainstate/graph/_convert.py
@@ -219,7 +219,12 @@ def graph_to_tree(
     leaf_prefixes = broadcast_prefix(prefix, may_have_graph_nodes, prefix_is_leaf=lambda x: x is None)
     leaf_keys, treedef = jax.tree_util.tree_flatten_with_path(may_have_graph_nodes)
 
-    assert len(leaf_keys) == len(leaf_prefixes)
+    if len(leaf_keys) != len(leaf_prefixes):
+        raise ValueError(
+            f"Mismatched number of leaves ({len(leaf_keys)}) and broadcast prefixes "
+            f"({len(leaf_prefixes)}); the `prefix` is not a valid prefix tree of "
+            f"`may_have_graph_nodes`."
+        )
 
     with split_context() as (ctx, index_ref):
         leaves_out = []
@@ -301,7 +306,11 @@ def tree_to_graph(
     _prefix_is_leaf = lambda x: x is None or is_leaf(x)
     leaf_prefixes = broadcast_prefix(prefix, tree, prefix_is_leaf=_prefix_is_leaf, tree_is_leaf=is_leaf)
     leaf_keys, treedef = jax.tree_util.tree_flatten_with_path(tree, is_leaf=is_leaf)
-    assert len(leaf_keys) == len(leaf_prefixes), "Mismatched number of keys and prefixes"
+    if len(leaf_keys) != len(leaf_prefixes):
+        raise ValueError(
+            f"Mismatched number of leaves ({len(leaf_keys)}) and broadcast prefixes "
+            f"({len(leaf_prefixes)}); the `prefix` is not a valid prefix tree of `tree`."
+        )
 
     with merge_context() as (ctx, index_ref):
         leaves_out = []

--- a/brainstate/graph/_convert.py
+++ b/brainstate/graph/_convert.py
@@ -70,13 +70,20 @@ def check_consistent_aliasing(
     node_prefixes = RefMap() if node_prefixes is None else node_prefixes
 
     for path, value in iter_graph(node):
-        if _is_graph_node(value) or isinstance(value, State):
+        if isinstance(value, State):
+            value.check_valid_trace(
+                lambda: f'Trying to extract graph node from different trace level, got {value!r}'
+            )
+            if value in node_prefixes:
+                node_prefixes[value].append((path, prefix))
+            else:
+                node_prefixes[value] = [(path, prefix)]
+
+    from ._walk import iter_node  # already exported from _walk
+    for path, value in iter_node(node):
+        if _is_graph_node(value):
             if isinstance(value, GraphNode):
                 value.check_valid_context(
-                    lambda: f'Trying to extract graph node from different trace level, got {value!r}'
-                )
-            if isinstance(value, State):
-                value.check_valid_trace(
                     lambda: f'Trying to extract graph node from different trace level, got {value!r}'
                 )
             if value in node_prefixes:

--- a/brainstate/graph/_convert_test.py
+++ b/brainstate/graph/_convert_test.py
@@ -198,6 +198,47 @@ class TestAliasingChecks(unittest.TestCase):
         shared = Empty()
         graph_to_tree([shared, shared], prefix=0)  # should not raise
 
+    def test_nested_graph_node_walked_and_recorded(self):
+        """The ``iter_node`` pass descends into *nested* graph nodes too.
+
+        ``check_consistent_aliasing`` walks every graph node reachable from a
+        leaf (the leaf node and each nested graph-node child). A single node that
+        holds an inner graph node must split without raising; the walk visits both
+        the outer and the inner node.
+        """
+
+        class Inner(brainstate.graph.Node):
+            def __init__(self):
+                self.w = brainstate.ParamState(jnp.ones((2,)))
+
+        class Outer(brainstate.graph.Node):
+            def __init__(self, inner):
+                self.inner = inner  # a nested graph node
+
+        tree, _ = graph_to_tree(Outer(Inner()), prefix=0)
+        self.assertIsNotNone(tree)
+
+    def test_shared_nested_graph_node_inconsistent_prefix_raises(self):
+        """A *nested* graph node shared across slots with conflicting prefixes
+        is detected by the per-node aliasing walk and raises ``ValueError``.
+
+        The inner node is reachable only by descending into each outer node, so
+        catching the conflict proves the walk records prefixes for nested nodes,
+        not just the top-level leaf node.
+        """
+
+        class Inner(brainstate.graph.Node):
+            def __init__(self):
+                self.w = brainstate.ParamState(jnp.ones((2,)))
+
+        class Outer(brainstate.graph.Node):
+            def __init__(self, inner):
+                self.inner = inner
+
+        inner = Inner()
+        with self.assertRaises(ValueError):
+            graph_to_tree([Outer(inner), Outer(inner)], prefix=[0, 1])
+
 
 class TestConvertHelpers(unittest.TestCase):
     """Internal helpers used by the conversion routines."""

--- a/brainstate/graph/_convert_test.py
+++ b/brainstate/graph/_convert_test.py
@@ -216,5 +216,39 @@ class TestConvertHelpers(unittest.TestCase):
         self.assertIs(_convert._get_rand_state(), RandomState)
 
 
+class TestLeafPrefixParityValidation(unittest.TestCase):
+    """The leaf/prefix length-parity guard must hold even under ``python -O``.
+
+    The check was historically an ``assert``, which is stripped when Python runs
+    optimized; a length mismatch would then silently truncate-``zip`` leaves and
+    prefixes (a wrong result) instead of raising. These tests force a mismatch
+    and require the *explicit* parity ``ValueError`` (identified by its message),
+    so they fail if the guard reverts to a stripped ``assert``.
+    """
+
+    def test_graph_to_tree_mismatched_prefixes_raise(self):
+        node = _Linear(2, 3)
+        original = _convert.broadcast_prefix
+        # Force a prefix list one element longer than the flattened leaves so the
+        # explicit guard (not a downstream pytree error) is the one that fires.
+        _convert.broadcast_prefix = lambda *a, **k: original(*a, **k) + [None]
+        try:
+            with self.assertRaisesRegex(ValueError, 'Mismatched number of leaves'):
+                graph_to_tree(node)
+        finally:
+            _convert.broadcast_prefix = original
+
+    def test_tree_to_graph_mismatched_prefixes_raise(self):
+        node = _Linear(2, 3)
+        tree, _ = graph_to_tree(node)
+        original = _convert.broadcast_prefix
+        _convert.broadcast_prefix = lambda *a, **k: original(*a, **k) + [None]
+        try:
+            with self.assertRaisesRegex(ValueError, 'Mismatched number of leaves'):
+                tree_to_graph(tree)
+        finally:
+            _convert.broadcast_prefix = original
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/graph/_convert_test.py
+++ b/brainstate/graph/_convert_test.py
@@ -168,6 +168,36 @@ class TestAliasingChecks(unittest.TestCase):
         tree, _ = graph_to_tree([shared, shared], prefix=[0, 1], check_aliasing=False)
         self.assertIsNotNone(tree)
 
+    def test_inconsistent_stateless_shared_node_raises(self):
+        """A *state-free* shared node with conflicting prefixes still raises.
+
+        Regression (L7): ``check_consistent_aliasing`` only iterated
+        ``iter_leaf`` (which yields leaf States, never graph nodes), so the
+        graph-node aliasing branch was dead. A stateless shared node therefore
+        recorded no prefixes and inconsistent aliasing went undetected. The
+        added ``iter_node`` pass must catch it.
+        """
+
+        class Empty(brainstate.graph.Node):
+            """A graph node carrying no ``State`` leaves at all."""
+
+            def __init__(self):
+                self.name = 'x'
+
+        shared = Empty()
+        with self.assertRaises(ValueError):
+            graph_to_tree([shared, shared], prefix=[0, 1])
+
+    def test_consistent_stateless_shared_node_ok(self):
+        """A consistently-prefixed *state-free* shared node does not raise."""
+
+        class Empty(brainstate.graph.Node):
+            def __init__(self):
+                self.name = 'x'
+
+        shared = Empty()
+        graph_to_tree([shared, shared], prefix=0)  # should not raise
+
 
 class TestConvertHelpers(unittest.TestCase):
     """Internal helpers used by the conversion routines."""

--- a/brainstate/graph/_engine_test.py
+++ b/brainstate/graph/_engine_test.py
@@ -161,6 +161,56 @@ class TestWalkRegistry(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'State is not a node'):
             _get_node_impl(brainstate.ParamState(1))
 
+    def test_get_node_impl_for_type_unregistered_raises_descriptive(self):
+        """An unregistered type yields a descriptive ``ValueError``, not a bare
+        ``KeyError`` exposing only the type repr."""
+        from brainstate.graph._walk import get_node_impl_for_type
+
+        class _NeverRegistered:
+            pass
+
+        with self.assertRaises(ValueError) as ctx:
+            get_node_impl_for_type(_NeverRegistered)
+        msg = str(ctx.exception)
+        self.assertIn('Unknown graph node type', msg)
+        self.assertIn('register_graph_node_type', msg)
+
+    def test_key_path_to_key_unhashable_message(self):
+        """The invalid-key error names *hashability* (the property actually
+        required/checked), not the misleading 'hashable or comparable'."""
+        from brainstate.graph._walk import _key_path_to_key
+
+        bad = jax.tree_util.DictKey(key=['unhashable', 'list'])
+        with self.assertRaises(ValueError) as ctx:
+            _key_path_to_key(bad)
+        msg = str(ctx.exception)
+        self.assertIn('Invalid key', msg)
+        self.assertIn('hashable', msg)
+        # The old wording claimed comparability was also checked; it never was.
+        self.assertNotIn('comparable', msg)
+
+    def test_node_dict_rejects_duplicate_child_keys(self):
+        """``node_dict`` must not silently collapse duplicate child keys (which
+        ``dict(items)`` would do); it raises so the data loss is visible."""
+        from brainstate.graph._walk import register_graph_node_type, _get_node_impl
+
+        class _DupNode:
+            pass
+
+        # A flatten that violates the unique-key contract by returning 'x' twice.
+        register_graph_node_type(
+            _DupNode,
+            flatten=lambda n: ((('x', 1), ('x', 2)), (_DupNode,)),
+            set_key=lambda n, k, v: None,
+            pop_key=lambda n, k: None,
+            create_empty=lambda meta: _DupNode(),
+            clear=lambda n: None,
+        )
+        impl = _get_node_impl(_DupNode())
+        with self.assertRaises(ValueError) as ctx:
+            impl.node_dict(_DupNode())
+        self.assertIn('Duplicate child keys', str(ctx.exception))
+
     def test_static_is_pytree_leaf(self):
         from brainstate.graph._walk import Static
         s = Static({'k': 'v'})

--- a/brainstate/graph/_flatten.py
+++ b/brainstate/graph/_flatten.py
@@ -295,7 +295,12 @@ def unflatten(
                 f"in the state mapping while rebuilding the graph."
             )
         if isinstance(edge, StateLeafEdge):
-            value = flat_states[edge.path]
+            value = flat_states.get(edge.path, _MISSING)
+            if value is _MISSING:
+                raise ValueError(
+                    f"Expected key {_format_path(edge.path)} "
+                    f"in the state mapping while rebuilding the graph."
+                )
             return value.to_state() if isinstance(value, TreefyState) else value
         if isinstance(edge, PytreeEdge):
             items = tuple((k, resolve(c)) for k, c in edge.fields)

--- a/brainstate/graph/_flatten_test.py
+++ b/brainstate/graph/_flatten_test.py
@@ -199,6 +199,35 @@ class TestIndexRefCacheEdgeCases(unittest.TestCase):
         self.assertTrue(bool(jnp.allclose(out.w.value, jnp.ones((2,)))))
 
 
+class TestStateLeafEdgeMissingPath(unittest.TestCase):
+    """A ``StateLeafEdge`` whose path is absent from the mapping must raise a
+    friendly ``ValueError`` (mirroring ``StateEdge``), not a bare ``KeyError``.
+
+    ``StateLeafEdge`` is a public, exported IR type, so a hand-built or
+    deserialized ``GraphDef`` can reference a path missing from the supplied
+    state mapping. The decoder used a bare ``flat_states[path]`` lookup there.
+    """
+
+    def test_missing_stateleafedge_path_raises_valueerror(self):
+        from brainstate.graph import NodeSpec, NodeEdge, StateLeafEdge
+        from brainstate.util import NestedDict
+
+        # Borrow a valid node spec, then point its single field at a missing path.
+        template, _ = flatten(_Cell())
+        spec0 = template.node_specs[0]
+        spec = NodeSpec(
+            spec0.type, spec0.index, spec0.metadata,
+            (('w', StateLeafEdge(('definitely_missing',))),),
+        )
+        gd = GraphDef(NodeEdge(spec0.index), (spec,))
+
+        with self.assertRaises(ValueError) as ctx:
+            unflatten(gd, NestedDict.from_flat({}))
+        msg = str(ctx.exception)
+        self.assertIn('definitely_missing', msg)
+        self.assertIn('state mapping', msg)
+
+
 class TestFormatPath(unittest.TestCase):
     """The ``_format_path`` helper used in error messages."""
 

--- a/brainstate/graph/_flatten_test.py
+++ b/brainstate/graph/_flatten_test.py
@@ -227,6 +227,34 @@ class TestStateLeafEdgeMissingPath(unittest.TestCase):
         self.assertIn('definitely_missing', msg)
         self.assertIn('state mapping', msg)
 
+    def test_present_stateleafedge_path_resolves(self):
+        """A ``StateLeafEdge`` whose path *is* present resolves to that value.
+
+        This is the success counterpart to the missing-path case: the decoder's
+        ``StateLeafEdge`` branch looks up the path, finds it, and (for a
+        ``TreefyState`` value) materialises it back into a live ``State``.
+        """
+        from brainstate.graph import NodeSpec, NodeEdge, StateLeafEdge
+        from brainstate.util import NestedDict
+        from brainstate._state import State
+
+        template, _ = flatten(_Cell())
+        spec0 = template.node_specs[0]
+        spec = NodeSpec(
+            spec0.type, spec0.index, spec0.metadata,
+            (('w', StateLeafEdge(('present_key',))),),
+        )
+        gd = GraphDef(NodeEdge(spec0.index), (spec,))
+
+        # Provide the path with a TreefyState value -> decoder calls .to_state().
+        tref = brainstate.ParamState(jnp.arange(3.0)).to_state_ref()
+        self.assertIsInstance(tref, TreefyState)
+        rebuilt = unflatten(gd, NestedDict.from_flat({('present_key',): tref}))
+
+        self.assertIsInstance(rebuilt, _Cell)
+        self.assertIsInstance(rebuilt.w, State)
+        self.assertTrue(bool(jnp.allclose(rebuilt.w.value, jnp.arange(3.0))))
+
 
 class TestFormatPath(unittest.TestCase):
     """The ``_format_path`` helper used in error messages."""

--- a/brainstate/graph/_operation_test.py
+++ b/brainstate/graph/_operation_test.py
@@ -1127,6 +1127,90 @@ class TestUpdateStates(unittest.TestCase):
         with self.assertRaises(ValueError):
             brainstate.graph.update_states(Outer(), brainstate.util.NestedDict({'sub': leaf}))
 
+    def test_update_readds_popped_states_as_live_states(self):
+        """Re-adding popped raw ``State``s grafts *live* States, not dead refs.
+
+        Regression (H1): the new-key branch of ``_graph_update_dynamic`` wrongly
+        converted a raw ``State`` to a ``TreefyState`` via ``to_state_ref()`` (and
+        stored ``TreefyState`` values as-is). The grafted attribute then looked
+        present (``hasattr`` true) but was a dead ``TreefyState`` invisible to
+        ``states()`` / ``treefy_split``. The states must come back live.
+        """
+        net = _Net()
+        popped = brainstate.graph.pop_states(net, brainstate.ParamState)
+        # ``pop_states`` emits raw States, and the keys were removed, so this
+        # exercises the new-key branch with raw ``State`` values.
+        brainstate.graph.update_states(net, popped)
+
+        self.assertIsInstance(net.w, brainstate.State)
+        self.assertIsInstance(net.b, brainstate.State)
+        # Live again: visible to both ``states`` and ``treefy_split``.
+        self.assertEqual(len(brainstate.graph.states(net)), 2)
+        self.assertEqual(len(brainstate.graph.treefy_split(net)[1].to_flat()), 2)
+
+    def test_graft_treefy_states_under_new_key_materializes_live(self):
+        """Grafting ``TreefyState``s under absent keys materializes live States.
+
+        Regression (H1): a ``TreefyState`` value in the new-key branch was stored
+        verbatim (a dead ref). It must be materialized to a live ``State`` via
+        ``to_state()`` so it is visible to ``states()``.
+        """
+        net = _Net()
+        treefy = brainstate.graph.treefy_states(net)
+        # Values are ``TreefyState`` objects.
+        self.assertTrue(all(
+            isinstance(v, brainstate.TreefyState) for v in treefy.to_flat().values()
+        ))
+        brainstate.graph.pop_states(net, brainstate.ParamState)  # remove the keys
+        self.assertFalse(hasattr(net, 'w'))
+
+        brainstate.graph.update_states(net, treefy)  # graft under now-absent keys
+        self.assertIsInstance(net.w, brainstate.State)
+        self.assertNotIsInstance(net.w, brainstate.TreefyState)
+        self.assertEqual(len(brainstate.graph.states(net)), 2)
+
+    def test_update_existing_key_with_raw_state(self):
+        """A raw ``State`` value at an *existing* key updates it in place.
+
+        Regression (M7): a raw ``State`` at an existing key fell through every
+        ``elif`` to the ``else`` and raised ``ValueError('Unsupported update
+        type')`` -- even though ``pop_states`` emits raw States and the new-key
+        branch accepts them. It must instead update the live State's value.
+        """
+        src = _Net()
+        src.w.value = jnp.full((2,), 7.0)
+        src.b.value = jnp.full((2,), 9.0)
+        popped = brainstate.graph.pop_states(src, brainstate.ParamState)  # raw States
+
+        tgt = _Net()  # keys are STILL present on the target
+        brainstate.graph.update_states(tgt, popped)
+
+        self.assertTrue(bool(jnp.allclose(tgt.w.value, jnp.full((2,), 7.0))))
+        self.assertTrue(bool(jnp.allclose(tgt.b.value, jnp.full((2,), 9.0))))
+        # The leaf is still a live ParamState and both remain visible.
+        params = brainstate.graph.states(tgt, brainstate.ParamState)
+        self.assertEqual(len(params), 2)
+        self.assertTrue(all(isinstance(v, brainstate.ParamState) for v in params.values()))
+        self.assertEqual(len(brainstate.graph.states(tgt)), 2)
+
+    def test_update_existing_key_with_non_state_raw_value_raises(self):
+        """A raw ``State`` aimed at a non-State attribute still raises.
+
+        The M7 branch must reject grafting a ``State`` onto an attribute whose
+        current value is not a ``State``.
+        """
+
+        class Mixed(brainstate.graph.Node):
+            def __init__(self):
+                self.w = brainstate.ParamState(jnp.ones((2,)))
+                self.tag = 'plain'  # not a State
+
+        node = Mixed()
+        with self.assertRaises(ValueError):
+            brainstate.graph.update_states(
+                node, brainstate.util.NestedDict({'tag': brainstate.ParamState(jnp.zeros((2,)))})
+            )
+
 
 class TestCloneAndGraphdef(unittest.TestCase):
     """``clone`` and ``graphdef`` thin wrappers."""

--- a/brainstate/graph/_operation_test.py
+++ b/brainstate/graph/_operation_test.py
@@ -475,6 +475,13 @@ class TestGraphOperation(unittest.TestCase):
         assert params is not None
         assert others is not None
 
+        # The (filter, rest) partition must be a complete, non-overlapping cover
+        # of all states (no leakage into spurious extra buckets). This locks the
+        # behaviour after the redundant trailing-Everything predicate was removed
+        # from ``states`` / ``nodes``.
+        self.assertEqual(len(params) + len(others), len(all_states))
+        self.assertTrue(all(isinstance(v, brainstate.ParamState) for v in params.values()))
+
     def test_split_merge_split_round_trip(self):
         # Regression: a state reconstructed by ``treefy_merge`` must be
         # splittable again. ``State.to_state_ref`` strips ``_trace_state`` when

--- a/brainstate/graph/_operations.py
+++ b/brainstate/graph/_operations.py
@@ -361,8 +361,8 @@ def _graph_update_dynamic(node, state) -> None:
                 raise ValueError(
                     f'Cannot set key {key!r} on immutable node of type {type(node).__name__}'
                 )
-            if isinstance(value, State):
-                value = value.to_state_ref()
+            if isinstance(value, TreefyState):
+                value = value.to_state()
             impl.set_key(node, key, value)
             continue
         current_value = node_dict[key]
@@ -370,6 +370,12 @@ def _graph_update_dynamic(node, state) -> None:
             if _is_state_leaf(value):
                 raise ValueError(f'Expected a subgraph for {key!r}, but got: {value!r}')
             _graph_update_dynamic(current_value, value)
+        elif isinstance(value, State):
+            if not isinstance(current_value, State):
+                raise ValueError(
+                    f'Trying to update a non-State attribute {key!r} with a State: {value!r}'
+                )
+            current_value.update_from_ref(value.to_state_ref())
         elif isinstance(value, TreefyState):
             if not isinstance(current_value, State):
                 raise ValueError(

--- a/brainstate/graph/_operations.py
+++ b/brainstate/graph/_operations.py
@@ -203,11 +203,11 @@ def states(
     """
     num_filters = len(filters)
     if num_filters == 0:
-        filters = (..., ...)
+        filters = (...,)
     else:
         filters = (*filters, ...)
     gen = _states_generator(node, allowed_hierarchy=allowed_hierarchy)
-    flat_states = _split_flatted(gen, (*filters, ...))
+    flat_states = _split_flatted(gen, filters)
     state_maps = tuple(FlattedDict(flat) for flat in flat_states)
     return state_maps[0] if num_filters < 2 else state_maps[:num_filters]
 
@@ -236,11 +236,11 @@ def nodes(
     """
     num_filters = len(filters)
     if num_filters == 0:
-        filters = (..., ...)
+        filters = (...,)
     else:
         filters = (*filters, ...)
     gen = iter_node(node, allowed_hierarchy=allowed_hierarchy)
-    flat_nodes = _split_flatted(gen, (*filters, ...))
+    flat_nodes = _split_flatted(gen, filters)
     node_maps = tuple(FlattedDict(flat) for flat in flat_nodes)
     return node_maps[0] if num_filters < 2 else node_maps[:num_filters]
 

--- a/brainstate/graph/_walk.py
+++ b/brainstate/graph/_walk.py
@@ -99,7 +99,14 @@ class NodeImplBase(Generic[N, Leaf, AuxData]):
     def node_dict(self, node: N) -> dict[Key, Leaf]:
         """Return the node's one-level children as an ordered ``{key: value}`` dict."""
         nodes, _ = self.flatten(node)
-        return dict(nodes)
+        nodes = tuple(nodes)
+        result = dict(nodes)
+        if len(result) != len(nodes):
+            raise ValueError(
+                f"Duplicate child keys returned by the flatten function for "
+                f"{type(node).__name__}; each child key must be unique."
+            )
+        return result
 
 
 @dataclasses.dataclass(frozen=True)
@@ -192,7 +199,13 @@ def get_node_impl_for_type(x: type) -> NodeImpl:
     """Return the node-impl registered for type ``x`` (or the pytree impl)."""
     if x is PytreeType:
         return PYTREE_NODE_IMPL
-    return _node_impl_for_type[x]
+    try:
+        return _node_impl_for_type[x]
+    except KeyError:
+        raise ValueError(
+            f"Unknown graph node type: {x!r}. Register it with "
+            f"brainstate.graph.register_graph_node_type before flatten/unflatten."
+        ) from None
 
 
 # ---------------------------------------------------------------------------
@@ -224,8 +237,8 @@ def _key_path_to_key(key: Any) -> Key:
     elif isinstance(key, (jax.tree_util.DictKey, jax.tree_util.FlattenedIndexKey)):
         if not isinstance(key.key, Key):
             raise ValueError(
-                f'Invalid key: {key.key}. May be due to its type not being '
-                f'hashable or comparable.'
+                f'Invalid key: {key.key!r}. A pytree key must be hashable '
+                f'(its type does not satisfy the Key protocol).'
             )
         return key.key
     elif isinstance(key, jax.tree_util.GetAttrKey):

--- a/brainstate/interop/_common.py
+++ b/brainstate/interop/_common.py
@@ -252,7 +252,7 @@ def bst_set_norm(layer, attr, scale, offset):
 
 # --- BatchNorm ------------------------------------------------------------
 
-_BN_CLS = {1: bnn.BatchNorm1d, 2: bnn.BatchNorm2d, 3: bnn.BatchNorm3d}
+_BN_CLS = {0: bnn.BatchNorm0d, 1: bnn.BatchNorm1d, 2: bnn.BatchNorm2d, 3: bnn.BatchNorm3d}
 
 
 def build_batchnorm(num_spatial_dims, in_size, epsilon, momentum, affine):

--- a/brainstate/interop/_conversion_test.py
+++ b/brainstate/interop/_conversion_test.py
@@ -771,5 +771,227 @@ class NnxConvInputDilationTest(absltest.TestCase):
             interop.from_nnx(src, sample_input=(8, 8, 3))
 
 
+class BiasOnlyBatchNormTest(absltest.TestCase):
+    """H2/H5: bias-only BatchNorm (use_scale=False, use_bias=True) must keep its bias."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nn = pytest.importorskip('flax.linen')
+
+    def test_bias_only_batchnorm_from_nnx(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 5, 3)
+        src = nnx.BatchNorm(3, use_scale=False, use_bias=True,
+                            use_running_average=True, rngs=nnx.Rngs(brainstate.random.split_key()))
+        src.bias[...] = brainstate.random.randn(3)
+        src.mean[...] = brainstate.random.randn(3)
+        src.var[...] = brainstate.random.rand(3) + 0.5
+        dst = interop.from_nnx(src, sample_input=(5, 3))
+        # bias must survive (affine present)
+        self.assertIsNotNone(dst.weight)
+        self.assertIn('bias', dst.weight.value)
+        self.assertNotIn('scale', dst.weight.value)
+        assert_close(src(x), bst_forward(dst, x), 'bias-only batchnorm nnx import')
+
+    def test_bias_only_batchnorm_from_linen(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 5, 3)
+        m = nn.BatchNorm(use_running_average=True, use_scale=False, use_bias=True)
+        v = m.init(_key(), jnp.ones((1, 5, 3)))
+        v = jax.tree_util.tree_map(
+            lambda a: brainstate.random.rand(*a.shape) + 0.5 if a.ndim == 1 else a, v)
+        dst = interop.from_linen(m, v, sample_input=(5, 3))
+        self.assertIsNotNone(dst.weight)
+        self.assertIn('bias', dst.weight.value)
+        self.assertNotIn('scale', dst.weight.value)
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'bias-only batchnorm linen import')
+
+
+class TwoDBatchNormRoundTripTest(absltest.TestCase):
+    """H3: a BatchNorm over a 2-D (batch, features) input resolves to nd==0 (BatchNorm0d).
+
+    Pre-fix this raised ``KeyError(0)`` because the ``_BN_CLS`` map and the nnx/linen
+    registration pairs started at spatial-dim 1. It must round-trip through nnx and linen.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nn = pytest.importorskip('flax.linen')
+
+    def test_2d_batchnorm_nnx_round_trip(self):
+        nnx = self.nnx
+        # (N, C) input -> nd == 0 -> BatchNorm0d
+        x = brainstate.random.randn(4, 3)
+        src = nnx.BatchNorm(3, use_running_average=True,
+                            rngs=nnx.Rngs(brainstate.random.split_key()))
+        src.scale[...] = brainstate.random.randn(3)
+        src.bias[...] = brainstate.random.randn(3)
+        src.mean[...] = brainstate.random.randn(3)
+        src.var[...] = brainstate.random.rand(3) + 0.5
+        dst = interop.from_nnx(src, sample_input=(3,))
+        self.assertIsInstance(dst, bnn.BatchNorm0d)
+        assert_close(src(x), bst_forward(dst, x), '2d batchnorm nnx import')
+        assert_close(src(x), interop.to_nnx(dst)(x), '2d batchnorm nnx export')
+
+    def test_2d_batchnorm_linen_round_trip(self):
+        nn = self.nn
+        x = brainstate.random.randn(4, 3)
+        m = nn.BatchNorm(use_running_average=True)
+        v = m.init(_key(), jnp.ones((1, 3)))
+        v = jax.tree_util.tree_map(
+            lambda a: brainstate.random.rand(*a.shape) + 0.5 if a.ndim == 1 else a, v)
+        dst = interop.from_linen(m, v, sample_input=(3,))
+        self.assertIsInstance(dst, bnn.BatchNorm0d)
+        assert_close(m.apply(v, x), bst_forward(dst, x), '2d batchnorm linen import')
+        m2, v2 = interop.to_linen(dst)
+        assert_close(m.apply(v, x), m2.apply(v2, x), '2d batchnorm linen export')
+
+
+class LinenGroupNormGroupSizeTest(absltest.TestCase):
+    """M8: linen GroupNorm with num_groups=None + group_size must not crash on int(None)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nn = pytest.importorskip('flax.linen')
+
+    def test_groupnorm_group_size_only(self):
+        nn = self.nn
+        x = brainstate.random.randn(1, 12)
+        m = nn.GroupNorm(num_groups=None, group_size=4)
+        v = m.init(_key(), jnp.ones((1, 12)))
+        v = jax.tree_util.tree_map(lambda a: brainstate.random.randn(*a.shape)
+                                   if a.ndim else a, v)
+        dst = interop.from_linen(m, v)
+        # 12 channels / group_size 4 == 3 groups
+        self.assertEqual(int(dst.num_groups), 3)
+        assert_close(m.apply(v, x), bst_forward(dst, x), 'groupnorm group_size-only import')
+
+
+class EquinoxRmsNormBiasTest(absltest.TestCase):
+    """H4: equinox RMSNorm with a non-zero bias cannot be represented and must raise."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.eqx = pytest.importorskip('equinox')
+
+    def test_nonzero_bias_raises(self):
+        eqx = self.eqx
+        src = eqx.nn.RMSNorm(6, use_bias=True)
+        src = eqx.tree_at(lambda m: m.bias, src, brainstate.random.randn(6))
+        with self.assertRaises(ConversionError):
+            interop.from_equinox(src)
+
+    def test_zero_bias_still_converts(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(4, 6)
+        # default RMSNorm has a zero (not None) bias; conversion must still succeed.
+        src = eqx.nn.RMSNorm(6)
+        src = eqx.tree_at(lambda m: m.weight, src, brainstate.random.randn(6))
+        dst = interop.from_equinox(src)
+        assert_close(jax.vmap(src)(x), bst_forward(dst, x), 'eqx zero-bias rmsnorm import')
+
+
+class NnxDtypePreservationTest(absltest.TestCase):
+    """M9: non-float32 weights must keep their dtype through from_nnx/to_nnx round-trips.
+
+    Sources are built directly with ``param_dtype`` so their weights carry a non-float32 dtype.
+    ``from_nnx`` must preserve it into the brainstate layer, and ``to_nnx`` must thread it back
+    into the rebuilt nnx layer (whose constructors otherwise default param_dtype to float32).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+
+    def _rngs(self):
+        return self.nnx.Rngs(brainstate.random.split_key())
+
+    def test_linear_bf16_round_trip(self):
+        nnx = self.nnx
+        dt = jnp.bfloat16
+        src = nnx.Linear(3, 5, param_dtype=dt, rngs=self._rngs())
+        dst = interop.from_nnx(src)
+        self.assertEqual(dst.weight.value['weight'].dtype, dt)
+        back = interop.to_nnx(dst)
+        self.assertEqual(back.kernel.value.dtype, dt)
+        self.assertEqual(back.bias.value.dtype, dt)
+
+    def test_conv_fp16_round_trip(self):
+        nnx = self.nnx
+        dt = jnp.float16
+        src = nnx.Conv(3, 4, (3, 3), param_dtype=dt, rngs=self._rngs())
+        dst = interop.from_nnx(src, sample_input=(8, 8, 3))
+        self.assertEqual(dst.weight.value['weight'].dtype, dt)
+        back = interop.to_nnx(dst)
+        self.assertEqual(back.kernel.value.dtype, dt)
+
+    def test_batchnorm_bf16_round_trip(self):
+        nnx = self.nnx
+        dt = jnp.bfloat16
+        # nnx forces running stats to float32 on construction; build the brainstate side with
+        # bf16 running stats explicitly so the export path is what must preserve the dtype.
+        layer = bnn.BatchNorm1d((5, 3), affine=True)
+        # Cast every stored array to bf16.
+        layer.weight.value = {k: v.astype(dt) for k, v in layer.weight.value.items()}
+        layer.running_mean.value = layer.running_mean.value.astype(dt)
+        layer.running_var.value = layer.running_var.value.astype(dt)
+        back = interop.to_nnx(layer)
+        self.assertEqual(back.scale.value.dtype, dt)
+        # running stats: nnx forces float32 on construction; the export must rebuild them.
+        self.assertEqual(back.mean.value.dtype, dt)
+        self.assertEqual(back.var.value.dtype, dt)
+
+    def test_lstm_bf16_round_trip(self):
+        nnx = self.nnx
+        dt = jnp.bfloat16
+        src = nnx.LSTMCell(3, 4, param_dtype=dt, rngs=self._rngs())
+        dst = interop.from_nnx(src)
+        self.assertEqual(dst.W.weight.value['weight'].dtype, dt)
+        back = interop.to_nnx(dst)
+        self.assertEqual(back.ii.kernel.value.dtype, dt)
+        self.assertEqual(back.hi.bias.value.dtype, dt)
+
+
+class DropoutEvalEquivalenceTest(absltest.TestCase):
+    """M10: exported Dropout must be deterministic (eval-equivalent), not stochastic."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.eqx = pytest.importorskip('equinox')
+
+    def test_to_nnx_dropout_deterministic(self):
+        nnx = self.nnx
+        x = brainstate.random.randn(4, 6)
+        src = bnn.Sequential(bnn.Linear(6, 6), bnn.Dropout(0.5), bnn.Linear(6, 6))
+        out = interop.to_nnx(src)
+        # Output-equivalent to brainstate eval-mode forward (deterministic Dropout = identity).
+        assert_close(bst_forward(src, x), out(x), 'to_nnx dropout eval-equivalent')
+
+    def test_to_equinox_dropout_inference(self):
+        eqx = self.eqx
+        x = brainstate.random.randn(4, 6)
+        src = bnn.Sequential(bnn.Linear(6, 6), bnn.Dropout(0.5), bnn.Linear(6, 6))
+        out = interop.to_equinox(src)
+        assert_close(bst_forward(src, x), jax.vmap(out)(x), 'to_equinox dropout eval-equivalent')
+
+
+class NnxConvChannelMismatchTest(absltest.TestCase):
+    """L8: from_nnx of a Conv with a sample_input channel count that mismatches the kernel."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nnx = pytest.importorskip('flax.nnx')
+
+    def test_channel_mismatch_raises(self):
+        nnx = self.nnx
+        # kernel expects 3 input channels; sample_input declares 5 -> clear ConversionError.
+        src = nnx.Conv(3, 4, (3, 3), rngs=nnx.Rngs(0))
+        with self.assertRaises(ConversionError):
+            interop.from_nnx(src, sample_input=(8, 8, 5))
+
+
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/interop/_frameworks/_equinox.py
+++ b/brainstate/interop/_frameworks/_equinox.py
@@ -124,6 +124,12 @@ def _layernorm_to_foreign(layer, ctx):
 def _rmsnorm_to_bst(m, ctx):
     scale = m.weight
     num = int(m.shape[0])
+    bias = getattr(m, 'bias', None)
+    if bias is not None and bool(u.math.any(bias != 0)):
+        raise ConversionError(
+            'equinox RMSNorm has a non-zero bias term, which brainstate RMSNorm (bias-free) '
+            'cannot represent; conversion would silently change the layer.'
+        )
     layer = C.build_rmsnorm((num,), scale is not None, float(m.eps))
     C.bst_set_norm(layer, 'scale', scale, None)
     return layer
@@ -170,7 +176,11 @@ def _dropout_to_bst(m, ctx):
 
 
 def _dropout_to_foreign(layer, ctx):
-    return eqx.nn.Dropout(1.0 - float(layer.prob))
+    # ``inference=True`` is baked in so the exported module (and any ``eqx.nn.Sequential``
+    # containing it) is directly applicable and output-equivalent to brainstate's eval-mode
+    # Dropout. Cross-framework RNG streams cannot be matched, so equivalence for Dropout is
+    # only defined in eval mode.
+    return eqx.nn.Dropout(1.0 - float(layer.prob), inference=True)
 
 
 # ---------------------------------------------------------------------------

--- a/brainstate/interop/_frameworks/_linen.py
+++ b/brainstate/interop/_frameworks/_linen.py
@@ -180,7 +180,10 @@ def _groupnorm_to_bst(node, ctx):
         raise ConversionError(
             "Cannot determine feature count for linen GroupNorm with no affine parameters."
         )
-    layer = C.build_groupnorm((num,), int(node.module.num_groups),
+    ng = node.module.num_groups
+    if ng is None:
+        ng = num // int(node.module.group_size)
+    layer = C.build_groupnorm((num,), int(ng),
                               scale is not None, bias is not None, float(node.module.epsilon))
     C.bst_set_norm(layer, 'weight', scale, bias)
     return layer
@@ -278,7 +281,7 @@ def _batchnorm_to_bst(node, ctx):
     var = bs['var']
     in_size = ctx.require_size('BatchNorm')
     nd = len(in_size) - 1
-    affine = scale is not None
+    affine = (scale is not None) or (bias is not None)
     layer = C.build_batchnorm(nd, in_size, float(node.module.epsilon),
                               float(node.module.momentum), affine)
 
@@ -431,6 +434,7 @@ def _register():
         (bnn.Conv1d, nn.Conv, _conv_to_bst, _conv_to_foreign),
         (bnn.Conv2d, nn.Conv, _conv_to_bst, _conv_to_foreign),
         (bnn.Conv3d, nn.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.BatchNorm0d, nn.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
         (bnn.BatchNorm1d, nn.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
         (bnn.BatchNorm2d, nn.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
         (bnn.BatchNorm3d, nn.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),

--- a/brainstate/interop/_frameworks/_nnx.py
+++ b/brainstate/interop/_frameworks/_nnx.py
@@ -60,6 +60,19 @@ def _split4(arr, axis=-1):
     return list(u.math.split(arr, 4, axis=axis))
 
 
+def _param_dtype(*arrays):
+    """Return the dtype of the first non-None array, or float32 if all are None.
+
+    Used to thread the source brainstate weight dtype into nnx export constructors, whose
+    ``param_dtype`` otherwise defaults to float32 and would silently downcast bf16/fp16 weights.
+    """
+    import jax.numpy as jnp
+    for a in arrays:
+        if a is not None:
+            return a.dtype
+    return jnp.float32
+
+
 # ---------------------------------------------------------------------------
 # Linear
 # ---------------------------------------------------------------------------
@@ -74,7 +87,8 @@ def _linear_to_bst(m, ctx):
 
 def _linear_to_foreign(layer, ctx):
     w, b = C.bst_get_linear(layer)
-    m = nnx.Linear(w.shape[0], w.shape[1], use_bias=b is not None, rngs=_rngs(ctx))
+    m = nnx.Linear(w.shape[0], w.shape[1], use_bias=b is not None,
+                   dtype=w.dtype, param_dtype=w.dtype, rngs=_rngs(ctx))
     _set(m.kernel, w)
     if b is not None:
         _set(m.bias, b)
@@ -94,7 +108,8 @@ def _embed_to_bst(m, ctx):
 
 def _embed_to_foreign(layer, ctx):
     table = C.bst_get_embedding(layer)
-    m = nnx.Embed(table.shape[0], table.shape[1], rngs=_rngs(ctx))
+    m = nnx.Embed(table.shape[0], table.shape[1],
+                  dtype=table.dtype, param_dtype=table.dtype, rngs=_rngs(ctx))
     _set(m.embedding, table)
     return m
 
@@ -115,8 +130,10 @@ def _layernorm_to_bst(m, ctx):
 def _layernorm_to_foreign(layer, ctx):
     scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
     num = int(layer.in_size[-1])
+    pdt = _param_dtype(scale, offset)
     m = nnx.LayerNorm(num, epsilon=float(layer.epsilon),
-                      use_scale=scale is not None, use_bias=offset is not None, rngs=_rngs(ctx))
+                      use_scale=scale is not None, use_bias=offset is not None,
+                      param_dtype=pdt, rngs=_rngs(ctx))
     if scale is not None:
         _set(m.scale, scale)
     if offset is not None:
@@ -135,8 +152,9 @@ def _rmsnorm_to_bst(m, ctx):
 def _rmsnorm_to_foreign(layer, ctx):
     scale, _ = C.bst_get_norm(layer, 'scale', has_offset=False)
     num = int(layer.in_size[-1])
+    pdt = _param_dtype(scale)
     m = nnx.RMSNorm(num, epsilon=float(layer.epsilon),
-                     use_scale=scale is not None, rngs=_rngs(ctx))
+                     use_scale=scale is not None, param_dtype=pdt, rngs=_rngs(ctx))
     if scale is not None:
         _set(m.scale, scale)
     return m
@@ -155,8 +173,10 @@ def _groupnorm_to_bst(m, ctx):
 def _groupnorm_to_foreign(layer, ctx):
     scale, offset = C.bst_get_norm(layer, 'weight', has_offset=True)
     num = int(layer.in_size[-1])
+    pdt = _param_dtype(scale, offset)
     m = nnx.GroupNorm(num, num_groups=int(layer.num_groups), epsilon=float(layer.epsilon),
-                      use_scale=scale is not None, use_bias=offset is not None, rngs=_rngs(ctx))
+                      use_scale=scale is not None, use_bias=offset is not None,
+                      param_dtype=pdt, rngs=_rngs(ctx))
     if scale is not None:
         _set(m.scale, scale)
     if offset is not None:
@@ -173,7 +193,11 @@ def _dropout_to_bst(m, ctx):
 
 
 def _dropout_to_foreign(layer, ctx):
-    return nnx.Dropout(1.0 - float(layer.prob), rngs=_rngs(ctx))
+    # ``deterministic=True`` is baked in so the exported module (and any ``nnx.Sequential``
+    # containing it) is directly applicable and output-equivalent to brainstate's eval-mode
+    # Dropout. Cross-framework RNG streams cannot be matched, so equivalence for Dropout is
+    # only defined in eval mode.
+    return nnx.Dropout(1.0 - float(layer.prob), deterministic=True, rngs=_rngs(ctx))
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +233,14 @@ def _conv_to_bst(m, ctx):
     in_size = ctx.require_size('Conv')
     has_bias = m.bias is not None
     groups = int(getattr(m, 'feature_group_count', 1))
+    expected_in = int(w.shape[-2]) * groups
+    if int(in_size[-1]) != expected_in:
+        raise ConversionError(
+            f"nnx Conv kernel expects {expected_in} input channels "
+            f"(kernel in//groups={int(w.shape[-2])} * feature_group_count={groups}), but the "
+            f"resolved `sample_input` has {int(in_size[-1])} channels in its last (channel) "
+            f"axis. Pass a `sample_input` whose channel count matches the layer's kernel."
+        )
     layer = C.build_conv(
         nd, in_size, out_channels, kernel_size,
         stride=getattr(m, 'strides', 1) or 1,
@@ -233,6 +265,7 @@ def _conv_to_foreign(layer, ctx):
         input_dilation=tuple(layer.lhs_dilation),
         feature_group_count=layer.groups,
         use_bias=b is not None,
+        dtype=w.dtype, param_dtype=w.dtype,
         rngs=_rngs(ctx),
     )
     _set(m.kernel, w)
@@ -260,7 +293,7 @@ def _batchnorm_to_bst(m, ctx):
     var = _get(m.var)
     in_size = ctx.require_size('BatchNorm')
     nd = len(in_size) - 1
-    affine = scale is not None
+    affine = (scale is not None) or (bias is not None)
     layer = C.build_batchnorm(nd, in_size, float(m.epsilon), float(m.momentum), affine)
     C.bst_set_batchnorm(
         layer,
@@ -273,20 +306,32 @@ def _batchnorm_to_bst(m, ctx):
 
 
 def _batchnorm_to_foreign(layer, ctx):
+    import jax.numpy as jnp
     scale, offset, mean, var = C.bst_get_batchnorm(layer)
     num = (scale if scale is not None else mean).shape[-1]
+    src_dtype = (scale if scale is not None else mean).dtype
     # ``use_running_average=True`` so the exported layer normalizes with the transferred running
     # statistics by default, matching brainstate's eval-mode forward (the only mode in which
     # BatchNorm output is framework-equivalent). Flip it for training.
     m = nnx.BatchNorm(num, momentum=float(layer.momentum), epsilon=float(layer.epsilon),
                       use_scale=scale is not None, use_bias=offset is not None,
-                      use_running_average=True, rngs=_rngs(ctx))
+                      use_running_average=True,
+                      dtype=src_dtype, param_dtype=src_dtype, rngs=_rngs(ctx))
     if scale is not None:
         _set(m.scale, _bn_reshape_to_foreign(scale))
     if offset is not None:
         _set(m.bias, _bn_reshape_to_foreign(offset))
-    _set(m.mean, _bn_reshape_to_foreign(mean))
-    _set(m.var, _bn_reshape_to_foreign(var))
+    new_mean = _bn_reshape_to_foreign(mean)
+    new_var = _bn_reshape_to_foreign(var)
+    _set(m.mean, new_mean)
+    _set(m.var, new_var)
+    # nnx forces running stats (BatchStat) to float32 on construction; ``_set`` may not preserve
+    # a non-float32 source dtype. Rebuild the BatchStat Variables so the running statistics keep
+    # the source dtype (otherwise bf16/fp16 weights silently round-trip as float32).
+    if _get(m.mean).dtype != mean.dtype:
+        m.mean = nnx.BatchStat(jnp.asarray(new_mean, dtype=mean.dtype))
+    if _get(m.var).dtype != var.dtype:
+        m.var = nnx.BatchStat(jnp.asarray(new_var, dtype=var.dtype))
     return m
 
 
@@ -302,7 +347,7 @@ def _lstm_to_foreign(layer, ctx):
     ii, ig, if_, io = _split4(Wi)                # brainstate order i,g,f,o
     hi, hg, hf, ho = _split4(Wh)
     bi, bg, bf, bo = _split4(bias)
-    m = nnx.LSTMCell(num_in, h, rngs=_rngs(ctx))
+    m = nnx.LSTMCell(num_in, h, dtype=W.dtype, param_dtype=W.dtype, rngs=_rngs(ctx))
     _set(m.ii.kernel, ii); _set(m.if_.kernel, if_); _set(m.ig.kernel, ig); _set(m.io.kernel, io)
     _set(m.hi.kernel, hi); _set(m.hf.kernel, hf); _set(m.hg.kernel, hg); _set(m.ho.kernel, ho)
     _set(m.hi.bias, bi); _set(m.hf.bias, bf + 1.0); _set(m.hg.bias, bg); _set(m.ho.bias, bo)
@@ -365,6 +410,7 @@ def _register():
         (bnn.Conv1d, nnx.Conv, _conv_to_bst, _conv_to_foreign),
         (bnn.Conv2d, nnx.Conv, _conv_to_bst, _conv_to_foreign),
         (bnn.Conv3d, nnx.Conv, _conv_to_bst, _conv_to_foreign),
+        (bnn.BatchNorm0d, nnx.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
         (bnn.BatchNorm1d, nnx.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
         (bnn.BatchNorm2d, nnx.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),
         (bnn.BatchNorm3d, nnx.BatchNorm, _batchnorm_to_bst, _batchnorm_to_foreign),

--- a/brainstate/interop/_transforms.py
+++ b/brainstate/interop/_transforms.py
@@ -135,10 +135,12 @@ class AddScalar(Transform):
         self.constant = constant
 
     def forward(self, x):
-        return x + self.constant
+        # Wrap the constant in x's unit so a united ``brainunit.Quantity`` bias
+        # folds in correctly (raw ``x + constant`` raises on a dimensioned x).
+        return u.math.add(x, u.Quantity(self.constant, unit=u.get_unit(x)))
 
     def inverse(self, x):
-        return x - self.constant
+        return u.math.subtract(x, u.Quantity(self.constant, unit=u.get_unit(x)))
 
     def __repr__(self):
         return f"AddScalar({self.constant})"

--- a/brainstate/interop/_transforms_test.py
+++ b/brainstate/interop/_transforms_test.py
@@ -134,6 +134,22 @@ class TransformQuantityTest(absltest.TestCase):
         y = tf.forward(x)
         self.assertTrue(u.get_unit(y) == u.get_unit(x))
 
+    def test_add_scalar_preserves_units(self):
+        # The constant must adopt x's unit so a united bias (e.g. the LSTM
+        # forget-gate +1) folds in correctly instead of raising UnitMismatchError.
+        x = brainstate.random.randn(5) * u.mV
+        tf = AddScalar(1.0)
+        y = tf.forward(x)
+        self.assertTrue(u.get_unit(y) == u.get_unit(x))
+        # forward adds the constant in x's unit ...
+        np.testing.assert_allclose(np.asarray(u.get_mantissa(y)),
+                                   np.asarray(u.get_mantissa(x)) + 1.0, rtol=1e-6)
+        # ... and inverse(forward(x)) round-trips exactly (unit and value).
+        z = tf.inverse(y)
+        self.assertTrue(u.get_unit(z) == u.get_unit(x))
+        np.testing.assert_allclose(np.asarray(u.get_mantissa(z)),
+                                   np.asarray(u.get_mantissa(x)), rtol=1e-6)
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/mixin.py
+++ b/brainstate/mixin.py
@@ -990,6 +990,23 @@ class Mode(Mixin):
         assert isinstance(other, Mode)
         return other.__class__ == self.__class__
 
+    def __hash__(self):
+        """
+        Return a hash for the mode based on its type.
+
+        Defining ``__eq__`` would otherwise set ``__hash__`` to ``None`` and make
+        every Mode instance unhashable. This implementation is consistent with the
+        type-based ``__eq__``: instances of the same class compare equal and hash
+        equal, so a Mode can be used as a dict key, set member, or JAX
+        ``static_argname``.
+
+        Returns
+        -------
+        int
+            The hash of the mode's class.
+        """
+        return hash(self.__class__)
+
     def is_a(self, mode: type):
         """
         Check whether the mode is exactly the desired mode type.

--- a/brainstate/mixin.py
+++ b/brainstate/mixin.py
@@ -24,7 +24,7 @@ description mixins, alignment interfaces, and custom type definitions for
 expressing complex type requirements.
 """
 
-from typing import Sequence, Optional, TypeVar, Union, _GenericAlias
+from typing import Any, Sequence, Optional, TypeVar, Union, _GenericAlias
 
 import jax
 
@@ -250,9 +250,16 @@ class HashableDict(dict):
 
     def __hash__(self):
         """
-        Compute hash from sorted items for consistent hashing regardless of insertion order.
+        Compute an order-independent hash of the items.
+
+        A ``frozenset`` of the items is used rather than ``sorted(...)``: sorting
+        compares keys against one another, which raises ``TypeError`` for dicts
+        whose keys are of mutually-unorderable types (e.g. mixing ``int`` and
+        ``str`` keys). ``frozenset`` only requires the items to be hashable
+        (which the constructor guarantees) and is likewise insertion-order
+        independent.
         """
-        return hash(tuple(sorted(self.items())))
+        return hash(frozenset(self.items()))
 
 
 class NoSubclassMeta(type):
@@ -464,7 +471,7 @@ class ParamDescriber(metaclass=NoSubclassMeta):
         return self._identifier
 
     @identifier.setter
-    def identifier(self, value: ArrayLike):
+    def identifier(self, value: Any):
         """
         Prevent modification of the identifier.
 
@@ -586,6 +593,22 @@ class _JointGenericAlias(_GenericAlias, _root=True):
         when unpickling.
         """
         return (_JointGenericAlias, (self.__origin__, self.__args__))
+
+    def __call__(self, *args, **kwargs):
+        """
+        Reject instantiation.
+
+        ``JointTypes[A, B]`` is a type-checking alias (use it with
+        ``isinstance``/``issubclass`` or as an annotation), not a constructor.
+        Its ``__origin__`` is ``object``, so the inherited ``_GenericAlias``
+        behaviour would otherwise silently build a bare ``object()`` instead of
+        an instance satisfying the joint type.
+        """
+        raise TypeError(
+            f"Cannot instantiate {self!r}: it is an intersection type used for "
+            f"isinstance/issubclass checks and annotations, not a constructor. "
+            f"Instantiate one of its component classes directly."
+        )
 
 
 class _OneOfGenericAlias(_GenericAlias, _root=True):

--- a/brainstate/mixin_test.py
+++ b/brainstate/mixin_test.py
@@ -1102,5 +1102,50 @@ class TestMixinCoverage(unittest.TestCase):
             _ = brainstate.mixin.ThisNameDoesNotExist
 
 
+class TestModeHashable(unittest.TestCase):
+    """Regression tests for Mode hashability (L6).
+
+    Mode defines __eq__; without an explicit __hash__, Python sets
+    Mode.__hash__ = None, making every Mode/Training/Batching/JointMode instance
+    unhashable (unusable as a dict key, set member, or JAX static_argname).
+    """
+
+    def test_mode_is_hashable(self):
+        """hash() works on Mode and its subclasses."""
+        self.assertIsInstance(hash(brainstate.mixin.Mode()), int)
+        self.assertIsInstance(hash(brainstate.mixin.Training()), int)
+        self.assertIsInstance(hash(brainstate.mixin.Batching()), int)
+
+    def test_equal_modes_hash_equal(self):
+        """Modes that compare equal hash equal (consistent with type-based __eq__)."""
+        t1 = brainstate.mixin.Training()
+        t2 = brainstate.mixin.Training()
+        self.assertEqual(t1, t2)
+        self.assertEqual(hash(t1), hash(t2))
+
+    def test_different_modes_not_equal(self):
+        """Different mode types are not equal."""
+        self.assertNotEqual(brainstate.mixin.Training(), brainstate.mixin.Batching())
+
+    def test_mode_usable_as_dict_key(self):
+        """A Mode can be used as a dict key, with equal instances colliding."""
+        d = {brainstate.mixin.Training(): "train", brainstate.mixin.Batching(): "batch"}
+        self.assertEqual(d[brainstate.mixin.Training()], "train")
+        self.assertEqual(d[brainstate.mixin.Batching()], "batch")
+        self.assertEqual(len(d), 2)
+
+    def test_mode_usable_as_set_member(self):
+        """A Mode can be a set member; equal instances de-duplicate."""
+        s = {brainstate.mixin.Training(), brainstate.mixin.Training(), brainstate.mixin.Batching()}
+        self.assertEqual(len(s), 2)
+        self.assertIn(brainstate.mixin.Training(), s)
+        self.assertIn(brainstate.mixin.Batching(), s)
+
+    def test_joint_mode_is_hashable(self):
+        """JointMode (a Mode subclass) is also hashable."""
+        joint = brainstate.mixin.JointMode(brainstate.mixin.Training())
+        self.assertIsInstance(hash(joint), int)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/mixin_test.py
+++ b/brainstate/mixin_test.py
@@ -164,6 +164,13 @@ class TestParamDesc(unittest.TestCase):
         with self.assertRaises(AttributeError):
             desc.identifier = "new"
 
+    def test_a19_identifier_setter_annotation_not_misleading(self):
+        """Appendix item 19: the always-raising identifier setter should not
+        advertise a misleading `value: ArrayLike` parameter type."""
+        from typing import Any
+        prop = brainstate.mixin.ParamDescriber.__dict__['identifier']
+        self.assertEqual(prop.fset.__annotations__.get('value'), Any)
+
     def test_param_describer_class_getitem(self):
         """Test ParamDescriber[Class] notation."""
 
@@ -212,6 +219,24 @@ class TestHashableDict(unittest.TestCase):
         d = brainstate.mixin.HashableDict({"x": 10})
         cache = {d: "result"}
         self.assertEqual(cache[d], "result")
+
+    def test_a18_mixed_unorderable_keys_hashable(self):
+        """Appendix item 18: mixed unorderable key types must still hash.
+
+        sorted() over {1: ..., 'x': ...} raised TypeError comparing int and str.
+        """
+        d = brainstate.mixin.HashableDict({1: "a", "x": "b", 2.0: "c"})
+        h = hash(d)  # must not raise
+        self.assertIsInstance(h, int)
+        # usable as a dict key too
+        cache = {d: "ok"}
+        self.assertEqual(cache[d], "ok")
+
+    def test_a18_mixed_keys_order_independent(self):
+        """Equal dicts with mixed keys hash equally regardless of order."""
+        d1 = brainstate.mixin.HashableDict({1: "a", "x": "b"})
+        d2 = brainstate.mixin.HashableDict({"x": "b", 1: "a"})
+        self.assertEqual(hash(d1), hash(d2))
 
 
 class TestJointTypes(unittest.TestCase):
@@ -291,6 +316,23 @@ class TestJointTypes(unittest.TestCase):
         # Should handle duplicates gracefully
         JointA = brainstate.mixin.JointTypes(A, A, A)
         self.assertEqual(JointA, A)
+
+    def test_a20_calling_joint_alias_raises(self):
+        """Appendix item 20: calling a JointTypes alias must raise, not silently
+        build a bare object()."""
+
+        class A:
+            pass
+
+        class B:
+            pass
+
+        Combined = brainstate.mixin.JointTypes(A, B)
+        with self.assertRaises(TypeError):
+            Combined()
+        # subscript form too
+        with self.assertRaises(TypeError):
+            brainstate.mixin.JointTypes[A, B]()
 
 
 class TestOneOfTypes(unittest.TestCase):

--- a/brainstate/nn/_activations.py
+++ b/brainstate/nn/_activations.py
@@ -89,7 +89,10 @@ def tanh(x: ArrayLike) -> Union[jax.Array, u.Quantity]:
     return u.math.tanh(x)
 
 
-def softmin(x: ArrayLike, axis: int = -1) -> Union[jax.Array, u.Quantity]:
+def softmin(
+    x: ArrayLike,
+    axis: int | tuple[int, ...] | None = -1
+) -> Union[jax.Array, u.Quantity]:
     r"""
     Softmin activation function.
 
@@ -103,9 +106,10 @@ def softmin(x: ArrayLike, axis: int = -1) -> Union[jax.Array, u.Quantity]:
     ----------
     x : ArrayLike
         Input array of any shape.
-    axis : int, optional
-        The axis along which Softmin will be computed. Every slice along this
-        dimension will sum to 1. Default is -1.
+    axis : int or tuple of int, optional
+        The axis or axes along which Softmin will be computed. Every slice along
+        these dimensions will sum to 1. Either an integer or a tuple of integers.
+        Default is -1.
 
     Returns
     -------
@@ -209,7 +213,9 @@ def soft_shrink(x: ArrayLike, lambd: float = 0.5) -> Union[jax.Array, u.Quantity
         u.math.where(
             x < -lambd,
             x + lambd,
-            u.Quantity(0., unit=u.get_unit(x))
+            # Use a zero that mirrors the input's unit *and* dtype so that an
+            # integer input is not silently promoted to float by a ``0.`` literal.
+            u.math.zeros_like(x)
         )
     )
 
@@ -319,7 +325,9 @@ def hard_shrink(x: ArrayLike, lambd: float = 0.5) -> Union[jax.Array, u.Quantity
         u.math.where(
             x < -lambd,
             x,
-            u.Quantity(0., unit=u.get_unit(x))
+            # Use a zero that mirrors the input's unit *and* dtype so that an
+            # integer input is not silently promoted to float by a ``0.`` literal.
+            u.math.zeros_like(x)
         )
     )
 

--- a/brainstate/nn/_activations.py
+++ b/brainstate/nn/_activations.py
@@ -112,8 +112,7 @@ def softmin(x: ArrayLike, axis: int = -1) -> Union[jax.Array, u.Quantity]:
     jax.Array or Quantity
         Output array with the same shape as the input.
     """
-    unnormalized = u.math.exp(-x)
-    return unnormalized / unnormalized.sum(axis, keepdims=True)
+    return jax.nn.softmax(-x, axis=axis)
 
 
 def tanh_shrink(x: ArrayLike) -> Union[jax.Array, u.Quantity]:

--- a/brainstate/nn/_activations_test.py
+++ b/brainstate/nn/_activations_test.py
@@ -370,6 +370,25 @@ class TestActivationAuditRegressions(parameterized.TestCase):
             # Non-negative entries pass through unchanged.
             np.testing.assert_allclose(out[2:], np.array([0., 1., 2.]), rtol=1e-6)
 
+    def test_softmin_no_overflow_large_magnitude(self):
+        """C1: softmin must not overflow to NaN for moderate/large-magnitude inputs."""
+        # Pre-fix: exp(-x) overflows to +inf, division yields NaN.
+        out = brainstate.nn.softmin(jnp.array([-1000., -1001., -1002.]))
+        self.assertTrue(jnp.all(jnp.isfinite(out)))
+        np.testing.assert_allclose(float(out.sum()), 1.0, rtol=1e-6)
+        # float32 overflows for inputs around -90 as well.
+        out2 = brainstate.nn.softmin(jnp.array([-90., -89., -88.]))
+        self.assertTrue(jnp.all(jnp.isfinite(out2)))
+
+    def test_softmin_matches_softmax_of_negation(self):
+        """C1: softmin(x) must equal softmax(-x) for ordinary inputs."""
+        x = jnp.array([0., 1., 2.])
+        np.testing.assert_allclose(
+            np.asarray(brainstate.nn.softmin(x)),
+            np.asarray(brainstate.nn.softmax(-x)),
+            rtol=1e-6,
+        )
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/nn/_activations_test.py
+++ b/brainstate/nn/_activations_test.py
@@ -18,6 +18,7 @@
 import itertools
 from functools import partial
 
+import brainunit as u
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -388,6 +389,44 @@ class TestActivationAuditRegressions(parameterized.TestCase):
             np.asarray(brainstate.nn.softmax(-x)),
             rtol=1e-6,
         )
+
+    def test_softmin_accepts_tuple_axis(self):
+        """Item 1: softmin accepts a tuple ``axis`` (matching ``softmax``)."""
+        x = brainstate.random.randn(2, 3, 4)
+        out = brainstate.nn.softmin(x, axis=(1, 2))
+        self.assertEqual(out.shape, x.shape)
+        # Each slice over the reduced axes sums to 1.
+        np.testing.assert_allclose(np.asarray(out.sum(axis=(1, 2))), np.ones(2), rtol=1e-5)
+        # Matches softmax(-x) over the same axes.
+        np.testing.assert_allclose(
+            np.asarray(out),
+            np.asarray(brainstate.nn.softmax(-x, axis=(1, 2))),
+            rtol=1e-6,
+        )
+
+    @parameterized.parameters(brainstate.nn.soft_shrink, brainstate.nn.hard_shrink)
+    def test_shrink_preserves_integer_dtype(self, fn):
+        """Item 2: integer inputs are not force-promoted to float by a ``0.`` literal.
+
+        With an integer ``lambd`` the result of the shrink stays integer; pre-fix the
+        ``u.Quantity(0., ...)`` zero-branch unconditionally promoted to float32.
+        """
+        x = jnp.array([-2, -1, 0, 1, 2], dtype=jnp.int32)
+        out = fn(x, lambd=1)
+        self.assertEqual(out.dtype, jnp.int32)
+
+    def test_hard_shrink_integer_values_correct(self):
+        """Item 2: hard_shrink on integers returns the exact integer selection."""
+        x = jnp.array([-3, -1, 0, 1, 3], dtype=jnp.int32)
+        out = np.asarray(brainstate.nn.hard_shrink(x, lambd=1))
+        # |x| <= 1 -> 0, else x unchanged.
+        np.testing.assert_array_equal(out, np.array([-3, 0, 0, 0, 3], dtype=np.int32))
+
+    def test_shrink_float_dtype_unchanged(self):
+        """Item 2: float inputs still return float (no regression)."""
+        x = jnp.array([-2., -0.3, 0.0, 0.4, 2.], dtype=jnp.float32)
+        self.assertEqual(brainstate.nn.soft_shrink(x).dtype, jnp.float32)
+        self.assertEqual(brainstate.nn.hard_shrink(x).dtype, jnp.float32)
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_conv.py
+++ b/brainstate/nn/_conv.py
@@ -291,7 +291,15 @@ class _BaseConv(Module):
             padding = tuple((padding, padding) for _ in range(self.num_spatial_dims))
         elif isinstance(padding, (tuple, list)):
             if isinstance(padding[0], int):
-                padding = (padding,) * self.num_spatial_dims
+                if self.num_spatial_dims == 1 and len(padding) == 2:
+                    padding = (tuple(padding),)
+                elif len(padding) == self.num_spatial_dims:
+                    padding = tuple((p, p) for p in padding)
+                else:
+                    raise ValueError(
+                        f"Integer padding tuple {padding} must have length "
+                        f"{self.num_spatial_dims} (one value per spatial dim)."
+                    )
             elif isinstance(padding[0], (tuple, list)):
                 if len(padding) == 1:
                     padding = tuple(padding) * self.num_spatial_dims
@@ -592,7 +600,7 @@ class Conv2d(_Conv):
         - 'SAME': output spatial size equals input size when stride=1
         - 'VALID': no padding, output size reduced by kernel size
         - int: same symmetric padding for all dimensions
-        - (pad_h, pad_w): different padding for each dimension
+        - (pad_h, pad_w[, pad_d]): symmetric padding per spatial dimension
         - [(pad_h_before, pad_h_after), (pad_w_before, pad_w_after)]: explicit padding
 
         Default: 'SAME'.
@@ -744,7 +752,7 @@ class Conv3d(_Conv):
         - 'SAME': output spatial size equals input size when stride=1
         - 'VALID': no padding, output size reduced by kernel size
         - int: same symmetric padding for all dimensions
-        - (pad_h, pad_w, pad_d): different padding for each dimension
+        - (pad_h, pad_w[, pad_d]): symmetric padding per spatial dimension
         - [(pad_h_before, pad_h_after), (pad_w_before, pad_w_after), (pad_d_before, pad_d_after)]: explicit padding
 
         Default: 'SAME'.
@@ -1143,7 +1151,7 @@ class ScaledWSConv2d(_ScaledWSConv):
         - 'SAME': output spatial size equals input size when stride=1
         - 'VALID': no padding, output size reduced by kernel size
         - int: same symmetric padding for all dimensions
-        - (pad_h, pad_w): different padding for each dimension
+        - (pad_h, pad_w[, pad_d]): symmetric padding per spatial dimension
         - [(pad_h_before, pad_h_after), (pad_w_before, pad_w_after)]: explicit padding
 
         Default: 'SAME'.
@@ -1322,7 +1330,7 @@ class ScaledWSConv3d(_ScaledWSConv):
         - 'SAME': output spatial size equals input size when stride=1
         - 'VALID': no padding, output size reduced by kernel size
         - int: same symmetric padding for all dimensions
-        - (pad_h, pad_w, pad_d): different padding for each dimension
+        - (pad_h, pad_w[, pad_d]): symmetric padding per spatial dimension
         - [(pad_h_before, pad_h_after), (pad_w_before, pad_w_after), (pad_d_before, pad_d_after)]: explicit padding
 
         Default: 'SAME'.
@@ -1479,7 +1487,6 @@ class _ConvTranspose(_BaseConv):
         kernel_size: Union[int, Tuple[int, ...]],
         stride: Union[int, Tuple[int, ...]] = 1,
         padding: Union[str, int, Tuple[int, int], Sequence[Tuple[int, int]]] = 'SAME',
-        lhs_dilation: Union[int, Tuple[int, ...]] = 1,
         rhs_dilation: Union[int, Tuple[int, ...]] = 1,
         groups: int = 1,
         w_init: Union[Callable, ArrayLike] = init.XavierNormal(),
@@ -1507,7 +1514,6 @@ class _ConvTranspose(_BaseConv):
         self.out_channels = out_channels
         self.stride = replicate(stride, self.num_spatial_dims, 'stride')
         self.kernel_size = replicate(kernel_size, self.num_spatial_dims, 'kernel_size')
-        self.lhs_dilation = replicate(lhs_dilation, self.num_spatial_dims, 'lhs_dilation')
         self.rhs_dilation = replicate(rhs_dilation, self.num_spatial_dims, 'rhs_dilation')
         self.groups = groups
         self.dimension_numbers = to_dimension_numbers(
@@ -1534,7 +1540,15 @@ class _ConvTranspose(_BaseConv):
         elif isinstance(padding, (tuple, list)):
             self.padding_mode = 'explicit'
             if isinstance(padding[0], int):
-                padding = (padding,) * self.num_spatial_dims
+                if self.num_spatial_dims == 1 and len(padding) == 2:
+                    padding = (tuple(padding),)
+                elif len(padding) == self.num_spatial_dims:
+                    padding = tuple((p, p) for p in padding)
+                else:
+                    raise ValueError(
+                        f"Integer padding tuple {padding} must have length "
+                        f"{self.num_spatial_dims} (one value per spatial dim)."
+                    )
             elif isinstance(padding[0], (tuple, list)):
                 if len(padding) == 1:
                     padding = tuple(padding) * self.num_spatial_dims
@@ -1662,9 +1676,6 @@ class ConvTranspose1d(_ConvTranspose):
         - (pad_before, pad_after): explicit padding for the sequence dimension
 
         Default: 'SAME'.
-    lhs_dilation : int or tuple of int, optional
-        The dilation factor for the input. For transposed convolution, this is typically
-        set equal to stride internally. Default: 1.
     rhs_dilation : int or tuple of int, optional
         The dilation factor for the kernel. Increases the receptive field without increasing
         parameters by inserting zeros between kernel elements. Default: 1.
@@ -1761,7 +1772,11 @@ class ConvTranspose1d(_ConvTranspose):
 
     - PyTorch uses channels-first by default; BrainState uses channels-last
     - Set `channel_first=True` for PyTorch-compatible format
-    - PyTorch's `output_padding` is handled through padding parameter
+    - Padding semantics differ from PyTorch. BrainState follows
+      ``jax.lax.conv_transpose``: explicit padding is *added* to the dilated
+      signal, so larger padding yields a *larger* output. This is the opposite
+      of PyTorch, where padding *subtracts* ``2 * padding`` from the output.
+      There is no ``output_padding`` parameter.
     """
     __module__ = 'brainstate.nn'
     num_spatial_dims: int = 1
@@ -1804,13 +1819,10 @@ class ConvTranspose2d(_ConvTranspose):
         - 'SAME': output size approximately equals input_size * stride
         - 'VALID': no padding, maximum output size
         - int: same symmetric padding for all dimensions
-        - (pad_h, pad_w): different padding for each dimension
+        - (pad_h, pad_w[, pad_d]): symmetric padding per spatial dimension
         - [(pad_h_before, pad_h_after), (pad_w_before, pad_w_after)]: explicit padding
 
         Default: 'SAME'.
-    lhs_dilation : int or tuple of int, optional
-        The dilation factor for the input. For transposed convolution, this is typically
-        set equal to stride internally. Default: 1.
     rhs_dilation : int or tuple of int, optional
         The dilation factor for the kernel. Increases the receptive field without increasing
         parameters by inserting zeros between kernel elements. Default: 1.
@@ -1921,7 +1933,11 @@ class ConvTranspose2d(_ConvTranspose):
     - PyTorch uses channels-first by default; BrainState uses channels-last
     - Set `channel_first=True` for PyTorch-compatible format
     - Kernel shape convention: PyTorch stores (C_in, C_out, H, W), BrainState uses (H, W, C_out, C_in)
-    - PyTorch's `output_padding` parameter controls output size; use padding parameter here
+    - Padding semantics differ from PyTorch. BrainState follows
+      ``jax.lax.conv_transpose``: explicit padding is *added* to the dilated
+      signal, so larger padding yields a *larger* output. This is the opposite
+      of PyTorch, where padding *subtracts* ``2 * padding`` from the output.
+      There is no ``output_padding`` parameter.
 
     **Tips:**
 
@@ -1969,13 +1985,10 @@ class ConvTranspose3d(_ConvTranspose):
         - 'SAME': output size approximately equals input_size * stride
         - 'VALID': no padding, maximum output size
         - int: same symmetric padding for all dimensions
-        - (pad_h, pad_w, pad_d): different padding for each dimension
+        - (pad_h, pad_w[, pad_d]): symmetric padding per spatial dimension
         - [(pad_h_before, pad_h_after), (pad_w_before, pad_w_after), (pad_d_before, pad_d_after)]: explicit
 
         Default: 'SAME'.
-    lhs_dilation : int or tuple of int, optional
-        The dilation factor for the input. For transposed convolution, this is typically
-        set equal to stride internally. Default: 1.
     rhs_dilation : int or tuple of int, optional
         The dilation factor for the kernel. Increases the receptive field without increasing
         parameters. Default: 1.
@@ -2089,7 +2102,11 @@ class ConvTranspose3d(_ConvTranspose):
     - PyTorch uses channels-first by default; BrainState uses channels-last
     - Set `channel_first=True` for PyTorch-compatible format
     - Kernel shape convention differs between frameworks
-    - PyTorch's `output_padding` parameter is handled through padding here
+    - Padding semantics differ from PyTorch. BrainState follows
+      ``jax.lax.conv_transpose``: explicit padding is *added* to the dilated
+      signal, so larger padding yields a *larger* output. This is the opposite
+      of PyTorch, where padding *subtracts* ``2 * padding`` from the output.
+      There is no ``output_padding`` parameter.
 
     **Tips:**
 

--- a/brainstate/nn/_conv.py
+++ b/brainstate/nn/_conv.py
@@ -261,7 +261,12 @@ class _BaseConv(Module):
         super().__init__(name=name)
 
         # general parameters
-        assert self.num_spatial_dims + 1 == len(in_size)
+        if self.num_spatial_dims + 1 != len(in_size):
+            raise ValueError(
+                f"in_size must have {self.num_spatial_dims + 1} entries "
+                f"({self.num_spatial_dims} spatial dimensions plus the channel "
+                f"dimension), but got {tuple(in_size)} with length {len(in_size)}."
+            )
         self.in_size = tuple(in_size)
         self.channel_first = channel_first
         self.channels_last = not channel_first
@@ -285,11 +290,52 @@ class _BaseConv(Module):
         )
 
         # the padding parameter
+        padding, _ = self._parse_padding(padding)
+        self.padding = padding
+
+        # the number of in-/out-channels
+        if self.out_channels % self.groups != 0:
+            raise ValueError(
+                f'"out_channels" ({self.out_channels}) should be divisible by '
+                f'groups ({self.groups})'
+            )
+        if self.in_channels % self.groups != 0:
+            raise ValueError(
+                f'"in_channels" ({self.in_channels}) should be divisible by '
+                f'groups ({self.groups})'
+            )
+
+        # kernel shape and w_mask
+        kernel_shape = tuple(self.kernel_size) + (self.in_channels // self.groups, self.out_channels)
+        self.kernel_shape = kernel_shape
+        self.w_mask = init.param(w_mask, kernel_shape, allow_none=True)
+
+    def _parse_padding(self, padding):
+        """Normalize the ``padding`` argument into the representation used by
+        ``jax.lax.conv_general_dilated``.
+
+        Returns a tuple ``(padding, padding_mode)`` where ``padding`` is either the
+        validated mode string (``'SAME'``/``'VALID'``) or a tuple of ``(low, high)``
+        pairs (one per spatial dimension), and ``padding_mode`` is ``'SAME'``,
+        ``'VALID'`` or ``'explicit'``. Raises ``ValueError`` (never a bare
+        ``AssertionError``/``IndexError``) for malformed input.
+        """
         if isinstance(padding, str):
-            assert padding in ['SAME', 'VALID']
+            if padding not in ('SAME', 'VALID'):
+                raise ValueError(
+                    f"String padding must be 'SAME' or 'VALID', got {padding!r}."
+                )
+            return padding, padding
         elif isinstance(padding, int):
             padding = tuple((padding, padding) for _ in range(self.num_spatial_dims))
+            return padding, 'explicit'
         elif isinstance(padding, (tuple, list)):
+            if len(padding) == 0:
+                raise ValueError(
+                    "Padding sequence must not be empty; expected an int, a "
+                    "Tuple[int, int], or a sequence of Tuple[int, int] with length "
+                    f"1 or {self.num_spatial_dims}."
+                )
             if isinstance(padding[0], int):
                 if self.num_spatial_dims == 1 and len(padding) == 2:
                     padding = (tuple(padding),)
@@ -300,6 +346,7 @@ class _BaseConv(Module):
                         f"Integer padding tuple {padding} must have length "
                         f"{self.num_spatial_dims} (one value per spatial dim)."
                     )
+                return padding, 'explicit'
             elif isinstance(padding[0], (tuple, list)):
                 if len(padding) == 1:
                     padding = tuple(padding) * self.num_spatial_dims
@@ -311,18 +358,17 @@ class _BaseConv(Module):
                             f"or sequence of Tuple[int, int] with length {self.num_spatial_dims}."
                         )
                     padding = tuple(padding)
+                return padding, 'explicit'
+            else:
+                raise ValueError(
+                    f"Padding {padding} must be a Tuple[int, int], or a sequence "
+                    f"of Tuple[int, int]; got element of type {type(padding[0]).__name__}."
+                )
         else:
-            raise ValueError
-        self.padding = padding
-
-        # the number of in-/out-channels
-        assert self.out_channels % self.groups == 0, '"out_channels" should be divisible by groups'
-        assert self.in_channels % self.groups == 0, '"in_channels" should be divisible by groups'
-
-        # kernel shape and w_mask
-        kernel_shape = tuple(self.kernel_size) + (self.in_channels // self.groups, self.out_channels)
-        self.kernel_shape = kernel_shape
-        self.w_mask = init.param(w_mask, kernel_shape, allow_none=True)
+            raise ValueError(
+                "Padding must be a string ('SAME'/'VALID'), an int, a "
+                f"Tuple[int, int], or a sequence of Tuple[int, int]; got {type(padding).__name__}."
+            )
 
     def _check_input_dim(self, x):
         if x.ndim == self.num_spatial_dims + 2:
@@ -1500,7 +1546,12 @@ class _ConvTranspose(_BaseConv):
         Module.__init__(self, name=name)
 
         # general parameters
-        assert self.num_spatial_dims + 1 == len(in_size)
+        if self.num_spatial_dims + 1 != len(in_size):
+            raise ValueError(
+                f"in_size must have {self.num_spatial_dims + 1} entries "
+                f"({self.num_spatial_dims} spatial dimensions plus the channel "
+                f"dimension), but got {tuple(in_size)} with length {len(in_size)}."
+            )
         self.in_size = tuple(in_size)
         self.channel_first = channel_first
         self.channels_last = not channel_first
@@ -1528,45 +1579,22 @@ class _ConvTranspose(_BaseConv):
         # correct transposed-conv output size differs from a forward conv and is
         # computed (per dimension) in ``_conv_op`` via ``_conv_transpose_padding`` so
         # that 'SAME'/'VALID' match ``jax.lax.conv_transpose`` at *all* strides
-        # (including stride == 1).
-        if isinstance(padding, str):
-            assert padding in ['SAME', 'VALID']
-            self.padding_mode = padding
-            # Keep the mode string; the explicit per-dimension padding is resolved
-            # lazily in ``_conv_op`` (it depends on the effective, dilated kernel size).
-        elif isinstance(padding, int):
-            self.padding_mode = 'explicit'
-            padding = tuple((padding, padding) for _ in range(self.num_spatial_dims))
-        elif isinstance(padding, (tuple, list)):
-            self.padding_mode = 'explicit'
-            if isinstance(padding[0], int):
-                if self.num_spatial_dims == 1 and len(padding) == 2:
-                    padding = (tuple(padding),)
-                elif len(padding) == self.num_spatial_dims:
-                    padding = tuple((p, p) for p in padding)
-                else:
-                    raise ValueError(
-                        f"Integer padding tuple {padding} must have length "
-                        f"{self.num_spatial_dims} (one value per spatial dim)."
-                    )
-            elif isinstance(padding[0], (tuple, list)):
-                if len(padding) == 1:
-                    padding = tuple(padding) * self.num_spatial_dims
-                else:
-                    if len(padding) != self.num_spatial_dims:
-                        raise ValueError(
-                            f"Padding {padding} must be a Tuple[int, int], "
-                            f"or sequence of Tuple[int, int] with length 1, "
-                            f"or sequence of Tuple[int, int] with length {self.num_spatial_dims}."
-                        )
-                    padding = tuple(padding)
-        else:
-            raise ValueError
+        # (including stride == 1). For a mode string we keep the string and resolve
+        # the explicit per-dimension padding lazily in ``_conv_op``.
+        padding, self.padding_mode = self._parse_padding(padding)
         self.padding = padding
 
         # the number of in-/out-channels
-        assert self.out_channels % self.groups == 0, '"out_channels" should be divisible by groups'
-        assert self.in_channels % self.groups == 0, '"in_channels" should be divisible by groups'
+        if self.out_channels % self.groups != 0:
+            raise ValueError(
+                f'"out_channels" ({self.out_channels}) should be divisible by '
+                f'groups ({self.groups})'
+            )
+        if self.in_channels % self.groups != 0:
+            raise ValueError(
+                f'"in_channels" ({self.in_channels}) should be divisible by '
+                f'groups ({self.groups})'
+            )
 
         # kernel shape for transpose conv
         # When transpose=True in dimension_numbers, kernel is (spatial..., out_channels, in_channels // groups)

--- a/brainstate/nn/_conv_test.py
+++ b/brainstate/nn/_conv_test.py
@@ -879,9 +879,30 @@ class TestConvPadding(unittest.TestCase):
         self.assertEqual(conv.padding, ((2, 2), (2, 2)))
 
     def test_padding_tuple_of_int(self):
-        """A tuple of ints is treated as a (low, high) pair applied to every dimension."""
-        conv = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=(1, 2))
-        self.assertEqual(conv.padding, ((1, 2), (1, 2)))
+        """A flat int tuple gives one symmetric pad per spatial dim (M11).
+
+        For Conv2d a length-2 tuple ``(1, 2)`` is one value per spatial axis:
+        axis 0 -> (1, 1), axis 1 -> (2, 2). This is NOT a single (low, high) pair
+        broadcast to every axis (the old, buggy behavior). For Conv1d, a length-2
+        tuple is unambiguously a single (low, high) pair for the one spatial axis.
+        """
+        # Conv2d: one symmetric pad per spatial dim.
+        conv2d = brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=(1, 2))
+        self.assertEqual(conv2d.padding, ((1, 1), (2, 2)))
+
+        # Conv3d: one symmetric pad per spatial dim.
+        conv3d = brainstate.nn.Conv3d(in_size=(16, 16, 16, 3), out_channels=8, kernel_size=3, padding=(1, 2, 3))
+        self.assertEqual(conv3d.padding, ((1, 1), (2, 2), (3, 3)))
+
+        # Conv1d: length-2 tuple is a single (low, high) pair for the one axis.
+        conv1d = brainstate.nn.Conv1d(in_size=(16, 3), out_channels=8, kernel_size=3, padding=(1, 2))
+        self.assertEqual(conv1d.padding, ((1, 2),))
+
+    def test_padding_int_tuple_wrong_length_raises(self):
+        """A flat int padding tuple of the wrong length raises ValueError (M11)."""
+        # Conv2d expects length 2; length 3 is invalid.
+        with self.assertRaises(ValueError):
+            brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=(1, 2, 3))
 
     def test_padding_sequence_of_tuples(self):
         """A full sequence of (low, high) tuples is preserved per dimension."""
@@ -1043,9 +1064,19 @@ class TestConvTransposePadding(unittest.TestCase):
         self.assertEqual(conv.padding_mode, 'explicit')
 
     def test_padding_tuple_of_int(self):
-        """A tuple of ints is applied per dimension."""
+        """A flat int tuple gives one symmetric pad per spatial dim (M11).
+
+        For ConvTranspose2d a length-2 tuple ``(1, 2)`` is one value per spatial
+        axis: axis 0 -> (1, 1), axis 1 -> (2, 2), not a single (low, high) pair
+        broadcast to every axis.
+        """
         conv = brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=(1, 2))
-        self.assertEqual(conv.padding, ((1, 2), (1, 2)))
+        self.assertEqual(conv.padding, ((1, 1), (2, 2)))
+
+    def test_padding_int_tuple_wrong_length_raises(self):
+        """A flat int padding tuple of the wrong length raises ValueError (M11)."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConvTranspose2d(in_size=(8, 8, 16), out_channels=8, kernel_size=3, padding=(1, 2, 3))
 
     def test_padding_sequence_of_tuples(self):
         """A full sequence of (low, high) tuples is preserved."""

--- a/brainstate/nn/_conv_test.py
+++ b/brainstate/nn/_conv_test.py
@@ -305,6 +305,16 @@ class TestErrorHandling(unittest.TestCase):
             # out_channels not divisible by groups
             conv = brainstate.nn.Conv2d(in_size=(32, 32, 16), out_channels=30, kernel_size=3, groups=4)
 
+    def test_in_channels_not_divisible_by_groups_raises(self):
+        """in_channels not divisible by groups raises ValueError naming in_channels.
+
+        out_channels IS divisible (8 % 4 == 0) so the out_channels guard passes;
+        the failure must come from the in_channels divisibility check (6 % 4 != 0).
+        """
+        with self.assertRaises(ValueError) as ctx:
+            brainstate.nn.Conv2d(in_size=(8, 8, 6), out_channels=8, kernel_size=3, groups=4)
+        self.assertIn('in_channels', str(ctx.exception))
+
     def test_dimension_mismatch(self):
         """Test dimension mismatch detection."""
         conv = brainstate.nn.Conv2d(in_size=(32, 32, 3), out_channels=16, kernel_size=3)
@@ -694,6 +704,16 @@ class TestErrorHandlingConvTranspose(unittest.TestCase):
                 groups=4
             )
 
+    def test_in_channels_not_divisible_by_groups_raises(self):
+        """in_channels not divisible by groups raises ValueError naming in_channels.
+
+        out_channels IS divisible (8 % 4 == 0) so the out_channels guard passes;
+        the failure must come from the in_channels divisibility check (6 % 4 != 0).
+        """
+        with self.assertRaises(ValueError) as ctx:
+            brainstate.nn.ConvTranspose2d(in_size=(8, 8, 6), out_channels=8, kernel_size=3, groups=4)
+        self.assertIn('in_channels', str(ctx.exception))
+
     def test_dimension_mismatch(self):
         """Test that wrong input dimensions raise error."""
         conv_t = brainstate.nn.ConvTranspose2d(
@@ -931,6 +951,20 @@ class TestConvPadding(unittest.TestCase):
         """A padding of an unsupported type raises ValueError."""
         with self.assertRaises(ValueError):
             brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=1.5)
+
+    def test_padding_sequence_with_bad_element_type_raises(self):
+        """A padding *sequence* whose elements are neither int nor tuple raises ValueError.
+
+        ``padding`` enters the sequence branch (it is a tuple), but ``padding[0]``
+        is a float, so it is neither a flat-int spec nor a sequence-of-pairs spec.
+        This exercises the dedicated element-type error (distinct from the
+        top-level unsupported-type error) and reports the offending element type.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            brainstate.nn.Conv2d(in_size=(16, 16, 3), out_channels=8, kernel_size=3, padding=(1.5, 2.5))
+        msg = str(ctx.exception)
+        self.assertIn('Tuple[int, int]', msg)
+        self.assertIn('float', msg)
 
 
 class TestConvWeightMask(unittest.TestCase):

--- a/brainstate/nn/_conv_test.py
+++ b/brainstate/nn/_conv_test.py
@@ -296,8 +296,12 @@ class TestErrorHandling(unittest.TestCase):
             conv(x_wrong)
 
     def test_invalid_groups(self):
-        """Test that invalid group configurations raise errors."""
-        with self.assertRaises(AssertionError):
+        """Test that invalid group configurations raise errors.
+
+        Validation of user-supplied constructor arguments must raise ``ValueError``
+        (which survives ``python -O``), not ``AssertionError``.
+        """
+        with self.assertRaises(ValueError):
             # out_channels not divisible by groups
             conv = brainstate.nn.Conv2d(in_size=(32, 32, 16), out_channels=30, kernel_size=3, groups=4)
 
@@ -677,8 +681,12 @@ class TestErrorHandlingConvTranspose(unittest.TestCase):
     """Test error handling for transposed convolutions."""
 
     def test_invalid_groups(self):
-        """Test that invalid groups raises assertion error."""
-        with self.assertRaises(AssertionError):
+        """Test that invalid groups raises a ValueError.
+
+        Validation of user-supplied constructor arguments must raise ``ValueError``
+        (which survives ``python -O``), not ``AssertionError``.
+        """
+        with self.assertRaises(ValueError):
             brainstate.nn.ConvTranspose2d(
                 in_size=(16, 16, 32),
                 out_channels=15,  # Not divisible by groups
@@ -1309,3 +1317,71 @@ class TestConvTransposeShapeVsJax(unittest.TestCase):
                     w_ref = jnp.ones((k, 3, 2))
                     y_ref = self._jax_reference(jnp.ones((1, 7, 2)), w_ref, s, padding)
                     self.assertEqual(conv.out_size, y_ref.shape[1:])
+
+
+class TestConvValidationAuditRegressions(unittest.TestCase):
+    """Regression tests for nn-audit items 3/4/5 (conv input validation).
+
+    Items 3 & 5: runtime input validation used ``assert``, which is stripped under
+    ``python -O``. These must raise ``ValueError`` (a subclass-checked exception that
+    survives ``-O``), never ``AssertionError``.
+
+    Item 4: padding parsing raised a cryptic ``IndexError`` on an empty sequence and a
+    bare ``raise ValueError`` with no message.
+    """
+
+    def test_in_size_wrong_length_raises_valueerror(self):
+        """Item 3: in_size length mismatch raises ValueError, not (stripped) assert."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Conv2d(in_size=(8, 3), out_channels=4, kernel_size=3)  # needs 3 entries
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConvTranspose2d(in_size=(8, 3), out_channels=4, kernel_size=3)
+
+    def test_groups_not_divisible_raises_valueerror(self):
+        """Item 3: non-divisible channels/groups raises ValueError, not assert."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Conv2d(in_size=(8, 8, 4), out_channels=5, kernel_size=3, groups=2)
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConvTranspose2d(in_size=(8, 8, 4), out_channels=5, kernel_size=3, groups=2)
+
+    def test_invalid_string_padding_raises_valueerror(self):
+        """Item 3: an unknown padding-mode string raises ValueError, not assert."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Conv2d(in_size=(8, 8, 3), out_channels=4, kernel_size=3, padding='FULL')
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConvTranspose2d(in_size=(8, 8, 3), out_channels=4, kernel_size=3, padding='FULL')
+
+    def test_empty_padding_sequence_raises_valueerror_not_indexerror(self):
+        """Item 4: an empty padding sequence raises a clear ValueError (was IndexError)."""
+        with self.assertRaises(ValueError):
+            brainstate.nn.Conv2d(in_size=(8, 8, 3), out_channels=4, kernel_size=3, padding=[])
+        with self.assertRaises(ValueError):
+            brainstate.nn.ConvTranspose2d(in_size=(8, 8, 3), out_channels=4, kernel_size=3, padding=[])
+
+    def test_invalid_padding_type_has_message(self):
+        """Item 4: the bare ``raise ValueError`` now carries an explanatory message."""
+        with self.assertRaises(ValueError) as ctx:
+            brainstate.nn.Conv2d(in_size=(8, 8, 3), out_channels=4, kernel_size=3, padding=3.5)
+        self.assertTrue(str(ctx.exception))  # non-empty message
+
+    def test_validation_not_assertion(self):
+        """Items 3/5: the raised exception is ValueError, not AssertionError.
+
+        (``AssertionError`` would be silently removed by ``python -O``.)
+        """
+        for bad in (
+            lambda: brainstate.nn.Conv2d(in_size=(8, 3), out_channels=4, kernel_size=3),
+            lambda: brainstate.nn.Conv2d(in_size=(8, 8, 4), out_channels=5, kernel_size=3, groups=2),
+            lambda: brainstate.nn.Conv2d(in_size=(8, 8, 3), out_channels=4, kernel_size=3, padding='FULL'),
+        ):
+            with self.assertRaises(ValueError):
+                bad()
+            self.assertNotIsInstance(self._capture(bad), AssertionError)
+
+    @staticmethod
+    def _capture(fn):
+        try:
+            fn()
+        except Exception as e:  # noqa: BLE001
+            return e
+        return None

--- a/brainstate/nn/_elementwise.py
+++ b/brainstate/nn/_elementwise.py
@@ -256,7 +256,8 @@ class Hardtanh(ElementWiseBlock):
         super().__init__()
         self.min_val = min_val
         self.max_val = max_val
-        assert self.max_val > self.min_val
+        if self.max_val <= self.min_val:
+            raise ValueError(f"max_val ({self.max_val}) must be greater than min_val ({self.min_val})")
 
     def __call__(self, x: ArrayLike) -> ArrayLike:
         return F.hard_tanh(x, self.min_val, self.max_val)

--- a/brainstate/nn/_elementwise.py
+++ b/brainstate/nn/_elementwise.py
@@ -81,10 +81,20 @@ class Threshold(ElementWiseBlock):
         self.value = value
 
     def __call__(self, x: ArrayLike) -> ArrayLike:
-        dtype = u.math.get_dtype(x)
-        return jnp.where(x > jnp.asarray(self.threshold, dtype=dtype),
-                         x,
-                         jnp.asarray(self.value, dtype=dtype))
+        # ``x`` may be a plain array or a :class:`~brainunit.Quantity` (both are part
+        # of the ``ArrayLike`` contract). Work on the mantissa so the comparison does
+        # not raise a unit-mismatch error, then reattach the unit. ``threshold`` and
+        # ``value`` are interpreted in the same unit as ``x`` (mirroring ``hard_tanh``).
+        x = u.Quantity(x)
+        unit = x.unit
+        mantissa = x.mantissa
+        dtype = mantissa.dtype
+        threshold = u.Quantity(self.threshold).to(unit).mantissa
+        value = u.Quantity(self.value).to(unit).mantissa
+        out = jnp.where(mantissa > jnp.asarray(threshold, dtype=dtype),
+                        mantissa,
+                        jnp.asarray(value, dtype=dtype))
+        return u.maybe_decimal(out * unit)
 
     def __repr__(self):
         return f'{self.__class__.__name__}(threshold={self.threshold}, value={self.value})'
@@ -201,9 +211,6 @@ class RReLU(ElementWiseBlock):
     def __call__(self, x: ArrayLike) -> ArrayLike:
         return F.rrelu(x, self.lower, self.upper)
 
-    def extra_repr(self):
-        return f'{self.__class__.__name__}(lower={self.lower}, upper={self.upper})'
-
 
 class Hardtanh(ElementWiseBlock):
     r"""Applies the HardTanh function element-wise.
@@ -261,9 +268,6 @@ class Hardtanh(ElementWiseBlock):
 
     def __call__(self, x: ArrayLike) -> ArrayLike:
         return F.hard_tanh(x, self.min_val, self.max_val)
-
-    def extra_repr(self) -> str:
-        return f'{self.__class__.__name__}(min_val={self.min_val}, max_val={self.max_val})'
 
 
 class ReLU6(Hardtanh):
@@ -538,9 +542,6 @@ class ELU(ElementWiseBlock):
     def __call__(self, x: ArrayLike) -> ArrayLike:
         return F.elu(x, self.alpha)
 
-    def extra_repr(self) -> str:
-        return f'{self.__class__.__name__}(alpha={self.alpha})'
-
 
 class CELU(ElementWiseBlock):
     r"""Applies the element-wise function.
@@ -585,9 +586,6 @@ class CELU(ElementWiseBlock):
 
     def __call__(self, x: ArrayLike) -> ArrayLike:
         return F.celu(x, self.alpha)
-
-    def extra_repr(self) -> str:
-        return f'{self.__class__.__name__}(alpha={self.alpha})'
 
 
 class SELU(ElementWiseBlock):

--- a/brainstate/nn/_elementwise_test.py
+++ b/brainstate/nn/_elementwise_test.py
@@ -17,6 +17,7 @@ import unittest
 from absl.testing import absltest
 from absl.testing import parameterized
 
+import brainunit as u
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -866,6 +867,40 @@ class TestElementwiseAuditRegressions(parameterized.TestCase):
         x = jnp.array([-2.0, 0.0, 2.0])
         out = np.asarray(layer(x))
         np.testing.assert_allclose(out, np.array([-1.0, 0.0, 1.0]), rtol=1e-6)
+
+    def test_threshold_plain_array_unchanged(self):
+        """Item 6: plain (dimensionless) arrays keep their dtype and values."""
+        layer = nn.Threshold(threshold=0.1, value=0.0)
+        x = jnp.array([0.05, 0.2, 0.5], dtype=jnp.float32)
+        out = layer(x)
+        self.assertEqual(out.dtype, jnp.float32)
+        np.testing.assert_allclose(np.asarray(out), np.array([0.0, 0.2, 0.5]), rtol=1e-6)
+
+    def test_threshold_accepts_quantity(self):
+        """Item 6: Quantity inputs (part of the ArrayLike contract) must not raise.
+
+        Pre-fix this raised ``UnitMismatchError`` because the threshold/value were
+        compared as dimensionless against a unitful input.
+        """
+        layer = nn.Threshold(threshold=0.1 * u.mV, value=0.0 * u.mV)
+        x = jnp.array([0.05, 0.2, 0.5], dtype=jnp.float32) * u.mV
+        out = layer(x)
+        self.assertIsInstance(out, u.Quantity)
+        self.assertEqual(out.unit, u.mV)
+        np.testing.assert_allclose(np.asarray(out.mantissa), np.array([0.0, 0.2, 0.5]), rtol=1e-6)
+
+    @parameterized.parameters(nn.RReLU, nn.Hardtanh, nn.ELU, nn.CELU)
+    def test_extra_repr_removed_repr_still_works(self, cls):
+        """Item 7: the dead ``extra_repr`` methods are gone, but ``repr`` still works.
+
+        The repr machinery is ``__pretty_repr__``-based; ``extra_repr`` was never
+        invoked and only duplicated the class name.
+        """
+        self.assertFalse(hasattr(cls, 'extra_repr'))
+        text = repr(cls())
+        self.assertIn(cls.__name__, text)
+        # The class name must appear exactly once (extra_repr would have doubled it).
+        self.assertEqual(text.count(cls.__name__), 1)
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_elementwise_test.py
+++ b/brainstate/nn/_elementwise_test.py
@@ -850,6 +850,23 @@ class TestElementwiseAuditRegressions(parameterized.TestCase):
         out = m(x)
         self.assertEqual(out.shape, x.shape)
 
+    def test_hardtanh_rejects_inverted_range(self):
+        """L12: an inverted range must raise (explicit raise survives python -O)."""
+        with self.assertRaises(ValueError):
+            nn.Hardtanh(min_val=2.0, max_val=-2.0)
+
+    def test_hardtanh_rejects_equal_range(self):
+        """L12: an empty (equal) range must raise."""
+        with self.assertRaises(ValueError):
+            nn.Hardtanh(min_val=1.0, max_val=1.0)
+
+    def test_hardtanh_accepts_valid_range(self):
+        """L12: a normal range still constructs and runs."""
+        layer = nn.Hardtanh(-1.0, 1.0)
+        x = jnp.array([-2.0, 0.0, 2.0])
+        out = np.asarray(layer(x))
+        np.testing.assert_allclose(out, np.array([-1.0, 0.0, 1.0]), rtol=1e-6)
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/nn/_metrics.py
+++ b/brainstate/nn/_metrics.py
@@ -22,6 +22,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from brainstate._compatible_import import Tracer
 from brainstate._state import LongTermState
 
 __all__ = [
@@ -495,10 +496,9 @@ class AccuracyMetric(AverageMetric):
             raise ValueError(
                 f'Expected logits.ndim==labels.ndim+1, got {logits.ndim} and {labels.ndim}'
             )
-        elif labels.dtype in (jnp.int64, np.int32, np.int64):
-            labels = jnp.astype(labels, jnp.int32)
-        elif labels.dtype != jnp.int32:
-            raise ValueError(f'Expected labels.dtype==jnp.int32, got {labels.dtype}')
+        elif not jnp.issubdtype(labels.dtype, jnp.integer):
+            raise ValueError(f'Expected integer labels.dtype, got {labels.dtype}')
+        labels = jnp.astype(labels, jnp.int32)
 
         super().update(values=(logits.argmax(axis=-1) == labels))
 
@@ -858,14 +858,33 @@ class F1ScoreMetric(Metric):
         jax.Array
             The F1 score value(s). Returns 0 when both precision and recall are 0.
         """
-        precision = self.precision_metric.compute()
-        recall = self.recall_metric.compute()
-        denominator = precision + recall
-        return jnp.where(
-            denominator > 0,
-            2 * precision * recall / denominator,
-            jnp.float32(0.0)
-        )
+        nc = self.precision_metric.num_classes
+        avg = self.precision_metric.average
+        if nc is None:
+            p = self.precision_metric.compute()
+            r = self.recall_metric.compute()
+            denom = p + r
+            return jnp.where(denom > 0, 2 * p * r / denom, jnp.float32(0.0))
+        if avg == 'micro':
+            p = self.precision_metric.compute()
+            r = self.recall_metric.compute()
+            denom = p + r
+            return jnp.where(denom > 0, 2 * p * r / denom, jnp.float32(0.0))
+        tp = self.precision_metric.true_positives.value
+        fp = self.precision_metric.false_positives.value
+        fn = self.recall_metric.false_negatives.value
+        support = self.precision_metric.support.value  # TP + FN per class
+        p_den = tp + fp
+        p_c = jnp.where(p_den > 0, tp / p_den, jnp.zeros_like(p_den, dtype=jnp.float32))
+        r_den = tp + fn
+        r_c = jnp.where(r_den > 0, tp / r_den, jnp.zeros_like(r_den, dtype=jnp.float32))
+        f_den = p_c + r_c
+        f1_c = jnp.where(f_den > 0, 2 * p_c * r_c / f_den, jnp.zeros_like(f_den, dtype=jnp.float32))
+        if avg == 'macro':
+            return jnp.mean(f1_c)
+        else:  # 'weighted'
+            total = jnp.sum(support)
+            return jnp.where(total > 0, jnp.sum(f1_c * support) / total, jnp.float32(0.0))
 
 
 class ConfusionMatrix(Metric):
@@ -938,10 +957,11 @@ class ConfusionMatrix(Metric):
         predictions = jnp.asarray(predictions, dtype=jnp.int32).flatten()
         labels = jnp.asarray(labels, dtype=jnp.int32).flatten()
 
-        if jnp.any((predictions < 0) | (predictions >= self.num_classes)):
-            raise ValueError(f"Predictions contain values outside [0, {self.num_classes})")
-        if jnp.any((labels < 0) | (labels >= self.num_classes)):
-            raise ValueError(f"Labels contain values outside [0, {self.num_classes})")
+        if not (isinstance(predictions, Tracer) or isinstance(labels, Tracer)):
+            if jnp.any((predictions < 0) | (predictions >= self.num_classes)):
+                raise ValueError(f"Predictions contain values outside [0, {self.num_classes})")
+            if jnp.any((labels < 0) | (labels >= self.num_classes)):
+                raise ValueError(f"Labels contain values outside [0, {self.num_classes})")
 
         for true_label in range(self.num_classes):
             for pred_label in range(self.num_classes):

--- a/brainstate/nn/_metrics.py
+++ b/brainstate/nn/_metrics.py
@@ -1028,13 +1028,17 @@ class MultiMetric(Metric):
     All keyword arguments passed to ``update`` are forwarded to all underlying metrics.
     Each metric will extract the arguments it needs based on its implementation.
 
-    Reserved method names ('reset', 'update', 'compute') cannot be used as metric names.
+    Reserved names ('reset', 'update', 'compute', '_metric_names') cannot be used as
+    metric names.
     """
     __module__ = "brainstate.nn"
 
     def __init__(self, **metrics):
-        # Validate that no reserved names are used
-        reserved_names = {'reset', 'update', 'compute'}
+        # Validate that no reserved names are used. This includes the public method
+        # names *and* the internal ``_metric_names`` bookkeeping attribute, which
+        # would otherwise be silently overwritten by a metric of the same name and
+        # break ``reset``/``update``/``compute``.
+        reserved_names = {'reset', 'update', 'compute', '_metric_names'}
         for metric_name in metrics.keys():
             if metric_name in reserved_names:
                 raise ValueError(

--- a/brainstate/nn/_metrics_test.py
+++ b/brainstate/nn/_metrics_test.py
@@ -210,6 +210,24 @@ class AccuracyMetricTest(parameterized.TestCase):
         with self.assertRaises(ValueError):
             metric.update(logits=logits, labels=labels)
 
+    def test_accuracy_metric_accepts_small_int_dtypes(self):
+        """L13: AccuracyMetric must accept small integer label dtypes (uint8, int16)."""
+        logits = jnp.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
+        for dtype in (jnp.uint8, jnp.int16):
+            metric = bst.nn.AccuracyMetric()
+            labels = jnp.array([1, 0, 1], dtype=dtype)
+            metric.update(logits=logits, labels=labels)
+            self.assertAlmostEqual(float(metric.compute()), 1.0)
+
+    def test_accuracy_metric_rejects_non_integer_labels(self):
+        """L13: float and bool labels must be rejected with ValueError."""
+        logits = jnp.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
+        metric = bst.nn.AccuracyMetric()
+        with self.assertRaises(ValueError):
+            metric.update(logits=logits, labels=jnp.array([1.0, 0.0, 1.0], dtype=jnp.float32))
+        with self.assertRaises(ValueError):
+            metric.update(logits=logits, labels=jnp.array([True, False, True]))
+
     def test_accuracy_metric_module_attribute(self):
         """Test that AccuracyMetric has correct __module__ attribute."""
         self.assertEqual(bst.nn.AccuracyMetric.__module__, "brainstate.nn")
@@ -353,15 +371,35 @@ class F1ScoreMetricTest(parameterized.TestCase):
         # Precision=2/3, Recall=1.0, F1=2*(2/3*1)/(2/3+1)=0.8
         self.assertAlmostEqual(float(result), 0.8, places=5)
 
-    def test_f1_score_multiclass(self):
-        """Test multi-class F1 score."""
+    def test_f1_score_multiclass_macro_exact(self):
+        """H6: macro F1 must be the mean of PER-CLASS F1, not harmonic mean of aggregates."""
+        labels = jnp.array([0, 0, 0, 0, 0, 1, 1, 2, 2, 2])
+        preds = jnp.array([0, 0, 1, 2, 0, 1, 2, 2, 0, 1])
         metric = bst.nn.F1ScoreMetric(num_classes=3, average='macro')
-        predictions = jnp.array([0, 1, 2, 1, 0])
-        labels = jnp.array([0, 1, 1, 1, 2])
-        metric.update(predictions=predictions, labels=labels)
+        metric.update(predictions=preds, labels=labels)
         result = metric.compute()
-        self.assertGreaterEqual(float(result), 0.0)
-        self.assertLessEqual(float(result), 1.0)
+        # Per-class F1: [2/3, 0.4, 1/3] -> mean = 0.46667
+        self.assertAlmostEqual(float(result), 0.4667, places=3)
+
+    def test_f1_score_multiclass_weighted_exact(self):
+        """H6: weighted F1 must be support-weighted mean of PER-CLASS F1."""
+        labels = jnp.array([0, 0, 0, 0, 0, 1, 1, 2, 2, 2])
+        preds = jnp.array([0, 0, 1, 2, 0, 1, 2, 2, 0, 1])
+        metric = bst.nn.F1ScoreMetric(num_classes=3, average='weighted')
+        metric.update(predictions=preds, labels=labels)
+        result = metric.compute()
+        # Per-class F1: [2/3, 0.4, 1/3], support [5, 2, 3] -> 0.51333
+        self.assertAlmostEqual(float(result), 0.5133, places=3)
+
+    def test_f1_score_multiclass_two_class_macro_exact(self):
+        """H6: 2-class macro F1 exact value (per-class F1 averaging)."""
+        labels = jnp.array([0] * 100 + [1] * 100)
+        preds = jnp.array([0] + [1] * 99 + [1] * 100)
+        metric = bst.nn.F1ScoreMetric(num_classes=2, average='macro')
+        metric.update(predictions=preds, labels=labels)
+        result = metric.compute()
+        # Per-class F1: [0.0198, 0.6689] -> mean = 0.34435
+        self.assertAlmostEqual(float(result), 0.3443, places=3)
 
     def test_f1_score_reset(self):
         """Test reset functionality."""
@@ -440,6 +478,45 @@ class ConfusionMatrixTest(parameterized.TestCase):
         labels = jnp.array([0, 1, 3])  # 3 is out of range
         with self.assertRaises(ValueError):
             metric.update(predictions=predictions, labels=labels)
+
+    def test_confusion_matrix_under_jit(self):
+        """M12: update must not concretize under jit (no TracerBoolConversionError)."""
+        metric = bst.nn.ConfusionMatrix(num_classes=3)
+        predictions = jnp.array([0, 1, 2, 1, 0])
+        labels = jnp.array([0, 1, 1, 1, 2])
+
+        @bst.transform.jit
+        def do_update(preds, lbls):
+            metric.update(predictions=preds, labels=lbls)
+
+        do_update(predictions, labels)
+        result = metric.compute()
+        expected = jnp.array([[1, 0, 0], [0, 2, 1], [1, 0, 0]], dtype=jnp.int32)
+        self.assertTrue(jnp.all(result == expected))
+
+    def test_confusion_matrix_under_vmap(self):
+        """M12: update must not concretize under vmap (no TracerBoolConversionError)."""
+        metric = bst.nn.ConfusionMatrix(num_classes=3)
+        preds = jnp.array([[0, 1, 2, 1, 0], [2, 2, 1, 0, 0]])
+        labels = jnp.array([[0, 1, 1, 1, 2], [2, 1, 1, 0, 0]])
+
+        def do_update(p, l):
+            metric.update(predictions=p, labels=l)
+
+        fn = bst.transform.vmap(do_update, out_states={0: metric.matrix})
+        fn(preds, labels)
+        # Per-lane matrices are stacked on axis 0; their sum is the full matrix.
+        summed = jnp.sum(metric.matrix.value, axis=0)
+        expected = jnp.array([[3, 0, 0], [0, 3, 2], [1, 0, 1]], dtype=jnp.int32)
+        self.assertTrue(jnp.all(summed == expected))
+
+    def test_confusion_matrix_eager_out_of_range_still_raises(self):
+        """M12: eager (non-traced) out-of-range inputs must still raise ValueError."""
+        metric = bst.nn.ConfusionMatrix(num_classes=2)
+        with self.assertRaises(ValueError):
+            metric.update(predictions=jnp.array([0, 1, 2]), labels=jnp.array([0, 1, 1]))
+        with self.assertRaises(ValueError):
+            metric.update(predictions=jnp.array([0, 1, 1]), labels=jnp.array([0, 1, 3]))
 
     def test_confusion_matrix_module_attribute(self):
         """Test that ConfusionMatrix has correct __module__ attribute."""

--- a/brainstate/nn/_metrics_test.py
+++ b/brainstate/nn/_metrics_test.py
@@ -721,6 +721,24 @@ class MetricsAuditRegressionTest(parameterized.TestCase):
         m.reset()
         self.assertEqual(m.count.value.dtype, jnp.int32)
 
+    def test_multimetric_reserved_internal_name(self):
+        """Item 9: '_metric_names' is reserved and must raise, not silently corrupt state.
+
+        Pre-fix, a metric named '_metric_names' overwrote the internal bookkeeping
+        list, so reset/update/compute raised 'object is not iterable'.
+        """
+        with self.assertRaises(ValueError):
+            bst.nn.MultiMetric(_metric_names=bst.nn.AverageMetric())
+
+    def test_multimetric_valid_names_still_work(self):
+        """Item 9: ordinary metric names continue to work after tightening the check."""
+        m = bst.nn.MultiMetric(loss=bst.nn.AverageMetric(), acc=bst.nn.AccuracyMetric())
+        m.update(values=jnp.array([1.0, 3.0]),
+                 logits=jnp.array([[0.1, 0.9], [0.8, 0.2]]),
+                 labels=jnp.array([1, 0]))
+        out = m.compute()
+        self.assertEqual(set(out.keys()), {'loss', 'acc'})
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/nn/_metrics_test.py
+++ b/brainstate/nn/_metrics_test.py
@@ -401,6 +401,33 @@ class F1ScoreMetricTest(parameterized.TestCase):
         # Per-class F1: [0.0198, 0.6689] -> mean = 0.34435
         self.assertAlmostEqual(float(result), 0.3443, places=3)
 
+    def test_f1_score_multiclass_micro_exact(self):
+        """Micro-averaged multi-class F1 equals overall accuracy (single-label).
+
+        Covers the ``avg == 'micro'`` branch of ``F1ScoreMetric.compute()`` for
+        ``num_classes is not None``: micro precision and micro recall are both
+        equal to the global accuracy, so their harmonic mean is the accuracy too.
+        """
+        labels = jnp.array([0, 0, 0, 0, 0, 1, 1, 2, 2, 2])
+        preds = jnp.array([0, 0, 1, 2, 0, 1, 2, 2, 0, 1])
+        metric = bst.nn.F1ScoreMetric(num_classes=3, average='micro')
+        metric.update(predictions=preds, labels=labels)
+        result = metric.compute()
+        # 5 of 10 predictions are correct -> accuracy 0.5 -> micro F1 0.5.
+        self.assertAlmostEqual(float(result), 0.5, places=5)
+        # It must equal the harmonic mean of the component micro metrics.
+        p = float(metric.precision_metric.compute())
+        r = float(metric.recall_metric.compute())
+        self.assertAlmostEqual(float(result), 2 * p * r / (p + r), places=5)
+
+    def test_f1_score_multiclass_micro_all_correct(self):
+        """Micro F1 is 1.0 when every single-label prediction is correct."""
+        labels = jnp.array([0, 1, 2, 2, 1, 0])
+        preds = jnp.array([0, 1, 2, 2, 1, 0])
+        metric = bst.nn.F1ScoreMetric(num_classes=3, average='micro')
+        metric.update(predictions=preds, labels=labels)
+        self.assertAlmostEqual(float(metric.compute()), 1.0, places=5)
+
     def test_f1_score_reset(self):
         """Test reset functionality."""
         metric = bst.nn.F1ScoreMetric()

--- a/brainstate/nn/_paddings.py
+++ b/brainstate/nn/_paddings.py
@@ -29,6 +29,7 @@ from typing import Union, Sequence, Optional
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from brainstate import environ
 from brainstate.typing import Size
@@ -66,7 +67,14 @@ def _format_padding(padding: Union[int, Sequence[int]], ndim: int) -> Sequence[t
     -------
     List of padding tuples for each dimension
     """
-    if isinstance(padding, int):
+    # Accept Python ints as well as 0-d numpy/JAX integer scalars as the
+    # scalar form. ``isinstance(padding, int)`` alone rejects ``numpy.int64``
+    # and similar, which then fall through to ``list(padding)`` and raise a
+    # confusing "object is not iterable" TypeError.
+    if isinstance(padding, (int, np.integer)) or (
+        hasattr(padding, 'ndim') and getattr(padding, 'ndim') == 0
+    ):
+        padding = int(padding)
         # Same padding for all sides of all dimensions
         return [(padding, padding) for _ in range(ndim)]
 

--- a/brainstate/nn/_paddings.py
+++ b/brainstate/nn/_paddings.py
@@ -109,10 +109,10 @@ class ReflectionPad1d(Module):
         >>> import brainstate as brainstate
         >>> import jax.numpy as jnp
         >>> pad = brainstate.nn.ReflectionPad1d(2)
-        >>> input = jnp.array([[[1, 2, 3, 4, 5]]])
+        >>> input = jnp.ones((1, 5, 3))   # (batch=1, length=5, channels=3)
         >>> output = pad(input)
         >>> print(output.shape)
-        (1, 9, 1)
+        (1, 9, 3)
     """
 
     def __init__(
@@ -157,7 +157,13 @@ class ReflectionPad2d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 2: (height_pad, width_pad)
-        - Sequence[int] of length 4: (left, right, top, bottom)
+        - Sequence[int] of length 4: (height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-4 form, the first pair pads the first spatial axis
+            (height) and the second pair pads the second spatial axis (width).
+            This order is the REVERSE of ``torch.nn.*Pad2d``, which lists the
+            last spatial axis (width) first as ``(left, right, top, bottom)``.
     in_size : Size, optional
         The input size.
     name : str, optional
@@ -218,7 +224,13 @@ class ReflectionPad3d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 3: (depth_pad, height_pad, width_pad)
-        - Sequence[int] of length 6: (left, right, top, bottom, front, back)
+        - Sequence[int] of length 6: (depth_before, depth_after, height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-6 form, the pairs pad the spatial axes in order
+            (depth, then height, then width). This order is the REVERSE of
+            ``torch.nn.*Pad3d``, which lists the last spatial axis (width)
+            first as ``(left, right, top, bottom, front, back)``.
     in_size : Size, optional
         The input size.
     name : str, optional
@@ -295,10 +307,10 @@ class ReplicationPad1d(Module):
         >>> import brainstate as brainstate
         >>> import jax.numpy as jnp
         >>> pad = brainstate.nn.ReplicationPad1d(2)
-        >>> input = jnp.array([[[1, 2, 3, 4, 5]]])
+        >>> input = jnp.ones((1, 5, 3))   # (batch=1, length=5, channels=3)
         >>> output = pad(input)
         >>> print(output.shape)
-        (1, 9, 1)
+        (1, 9, 3)
     """
 
     def __init__(
@@ -343,7 +355,13 @@ class ReplicationPad2d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 2: (height_pad, width_pad)
-        - Sequence[int] of length 4: (left, right, top, bottom)
+        - Sequence[int] of length 4: (height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-4 form, the first pair pads the first spatial axis
+            (height) and the second pair pads the second spatial axis (width).
+            This order is the REVERSE of ``torch.nn.*Pad2d``, which lists the
+            last spatial axis (width) first as ``(left, right, top, bottom)``.
     in_size : Size, optional
         The input size.
     name : str, optional
@@ -404,7 +422,13 @@ class ReplicationPad3d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 3: (depth_pad, height_pad, width_pad)
-        - Sequence[int] of length 6: (left, right, top, bottom, front, back)
+        - Sequence[int] of length 6: (depth_before, depth_after, height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-6 form, the pairs pad the spatial axes in order
+            (depth, then height, then width). This order is the REVERSE of
+            ``torch.nn.*Pad3d``, which lists the last spatial axis (width)
+            first as ``(left, right, top, bottom, front, back)``.
     in_size : Size, optional
         The input size.
     name : str, optional
@@ -481,10 +505,10 @@ class ZeroPad1d(Module):
         >>> import brainstate as brainstate
         >>> import jax.numpy as jnp
         >>> pad = brainstate.nn.ZeroPad1d(2)
-        >>> input = jnp.array([[[1, 2, 3, 4, 5]]])
+        >>> input = jnp.ones((1, 5, 3))   # (batch=1, length=5, channels=3)
         >>> output = pad(input)
         >>> print(output.shape)
-        (1, 9, 1)
+        (1, 9, 3)
     """
 
     def __init__(
@@ -529,7 +553,13 @@ class ZeroPad2d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 2: (height_pad, width_pad)
-        - Sequence[int] of length 4: (left, right, top, bottom)
+        - Sequence[int] of length 4: (height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-4 form, the first pair pads the first spatial axis
+            (height) and the second pair pads the second spatial axis (width).
+            This order is the REVERSE of ``torch.nn.*Pad2d``, which lists the
+            last spatial axis (width) first as ``(left, right, top, bottom)``.
     in_size : Size, optional
         The input size.
     name : str, optional
@@ -590,7 +620,13 @@ class ZeroPad3d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 3: (depth_pad, height_pad, width_pad)
-        - Sequence[int] of length 6: (left, right, top, bottom, front, back)
+        - Sequence[int] of length 6: (depth_before, depth_after, height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-6 form, the pairs pad the spatial axes in order
+            (depth, then height, then width). This order is the REVERSE of
+            ``torch.nn.*Pad3d``, which lists the last spatial axis (width)
+            first as ``(left, right, top, bottom, front, back)``.
     in_size : Size, optional
         The input size.
     name : str, optional
@@ -669,10 +705,10 @@ class ConstantPad1d(Module):
         >>> import brainstate as brainstate
         >>> import jax.numpy as jnp
         >>> pad = brainstate.nn.ConstantPad1d(2, value=3.5)
-        >>> input = jnp.array([[[1, 2, 3, 4, 5]]])
+        >>> input = jnp.ones((1, 5, 3))   # (batch=1, length=5, channels=3)
         >>> output = pad(input)
         >>> print(output.shape)
-        (1, 9, 1)
+        (1, 9, 3)
     """
 
     def __init__(
@@ -719,7 +755,13 @@ class ConstantPad2d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 2: (height_pad, width_pad)
-        - Sequence[int] of length 4: (left, right, top, bottom)
+        - Sequence[int] of length 4: (height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-4 form, the first pair pads the first spatial axis
+            (height) and the second pair pads the second spatial axis (width).
+            This order is the REVERSE of ``torch.nn.*Pad2d``, which lists the
+            last spatial axis (width) first as ``(left, right, top, bottom)``.
     value : float, optional
         The constant value to use for padding. Default is 0.
     in_size : Size, optional
@@ -784,7 +826,13 @@ class ConstantPad3d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 3: (depth_pad, height_pad, width_pad)
-        - Sequence[int] of length 6: (left, right, top, bottom, front, back)
+        - Sequence[int] of length 6: (depth_before, depth_after, height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-6 form, the pairs pad the spatial axes in order
+            (depth, then height, then width). This order is the REVERSE of
+            ``torch.nn.*Pad3d``, which lists the last spatial axis (width)
+            first as ``(left, right, top, bottom, front, back)``.
     value : float, optional
         The constant value to use for padding. Default is 0.
     in_size : Size, optional
@@ -865,10 +913,10 @@ class CircularPad1d(Module):
         >>> import brainstate as brainstate
         >>> import jax.numpy as jnp
         >>> pad = brainstate.nn.CircularPad1d(2)
-        >>> input = jnp.array([[[1, 2, 3, 4, 5]]])
+        >>> input = jnp.ones((1, 5, 3))   # (batch=1, length=5, channels=3)
         >>> output = pad(input)
         >>> print(output.shape)
-        (1, 9, 1)
+        (1, 9, 3)
     """
 
     def __init__(
@@ -913,7 +961,13 @@ class CircularPad2d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 2: (height_pad, width_pad)
-        - Sequence[int] of length 4: (left, right, top, bottom)
+        - Sequence[int] of length 4: (height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-4 form, the first pair pads the first spatial axis
+            (height) and the second pair pads the second spatial axis (width).
+            This order is the REVERSE of ``torch.nn.*Pad2d``, which lists the
+            last spatial axis (width) first as ``(left, right, top, bottom)``.
     in_size : Size, optional
         The input size.
     name : str, optional
@@ -974,7 +1028,13 @@ class CircularPad3d(Module):
 
         - int: same padding for all sides
         - Sequence[int] of length 3: (depth_pad, height_pad, width_pad)
-        - Sequence[int] of length 6: (left, right, top, bottom, front, back)
+        - Sequence[int] of length 6: (depth_before, depth_after, height_before, height_after, width_before, width_after)
+
+        .. note::
+            For the length-6 form, the pairs pad the spatial axes in order
+            (depth, then height, then width). This order is the REVERSE of
+            ``torch.nn.*Pad3d``, which lists the last spatial axis (width)
+            first as ``(left, right, top, bottom, front, back)``.
     in_size : Size, optional
         The input size.
     name : str, optional

--- a/brainstate/nn/_paddings_test.py
+++ b/brainstate/nn/_paddings_test.py
@@ -925,5 +925,33 @@ class TestPaddingSpatialOrder(unittest.TestCase):
         np.testing.assert_array_equal(out[0, :, :, 1, 0], x[0, :, :, 0, 0])
 
 
+class TestFormatPaddingScalarTypes(unittest.TestCase):
+    """Regression: _format_padding must accept numpy/JAX integer scalars (P1)."""
+
+    def test_numpy_int_scalar_is_int_form(self):
+        # np.int64 is not a Python ``int``; previously this fell through to
+        # ``list(padding)`` and raised "object is not iterable".
+        self.assertEqual(_format_padding(np.int64(2), 1), [(2, 2)])
+        self.assertEqual(_format_padding(np.int32(3), 2), [(3, 3), (3, 3)])
+
+    def test_jax_int_scalar_is_int_form(self):
+        self.assertEqual(_format_padding(jnp.array(2), 1), [(2, 2)])
+
+    def test_numpy_0d_array_is_int_form(self):
+        self.assertEqual(_format_padding(np.array(4), 3), [(4, 4), (4, 4), (4, 4)])
+
+    def test_numpy_int_scalar_in_layer(self):
+        # End-to-end: a numpy-int padding should build and run a pad layer.
+        pad = brainstate.nn.ZeroPad1d(np.int64(2))
+        x = jnp.ones((1, 5, 3))
+        self.assertEqual(pad(x).shape, (1, 9, 3))
+
+    def test_python_and_sequence_forms_unchanged(self):
+        self.assertEqual(_format_padding(2, 1), [(2, 2)])
+        self.assertEqual(_format_padding([2, 3], 2), [(2, 2), (3, 3)])
+        with self.assertRaises(ValueError):
+            _format_padding([1, 2, 3], 1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/nn/_paddings_test.py
+++ b/brainstate/nn/_paddings_test.py
@@ -144,10 +144,11 @@ class TestReflectionPad2d(unittest.TestCase):
 
     def test_reflection_pad2d_asymmetric(self):
         """Test ReflectionPad2d with asymmetric padding."""
-        pad = brainstate.nn.ReflectionPad2d([1, 2, 3, 4])  # left, right, top, bottom
+        # Length-4 padding is (height_before, height_after, width_before, width_after).
+        pad = brainstate.nn.ReflectionPad2d([1, 2, 3, 4])
         x = jnp.ones((2, 5, 5, 3))
         output = pad(x)
-        # For 2D: first pair is height (top/bottom), second is width (left/right)
+        # First pair pads height (first spatial axis), second pair pads width.
         # Height: 5+1+2=8, Width: 5+3+4=12
         self.assertEqual(output.shape, (2, 8, 12, 3))
 
@@ -825,6 +826,103 @@ class TestPaddingInSize(unittest.TestCase):
         """ReflectionPad2d computes out_size from an unbatched in_size."""
         pad = brainstate.nn.ReflectionPad2d(1, in_size=(4, 4, 3))
         self.assertEqual(pad.out_size, (6, 6, 3))
+
+
+class TestPaddingDocstringShapes(unittest.TestCase):
+    """Regression: the 1D docstring Examples must report the real output shape (M13).
+
+    Every 1D padding class documents a (batch=1, length=5, channels=3) input
+    yielding (1, 9, 3) under the implemented channels-last convention. The old
+    examples claimed (1, 9, 1) for a (1, 1, 5) input, which actually produces
+    (1, 5, 5). These tests pin the documented shape against actual output.
+    """
+
+    def test_reflection_pad1d_docstring_shape(self):
+        pad = brainstate.nn.ReflectionPad1d(2)
+        x = jnp.ones((1, 5, 3))  # (batch=1, length=5, channels=3)
+        self.assertEqual(pad(x).shape, (1, 9, 3))
+
+    def test_replication_pad1d_docstring_shape(self):
+        pad = brainstate.nn.ReplicationPad1d(2)
+        x = jnp.ones((1, 5, 3))
+        self.assertEqual(pad(x).shape, (1, 9, 3))
+
+    def test_zero_pad1d_docstring_shape(self):
+        pad = brainstate.nn.ZeroPad1d(2)
+        x = jnp.ones((1, 5, 3))
+        self.assertEqual(pad(x).shape, (1, 9, 3))
+
+    def test_constant_pad1d_docstring_shape(self):
+        pad = brainstate.nn.ConstantPad1d(2, value=3.5)
+        x = jnp.ones((1, 5, 3))
+        self.assertEqual(pad(x).shape, (1, 9, 3))
+
+    def test_circular_pad1d_docstring_shape(self):
+        pad = brainstate.nn.CircularPad1d(2)
+        x = jnp.ones((1, 5, 3))
+        self.assertEqual(pad(x).shape, (1, 9, 3))
+
+    def test_old_docstring_input_does_not_yield_old_shape(self):
+        """The original (1, 1, 5) input yields (1, 5, 5), never the old (1, 9, 1)."""
+        pad = brainstate.nn.ZeroPad1d(2)
+        x = jnp.array([[[1, 2, 3, 4, 5]]])  # shape (1, 1, 5)
+        self.assertEqual(pad(x).shape, (1, 5, 5))
+
+
+class TestPaddingSpatialOrder(unittest.TestCase):
+    """Regression: length-4/6 padding pads spatial axes first-to-last (M14).
+
+    The docstrings label the length-4 form (height_before, height_after,
+    width_before, width_after) and the length-6 form
+    (depth_before, depth_after, height_before, height_after,
+    width_before, width_after). These tests distinguish the spatial axes by
+    VALUE (not just shape), pinning that the FIRST pair pads the FIRST spatial
+    axis -- the reverse of PyTorch's (left, right, top, bottom) order.
+    """
+
+    def test_constant_pad2d_first_pair_pads_height(self):
+        """ConstantPad2d((1,0,0,0)) grows height at the front; width is untouched."""
+        x = jnp.arange(1, 7, dtype=jnp.float32).reshape(1, 2, 3, 1)  # (b, H=2, W=3, c)
+        out = brainstate.nn.ConstantPad2d([1, 0, 0, 0], value=-9.0)(x)
+        # Height 2 -> 3 (one new row before), width 3 unchanged.
+        self.assertEqual(out.shape, (1, 3, 3, 1))
+        # The newly added first row is the pad value across the full width.
+        np.testing.assert_array_equal(out[0, 0, :, 0], -9.0 * jnp.ones(3))
+        # The original first row is preserved at the next height index.
+        np.testing.assert_array_equal(out[0, 1, :, 0], x[0, 0, :, 0])
+
+    def test_constant_pad2d_second_pair_pads_width(self):
+        """ConstantPad2d((0,0,1,0)) grows width at the front; height is untouched."""
+        x = jnp.arange(1, 7, dtype=jnp.float32).reshape(1, 2, 3, 1)  # (b, H=2, W=3, c)
+        out = brainstate.nn.ConstantPad2d([0, 0, 1, 0], value=-9.0)(x)
+        # Width 3 -> 4 (one new column before), height 2 unchanged.
+        self.assertEqual(out.shape, (1, 2, 4, 1))
+        # The newly added first column is the pad value across the full height.
+        np.testing.assert_array_equal(out[0, :, 0, 0], -9.0 * jnp.ones(2))
+        # The original first column is preserved at the next width index.
+        np.testing.assert_array_equal(out[0, :, 1, 0], x[0, :, 0, 0])
+
+    def test_constant_pad3d_first_pair_pads_depth(self):
+        """ConstantPad3d((1,0,0,0,0,0)) grows depth at the front; H/W untouched."""
+        x = jnp.arange(1, 9, dtype=jnp.float32).reshape(1, 2, 2, 2, 1)  # (b, D, H, W, c)
+        out = brainstate.nn.ConstantPad3d([1, 0, 0, 0, 0, 0], value=-7.0)(x)
+        # Depth 2 -> 3 (one new slab before), height and width unchanged.
+        self.assertEqual(out.shape, (1, 3, 2, 2, 1))
+        # The newly added first depth slab is entirely the pad value.
+        np.testing.assert_array_equal(out[0, 0, :, :, 0], -7.0 * jnp.ones((2, 2)))
+        # The original first depth slab is preserved at the next depth index.
+        np.testing.assert_array_equal(out[0, 1, :, :, 0], x[0, 0, :, :, 0])
+
+    def test_constant_pad3d_last_pair_pads_width(self):
+        """ConstantPad3d((0,0,0,0,1,0)) grows width at the front; D/H untouched."""
+        x = jnp.arange(1, 9, dtype=jnp.float32).reshape(1, 2, 2, 2, 1)  # (b, D, H, W, c)
+        out = brainstate.nn.ConstantPad3d([0, 0, 0, 0, 1, 0], value=-7.0)(x)
+        # Width 2 -> 3 (one new column before), depth and height unchanged.
+        self.assertEqual(out.shape, (1, 2, 2, 3, 1))
+        # The newly added first width column is entirely the pad value.
+        np.testing.assert_array_equal(out[0, :, :, 0, 0], -7.0 * jnp.ones((2, 2)))
+        # The original first width column is preserved at the next width index.
+        np.testing.assert_array_equal(out[0, :, :, 1, 0], x[0, :, :, 0, 0])
 
 
 if __name__ == '__main__':

--- a/brainstate/nn/_poolings.py
+++ b/brainstate/nn/_poolings.py
@@ -98,16 +98,15 @@ class Flatten(Module):
     def update(self, x):
         if self._in_size is None:
             start_axis = self.start_axis if self.start_axis >= 0 else x.ndim + self.start_axis
+            end_axis = self.end_axis if self.end_axis >= 0 else x.ndim + self.end_axis
         else:
             assert x.ndim >= len(self.in_size), 'Input tensor has fewer dimensions than the expected shape.'
             dim_diff = x.ndim - len(self.in_size)
             if self.in_size != x.shape[dim_diff:]:
                 raise ValueError(f'Input tensor has shape {x.shape}, but expected shape {self.in_size}.')
-            if self.start_axis >= 0:
-                start_axis = self.start_axis + dim_diff
-            else:
-                start_axis = x.ndim + self.start_axis
-        return u.math.flatten(x, start_axis, self.end_axis)
+            start_axis = self.start_axis + dim_diff if self.start_axis >= 0 else x.ndim + self.start_axis
+            end_axis = self.end_axis + dim_diff if self.end_axis >= 0 else x.ndim + self.end_axis
+        return u.math.flatten(x, start_axis, end_axis)
 
 
 class Unflatten(Module):
@@ -356,7 +355,7 @@ class _AvgPool(_MaxPool):
                                                   window_strides=stride,
                                                   padding=padding)
             assert pooled.shape == window_counts.shape
-            return pooled / window_counts
+            return pooled / jnp.maximum(window_counts, 1)
 
 
 class MaxPool1d(_MaxPool):
@@ -723,12 +722,12 @@ class _MaxUnpool(Module):
             raise ValueError(f'Expected input with >= {x_dim} dimensions, but got {x.ndim}.')
 
         # Natural output shape: the layout the stored ``indices`` are flat positions in.
+        spatial_axes = self._get_spatial_axes(x.ndim)
         spatial_dims = self._get_spatial_dims(x.shape)
         natural_spatial_shape = self._compute_output_shape(spatial_dims, None)
         natural_shape = list(x.shape)
-        spatial_start = self._get_spatial_start_idx(x.ndim)
         for i, size in enumerate(natural_spatial_shape):
-            natural_shape[spatial_start + i] = size
+            natural_shape[spatial_axes[i]] = size
         natural_shape = tuple(natural_shape)
 
         # Determine the requested output shape.
@@ -746,13 +745,13 @@ class _MaxUnpool(Module):
                         raise ValueError(f"output_size must have {self.pool_dim} spatial dimensions, got {len(output_size)}")
                     output_shape = list(x.shape)
                     for i, size in enumerate(output_size):
-                        output_shape[spatial_start + i] = size
+                        output_shape[spatial_axes[i]] = size
                     output_shape = tuple(output_shape)
             else:
                 # Single integer provided, use for all spatial dims
                 output_shape = list(x.shape)
                 for i in range(self.pool_dim):
-                    output_shape[spatial_start + i] = output_size
+                    output_shape[spatial_axes[i]] = output_size
                 output_shape = tuple(output_shape)
 
         # Flatten values and the stored within-natural-layout indices.
@@ -799,16 +798,19 @@ class _MaxUnpool(Module):
             all_dims.pop(channel_axis)
             return tuple(shape[i] for i in all_dims[-self.pool_dim:])
 
-    def _get_spatial_start_idx(self, ndim):
-        """Get the starting index of spatial dimensions."""
+    def _get_spatial_axes(self, ndim):
+        """Get the ordered spatial axis indices.
+
+        Unlike a single start index, this returns the explicit list of spatial
+        axes so that an interleaved ``channel_axis`` (e.g. ``(N, H, C, W)``) is
+        handled correctly: the spatial dimensions need not be contiguous.
+        """
         if self.channel_axis is None:
-            return ndim - self.pool_dim
-        else:
-            channel_axis = self.channel_axis if self.channel_axis >= 0 else ndim + self.channel_axis
-            if channel_axis < ndim - self.pool_dim:
-                return ndim - self.pool_dim
-            else:
-                return ndim - self.pool_dim - 1
+            return list(range(ndim))[-self.pool_dim:]
+        ca = self.channel_axis if self.channel_axis >= 0 else ndim + self.channel_axis
+        all_dims = list(range(ndim))
+        all_dims.pop(ca)
+        return all_dims[-self.pool_dim:]
 
     def update(self, x, indices, output_size=None):
         """Forward pass of MaxUnpool1d.
@@ -1341,8 +1343,8 @@ class _LPPool(Module):
     ):
         super().__init__(name=name)
 
-        if norm_type <= 0:
-            raise ValueError(f"norm_type must be positive, got {norm_type}")
+        if not (norm_type > 0) or not np.isfinite(norm_type):
+            raise ValueError(f"norm_type must be a positive finite number, got {norm_type}")
         self.norm_type = norm_type
         self.pool_dim = pool_dim
 
@@ -1438,11 +1440,15 @@ class _LPPool(Module):
             padding=padding
         )
 
-        # Step 3: Take p-th root and multiply by normalization factor
-        # The normalization factor is (1/N)^(1/p) where N is the window size
-        window_size = np.prod([w for i, w in enumerate(self.kernel_size)])
-        norm_factor = window_size ** (-1.0 / self.norm_type)
-        result = norm_factor * (pooled_sum ** (1.0 / self.norm_type))
+        # Step 3: Take p-th root and multiply by normalization factor.
+        # The normalization factor is (1/N)^(1/p) where N is the window size.
+        # Use a double-``where`` so the power is never evaluated at 0, which would
+        # otherwise produce a NaN gradient (0 ** (1/p) has an infinite derivative).
+        inv_p = 1.0 / self.norm_type
+        window_size = np.prod([w for w in self.kernel_size])
+        norm_factor = window_size ** (-inv_p)
+        safe_sum = jnp.where(pooled_sum > 0, pooled_sum, 1.0)
+        result = norm_factor * jnp.where(pooled_sum > 0, safe_sum ** inv_p, 0.0)
 
         return result
 
@@ -1473,7 +1479,8 @@ class LPPool1d(_LPPool):
     where :math:`N` is the number of elements in the window
     (:math:`N = \prod_i \text{kernel\_size}[i]`).
 
-    - At :math:`p = \infty`, one gets max pooling
+    - As :math:`p \to \infty`, the result approaches max pooling (the limit;
+      :math:`p = \infty` itself is not supported -- ``norm_type`` must be finite)
     - At :math:`p = 1`, one gets average pooling (with absolute values)
     - At :math:`p = 2`, one gets root mean square (RMS) pooling
 
@@ -1557,7 +1564,8 @@ class LPPool2d(_LPPool):
     where :math:`N` is the number of elements in the window
     (:math:`N = \prod_i \text{kernel\_size}[i]`).
 
-    - At :math:`p = \infty`, one gets max pooling
+    - As :math:`p \to \infty`, the result approaches max pooling (the limit;
+      :math:`p = \infty` itself is not supported -- ``norm_type`` must be finite)
     - At :math:`p = 1`, one gets average pooling (with absolute values)
     - At :math:`p = 2`, one gets root mean square (RMS) pooling
 
@@ -1646,7 +1654,8 @@ class LPPool3d(_LPPool):
     where :math:`N` is the number of elements in the window
     (:math:`N = \prod_i \text{kernel\_size}[i]`).
 
-    - At :math:`p = \infty`, one gets max pooling
+    - As :math:`p \to \infty`, the result approaches max pooling (the limit;
+      :math:`p = \infty` itself is not supported -- ``norm_type`` must be finite)
     - At :math:`p = 1`, one gets average pooling (with absolute values)
     - At :math:`p = 2`, one gets root mean square (RMS) pooling
 
@@ -1744,6 +1753,13 @@ def _adaptive_pool1d(x, target_size: int, operation: Callable):
     A JAX array of shape `(target_size, )`.
     """
     size = jnp.size(x)
+    if target_size < 1:
+        raise ValueError(f"target_size must be >= 1, got {target_size}")
+    if size < target_size:
+        raise ValueError(
+            f"target_size ({target_size}) must be <= input size ({size}); "
+            f"upsampling is not supported"
+        )
     num_head_arrays = size % target_size
     num_block = size // target_size
     if num_head_arrays != 0:
@@ -1853,7 +1869,8 @@ class _AdaptivePool(Module):
 class AdaptiveAvgPool1d(_AdaptivePool):
     r"""Applies a 1D adaptive average pooling over an input signal composed of several input planes.
 
-    The output size is :math:`L_{out}`, for any input size.
+    The output size is :math:`L_{out}`, which must be no larger than the input size
+    along the pooled axis (downsampling only; upsampling is not supported).
     The number of output features is equal to the number of input planes.
 
     Adaptive pooling automatically computes the kernel size and stride to achieve the desired
@@ -1887,11 +1904,11 @@ class AdaptiveAvgPool1d(_AdaptivePool):
         >>> output = m(input)
         >>> output.shape
         (1, 5, 8)
-        >>> # Can handle variable input sizes
+        >>> # Handles variable input sizes, as long as they are >= the target size
         >>> input2 = brainstate.random.randn(1, 32, 8)
         >>> output2 = m(input2)
         >>> output2.shape
-        (1, 5, 8)  # Same output size regardless of input size
+        (1, 5, 8)  # Same output size for any input size >= the target
 
     See Also
     --------
@@ -1920,7 +1937,9 @@ class AdaptiveAvgPool1d(_AdaptivePool):
 class AdaptiveAvgPool2d(_AdaptivePool):
     r"""Applies a 2D adaptive average pooling over an input signal composed of several input planes.
 
-    The output is of size :math:`H_{out} \times W_{out}`, for any input size.
+    The output is of size :math:`H_{out} \times W_{out}`, each of which must be no
+    larger than the corresponding input size (downsampling only; upsampling is not
+    supported).
     The number of output features is equal to the number of input planes.
 
     Adaptive pooling automatically computes the kernel size and stride to achieve the desired
@@ -1996,7 +2015,9 @@ class AdaptiveAvgPool2d(_AdaptivePool):
 class AdaptiveAvgPool3d(_AdaptivePool):
     r"""Applies a 3D adaptive average pooling over an input signal composed of several input planes.
 
-    The output is of size :math:`D_{out} \times H_{out} \times W_{out}`, for any input size.
+    The output is of size :math:`D_{out} \times H_{out} \times W_{out}`, each of which
+    must be no larger than the corresponding input size (downsampling only; upsampling
+    is not supported).
     The number of output features is equal to the number of input planes.
 
     Adaptive pooling automatically computes the kernel size and stride to achieve the desired
@@ -2072,7 +2093,8 @@ class AdaptiveAvgPool3d(_AdaptivePool):
 class AdaptiveMaxPool1d(_AdaptivePool):
     r"""Applies a 1D adaptive max pooling over an input signal composed of several input planes.
 
-    The output size is :math:`L_{out}`, for any input size.
+    The output size is :math:`L_{out}`, which must be no larger than the input size
+    along the pooled axis (downsampling only; upsampling is not supported).
     The number of output features is equal to the number of input planes.
 
     Adaptive pooling automatically computes the kernel size and stride to achieve the desired
@@ -2106,11 +2128,11 @@ class AdaptiveMaxPool1d(_AdaptivePool):
         >>> output = m(input)
         >>> output.shape
         (1, 5, 8)
-        >>> # Can handle variable input sizes
+        >>> # Handles variable input sizes, as long as they are >= the target size
         >>> input2 = brainstate.random.randn(1, 32, 8)
         >>> output2 = m(input2)
         >>> output2.shape
-        (1, 5, 8)  # Same output size regardless of input size
+        (1, 5, 8)  # Same output size for any input size >= the target
 
     See Also
     --------
@@ -2139,7 +2161,9 @@ class AdaptiveMaxPool1d(_AdaptivePool):
 class AdaptiveMaxPool2d(_AdaptivePool):
     r"""Applies a 2D adaptive max pooling over an input signal composed of several input planes.
 
-    The output is of size :math:`H_{out} \times W_{out}`, for any input size.
+    The output is of size :math:`H_{out} \times W_{out}`, each of which must be no
+    larger than the corresponding input size (downsampling only; upsampling is not
+    supported).
     The number of output features is equal to the number of input planes.
 
     Adaptive pooling automatically computes the kernel size and stride to achieve the desired
@@ -2215,7 +2239,9 @@ class AdaptiveMaxPool2d(_AdaptivePool):
 class AdaptiveMaxPool3d(_AdaptivePool):
     r"""Applies a 3D adaptive max pooling over an input signal composed of several input planes.
 
-    The output is of size :math:`D_{out} \times H_{out} \times W_{out}`, for any input size.
+    The output is of size :math:`D_{out} \times H_{out} \times W_{out}`, each of which
+    must be no larger than the corresponding input size (downsampling only; upsampling
+    is not supported).
     The number of output features is equal to the number of input planes.
 
     Adaptive pooling automatically computes the kernel size and stride to achieve the desired

--- a/brainstate/nn/_poolings.py
+++ b/brainstate/nn/_poolings.py
@@ -193,9 +193,10 @@ class _MaxPool(Module):
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size,) * pool_dim
         elif isinstance(kernel_size, Sequence):
-            assert isinstance(kernel_size, (tuple, list)), f'kernel_size should be a tuple, but got {type(kernel_size)}'
-            assert all(
-                [isinstance(x, int) for x in kernel_size]), f'kernel_size should be a tuple of ints. {kernel_size}'
+            if not isinstance(kernel_size, (tuple, list)):
+                raise TypeError(f'kernel_size should be a tuple, but got {type(kernel_size)}')
+            if not all([isinstance(x, int) for x in kernel_size]):
+                raise TypeError(f'kernel_size should be a tuple of ints. {kernel_size}')
             if len(kernel_size) != pool_dim:
                 raise ValueError(f'kernel_size should a tuple with {pool_dim} ints, but got {len(kernel_size)}')
         else:
@@ -208,10 +209,12 @@ class _MaxPool(Module):
         if isinstance(stride, int):
             stride = (stride,) * pool_dim
         elif isinstance(stride, Sequence):
-            assert isinstance(stride, (tuple, list)), f'stride should be a tuple, but got {type(stride)}'
-            assert all([isinstance(x, int) for x in stride]), f'stride should be a tuple of ints. {stride}'
+            if not isinstance(stride, (tuple, list)):
+                raise TypeError(f'stride should be a tuple, but got {type(stride)}')
+            if not all([isinstance(x, int) for x in stride]):
+                raise TypeError(f'stride should be a tuple of ints. {stride}')
             if len(stride) != pool_dim:
-                raise ValueError(f'stride should a tuple with {pool_dim} ints, but got {len(kernel_size)}')
+                raise ValueError(f'stride should a tuple with {pool_dim} ints, but got {len(stride)}')
         else:
             raise TypeError(f'stride should be a int or a tuple with {pool_dim} ints.')
         self.stride = stride
@@ -236,14 +239,15 @@ class _MaxPool(Module):
                     raise ValueError(f"Each entry in padding must be tuple of 2 ints. {padding} ")
                 if len(padding) == 1:
                     padding = tuple(padding) * pool_dim
-                assert len(padding) == pool_dim, f'padding should has the length of {pool_dim}. {padding}'
+                if len(padding) != pool_dim:
+                    raise ValueError(f'padding should has the length of {pool_dim}. {padding}')
         else:
-            raise ValueError
+            raise ValueError(f'padding should be a str, int, or sequence, but got {type(padding)}')
         self.padding = padding
 
         # channel_axis
-        assert channel_axis is None or isinstance(channel_axis, int), \
-            f'channel_axis should be an int, but got {channel_axis}'
+        if not (channel_axis is None or isinstance(channel_axis, int)):
+            raise TypeError(f'channel_axis should be an int, but got {channel_axis}')
         self.channel_axis = channel_axis
 
         # in & out shapes
@@ -649,9 +653,10 @@ class _MaxUnpool(Module):
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size,) * pool_dim
         elif isinstance(kernel_size, Sequence):
-            assert isinstance(kernel_size, (tuple, list)), f'kernel_size should be a tuple, but got {type(kernel_size)}'
-            assert all(
-                [isinstance(x, int) for x in kernel_size]), f'kernel_size should be a tuple of ints. {kernel_size}'
+            if not isinstance(kernel_size, (tuple, list)):
+                raise TypeError(f'kernel_size should be a tuple, but got {type(kernel_size)}')
+            if not all([isinstance(x, int) for x in kernel_size]):
+                raise TypeError(f'kernel_size should be a tuple of ints. {kernel_size}')
             if len(kernel_size) != pool_dim:
                 raise ValueError(f'kernel_size should a tuple with {pool_dim} ints, but got {len(kernel_size)}')
         else:
@@ -664,8 +669,10 @@ class _MaxUnpool(Module):
         if isinstance(stride, int):
             stride = (stride,) * pool_dim
         elif isinstance(stride, Sequence):
-            assert isinstance(stride, (tuple, list)), f'stride should be a tuple, but got {type(stride)}'
-            assert all([isinstance(x, int) for x in stride]), f'stride should be a tuple of ints. {stride}'
+            if not isinstance(stride, (tuple, list)):
+                raise TypeError(f'stride should be a tuple, but got {type(stride)}')
+            if not all([isinstance(x, int) for x in stride]):
+                raise TypeError(f'stride should be a tuple of ints. {stride}')
             if len(stride) != pool_dim:
                 raise ValueError(f'stride should a tuple with {pool_dim} ints, but got {len(stride)}')
         else:
@@ -683,8 +690,8 @@ class _MaxUnpool(Module):
         self.padding = padding
 
         # channel_axis
-        assert channel_axis is None or isinstance(channel_axis, int), \
-            f'channel_axis should be an int, but got {channel_axis}'
+        if not (channel_axis is None or isinstance(channel_axis, int)):
+            raise TypeError(f'channel_axis should be an int, but got {channel_axis}')
         self.channel_axis = channel_axis
 
         # in & out shapes
@@ -1352,9 +1359,10 @@ class _LPPool(Module):
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size,) * pool_dim
         elif isinstance(kernel_size, Sequence):
-            assert isinstance(kernel_size, (tuple, list)), f'kernel_size should be a tuple, but got {type(kernel_size)}'
-            assert all(
-                [isinstance(x, int) for x in kernel_size]), f'kernel_size should be a tuple of ints. {kernel_size}'
+            if not isinstance(kernel_size, (tuple, list)):
+                raise TypeError(f'kernel_size should be a tuple, but got {type(kernel_size)}')
+            if not all([isinstance(x, int) for x in kernel_size]):
+                raise TypeError(f'kernel_size should be a tuple of ints. {kernel_size}')
             if len(kernel_size) != pool_dim:
                 raise ValueError(f'kernel_size should a tuple with {pool_dim} ints, but got {len(kernel_size)}')
         else:
@@ -1367,8 +1375,10 @@ class _LPPool(Module):
         if isinstance(stride, int):
             stride = (stride,) * pool_dim
         elif isinstance(stride, Sequence):
-            assert isinstance(stride, (tuple, list)), f'stride should be a tuple, but got {type(stride)}'
-            assert all([isinstance(x, int) for x in stride]), f'stride should be a tuple of ints. {stride}'
+            if not isinstance(stride, (tuple, list)):
+                raise TypeError(f'stride should be a tuple, but got {type(stride)}')
+            if not all([isinstance(x, int) for x in stride]):
+                raise TypeError(f'stride should be a tuple of ints. {stride}')
             if len(stride) != pool_dim:
                 raise ValueError(f'stride should a tuple with {pool_dim} ints, but got {len(stride)}')
         else:
@@ -1395,14 +1405,15 @@ class _LPPool(Module):
                     raise ValueError(f"Each entry in padding must be tuple of 2 ints. {padding} ")
                 if len(padding) == 1:
                     padding = tuple(padding) * pool_dim
-                assert len(padding) == pool_dim, f'padding should has the length of {pool_dim}. {padding}'
+                if len(padding) != pool_dim:
+                    raise ValueError(f'padding should has the length of {pool_dim}. {padding}')
         else:
-            raise ValueError
+            raise ValueError(f'padding should be a str, int, or sequence, but got {type(padding)}')
         self.padding = padding
 
         # channel_axis
-        assert channel_axis is None or isinstance(channel_axis, int), \
-            f'channel_axis should be an int, but got {channel_axis}'
+        if not (channel_axis is None or isinstance(channel_axis, int)):
+            raise TypeError(f'channel_axis should be an int, but got {channel_axis}')
         self.channel_axis = channel_axis
 
         # in & out shapes
@@ -1812,10 +1823,27 @@ class _AdaptivePool(Module):
 
         self.channel_axis = channel_axis
         self.operation = operation
+        # ``str`` is a ``Sequence`` so it must be rejected explicitly; otherwise a
+        # string of the right length would be silently accepted as a target shape.
+        if isinstance(target_size, str):
+            raise TypeError("`target_size` must be an int or a sequence of ints, not a str.")
         if isinstance(target_size, int):
+            if target_size <= 0:
+                raise ValueError(f"`target_size` must be a positive int, but got {target_size}.")
             self.target_shape = (target_size,) * num_spatial_dims
         elif isinstance(target_size, Sequence) and (len(target_size) == num_spatial_dims):
-            self.target_shape = target_size
+            # Each entry must be a positive int or ``None`` (meaning "do not pool
+            # this axis"); reject non-positive sizes and non-int/None entries.
+            for t in target_size:
+                if t is None:
+                    continue
+                if not isinstance(t, int):
+                    raise TypeError("`target_size` entries must be ints or None, "
+                                    f"but got {type(t)}.")
+                if t <= 0:
+                    raise ValueError("`target_size` entries must be positive ints, "
+                                     f"but got {t}.")
+            self.target_shape = tuple(target_size)
         else:
             raise ValueError("`target_size` must either be an int or tuple of length "
                              f"{num_spatial_dims} containing ints.")
@@ -1851,7 +1879,11 @@ class _AdaptivePool(Module):
                              f"But got {x.ndim} dimensions.")
         # pooling dimensions
         pool_dims = list(range(x.ndim))
-        if channel_axis:
+        # ``channel_axis`` has been normalised to a non-negative int above when it
+        # is not ``None``. Use an explicit ``is not None`` check so that
+        # ``channel_axis=0`` (a falsy but valid axis) still removes the channel
+        # axis from the pooled dimensions.
+        if channel_axis is not None:
             pool_dims.pop(channel_axis)
 
         # pooling

--- a/brainstate/nn/_poolings_test.py
+++ b/brainstate/nn/_poolings_test.py
@@ -656,6 +656,30 @@ class TestMaxUnpool2d(parameterized.TestCase):
         # Check shape
         self.assertEqual(unpooled.shape, (1, 2, 2, 2))
 
+    def test_maxunpool2d_interleaved_channel_axis_roundtrip(self):
+        """Regression (H8): unpool handles a non-contiguous (interleaved) channel axis.
+
+        With ``channel_axis=2`` the layout is ``(N, H, C, W)``, so the spatial axes
+        (1 and 3) are *not* contiguous. The previous implementation assumed a single
+        contiguous spatial block and mislaid values; here a pool/unpool roundtrip must
+        recover the correct shape and the pooled maxima.
+        """
+        with seeded(11):
+            arr = brainstate.random.randn(1, 4, 2, 4)  # (N, H, C, W)
+
+        pool = nn.MaxPool2d(2, 2, channel_axis=2, return_indices=True)
+        pooled, indices = pool(arr)
+        # Spatial axes 1 (H: 4->2) and 3 (W: 4->2); channel axis 2 (size 2) untouched.
+        self.assertEqual(pooled.shape, (1, 2, 2, 2))
+
+        unpool = nn.MaxUnpool2d(2, 2, channel_axis=2)
+        unpooled = unpool(pooled, indices)
+
+        self.assertEqual(unpooled.shape, (1, 4, 2, 4))
+        # The non-zero entries of the reconstruction are exactly the pooled maxima.
+        assert_allclose(jnp.sum(unpooled), jnp.sum(pooled))
+        self.assertEqual(float(jnp.max(unpooled)), float(jnp.max(pooled)))
+
 
 class TestMaxUnpool3d(parameterized.TestCase):
     """Comprehensive tests for MaxUnpool3d."""
@@ -1044,6 +1068,30 @@ class TestFlattenInSizePaths(unittest.TestCase):
         assert_jit_equal(f, x)
         assert_grad_finite(lambda y: jnp.sum(f(y)), x)
 
+    def test_flatten_in_size_positive_end_axis_rebased(self):
+        """Regression (H7): a positive ``end_axis`` is rebased by the batch offset.
+
+        With ``in_size=(3, 4, 5)`` and a leading batch dim, ``Flatten(0, 1)`` should
+        flatten the *local* first two axes (3, 4) -> 12, leaving the batch and the
+        trailing 5 intact. Before the fix, ``end_axis`` was passed unrebased, so the
+        flattened span was wrong.
+        """
+        f = nn.Flatten(start_axis=0, end_axis=1, in_size=(3, 4, 5))
+        out = f(brainstate.random.randn(2, 3, 4, 5))
+        self.assertEqual(out.shape, (2, 12, 5))
+
+    def test_flatten_in_size_default_end_axis_unchanged(self):
+        """Regression (H7): a negative (default) ``end_axis`` still resolves correctly.
+
+        ``start_axis`` is relative to ``in_size=(3, 4, 5)``; with a leading batch dim
+        ``dim_diff == 1`` rebases ``start_axis=1`` to local axis 2 and ``end_axis=-1``
+        to the last axis, flattening (4, 5) -> 20 while leaving the batch and the
+        first in_size axis intact.
+        """
+        f = nn.Flatten(start_axis=1, in_size=(3, 4, 5))
+        out = f(brainstate.random.randn(2, 3, 4, 5))
+        self.assertEqual(out.shape, (2, 3, 20))
+
 
 class TestMaxPoolConstructorValidation(unittest.TestCase):
     """Cover the argument-validation branches in the ``_MaxPool`` base class."""
@@ -1197,6 +1245,26 @@ class TestAvgPoolExtra(unittest.TestCase):
         assert_jit_equal(pool, x)
         assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
 
+    def test_avgpool_all_padding_window_is_nan_free(self):
+        """Regression (M15): a window that is entirely padding does not produce NaN.
+
+        With ``kernel_size=3``, ``stride=3`` and ``padding=3`` the border windows
+        consist solely of padding cells, so the valid-element count there is 0.
+        The naive ``pooled / window_counts`` divisor yields 0/0 = NaN; the NaN-safe
+        divisor (``jnp.maximum(window_counts, 1)``) must keep the output finite.
+        """
+        pool = nn.AvgPool1d(3, stride=3, padding=3, channel_axis=-1)
+        out = pool(brainstate.random.randn(1, 9, 2))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(out))))
+
+    def test_avgpool_valid_padding_is_finite(self):
+        """Regression (M15): ordinary padded pooling stays finite and correct."""
+        pool = nn.AvgPool1d(3, stride=1, padding=1, channel_axis=-1)
+        out = pool(jnp.ones((1, 6, 2)))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(out))))
+        # Constant ones input averages back to ones (padding cells are excluded).
+        assert_allclose(out, jnp.ones_like(out))
+
 
 class TestMaxUnpoolValidation(unittest.TestCase):
     """Cover the validation and output-shape branches of ``_MaxUnpool``."""
@@ -1319,6 +1387,18 @@ class TestLPPoolValidation(unittest.TestCase):
         with self.assertRaises(ValueError):
             nn.LPPool2d(norm_type=-1.0, kernel_size=2)
 
+    def test_nonfinite_norm_type_raises(self):
+        """Regression (M16): a non-finite ``norm_type`` (inf/nan) is rejected.
+
+        ``p = inf`` would correspond to max pooling only in the limit; the
+        implementation cannot evaluate it, so it must raise rather than silently
+        producing NaNs.
+        """
+        with self.assertRaises(ValueError):
+            nn.LPPool1d(float('inf'), kernel_size=2, stride=2, channel_axis=-1)
+        with self.assertRaises(ValueError):
+            nn.LPPool2d(float('nan'), kernel_size=2)
+
     def test_kernel_size_wrong_length_raises(self):
         """An LP kernel tuple of the wrong length is rejected."""
         with self.assertRaises(ValueError):
@@ -1408,6 +1488,17 @@ class TestLPPoolTransforms(unittest.TestCase):
         assert_jit_equal(pool, x)
         assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
 
+    def test_lppool1d_grad_finite_at_all_zero_window(self):
+        """Regression (M17): the gradient is finite even when a window is all zeros.
+
+        At an all-zero window ``pooled_sum == 0`` and the naive ``sum ** (1/p)`` has an
+        infinite derivative, producing a NaN gradient. The double-``where`` guard must
+        keep the gradient finite (and zero) there.
+        """
+        pool = nn.LPPool1d(2.0, 2, stride=2, channel_axis=None)
+        grad = jax.grad(lambda x: jnp.sum(pool(x)))(jnp.zeros(4))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(grad))))
+
     @pytest.mark.slow
     def test_lppool3d_grad_large_kernel(self):
         """LPPool3d gradients remain finite with a larger kernel."""
@@ -1458,6 +1549,23 @@ class TestAdaptivePoolValidation(unittest.TestCase):
         p = nn.AdaptiveAvgPool1d(5, channel_axis=None)
         out = p(brainstate.random.randn(2, 32))
         self.assertEqual(out.shape, (2, 5))
+
+    def test_adaptive_pool_target_larger_than_input_raises(self):
+        """Regression (H9): target size larger than the input raises ValueError.
+
+        Previously this hit ``num_block = size // target_size == 0`` and raised a
+        bare ``ZeroDivisionError`` from the reshape; it must now raise a clear
+        ``ValueError`` (upsampling is unsupported).
+        """
+        p = nn.AdaptiveAvgPool1d(5, channel_axis=-1)
+        with self.assertRaises(ValueError):
+            p(brainstate.random.randn(1, 3, 2))  # pooled axis size 3 < target 5
+
+    def test_adaptive_pool1d_target_larger_raises_directly(self):
+        """Regression (H9): the internal 1D helper raises ValueError, not ZeroDivisionError."""
+        from brainstate.nn._poolings import _adaptive_pool1d
+        with self.assertRaises(ValueError):
+            _adaptive_pool1d(brainstate.random.rand(3), 5, jnp.mean)
 
     def test_negative_channel_axis_forward(self):
         """Adaptive pooling resolves a negative channel axis."""

--- a/brainstate/nn/_poolings_test.py
+++ b/brainstate/nn/_poolings_test.py
@@ -1634,5 +1634,60 @@ class TestAdaptivePoolTransforms(unittest.TestCase):
         assert_grad_finite(lambda y: jnp.sum(pool(y)), x)
 
 
+class TestPoolingAuditRegressions(unittest.TestCase):
+    """Regression tests for pooling audit findings (P3-P8)."""
+
+    def test_maxpool_stride_length_error_reports_stride_len(self):
+        # P4: the stride-length error must mention the stride length, not the
+        # kernel length. With kernel len 2 and stride len 3 the message must
+        # report 3.
+        with self.assertRaises(ValueError) as ctx:
+            nn.MaxPool2d(kernel_size=(2, 2), stride=(2, 2, 2))
+        self.assertIn("got 3", str(ctx.exception))
+
+    def test_maxpool_bad_kernel_element_raises_not_assert(self):
+        # P3: non-int kernel elements must raise (TypeError), not rely on
+        # ``assert`` (which is stripped under ``python -O``).
+        with self.assertRaises(TypeError):
+            nn.MaxPool2d(kernel_size=(2.0, 2))
+
+    def test_maxpool_bad_channel_axis_raises_not_assert(self):
+        # P3: a bad channel_axis must raise TypeError, not assert.
+        with self.assertRaises(TypeError):
+            nn.MaxPool2d(kernel_size=2, channel_axis=1.5)
+
+    def test_lppool_bad_stride_element_raises_not_assert(self):
+        # P3/P5: _LPPool must validate via raise, not assert.
+        with self.assertRaises(TypeError):
+            nn.LPPool2d(norm_type=2, kernel_size=2, stride=(2.0, 2))
+
+    def test_adaptivepool_rejects_str_target_size(self):
+        # P6: a str target_size must be rejected (str is a Sequence).
+        with self.assertRaises(TypeError):
+            nn.AdaptiveAvgPool1d(target_size="ab")
+
+    def test_adaptivepool_rejects_nonpositive_target_size(self):
+        # P6: non-positive target sizes must be rejected.
+        with self.assertRaises(ValueError):
+            nn.AdaptiveAvgPool1d(target_size=0)
+        with self.assertRaises(ValueError):
+            nn.AdaptiveAvgPool2d(target_size=(2, -1))
+
+    def test_adaptivepool_channel_axis_zero_preserves_channels(self):
+        # P7/P8: channel_axis=0 must skip the channel axis when pooling. Input
+        # (C=3, L=4) -> (C=3, L=2); previously ``if channel_axis:`` was falsy for
+        # 0 and the channel axis was incorrectly pooled.
+        pool = nn.AdaptiveAvgPool1d(target_size=2, channel_axis=0)
+        x = jnp.arange(12.0).reshape(3, 4)
+        y = pool(x)
+        self.assertEqual(y.shape, (3, 2))
+        # Each channel row is the mean over its two adaptive windows.
+        expected = jnp.stack([
+            jnp.array([(x[c, 0] + x[c, 1]) / 2, (x[c, 2] + x[c, 3]) / 2])
+            for c in range(3)
+        ])
+        np.testing.assert_allclose(np.asarray(y), np.asarray(expected), rtol=1e-6)
+
+
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/nn/_poolings_test.py
+++ b/brainstate/nn/_poolings_test.py
@@ -1689,5 +1689,126 @@ class TestPoolingAuditRegressions(unittest.TestCase):
         np.testing.assert_allclose(np.asarray(y), np.asarray(expected), rtol=1e-6)
 
 
+class TestPoolingSequenceBranchValidation(unittest.TestCase):
+    """Cover the ``Sequence``-but-not-``tuple``/``list`` and non-int-element
+    validation branches across the pooling base classes.
+
+    These branches fire for an argument that *is* a ``collections.abc.Sequence``
+    (so it passes the ``isinstance(x, Sequence)`` guard) yet is neither a tuple
+    nor a list -- e.g. a ``range`` object -- and for tuple/list arguments whose
+    elements are not all ints. The existing tests only exercise the outer
+    ``else`` (non-int, non-sequence) branch, so these complete the matrix.
+    """
+
+    # ------------------------------------------------------------------ _MaxPool
+
+    def test_maxpool_kernel_size_sequence_not_tuple_raises(self):
+        """A ``range`` kernel_size (a Sequence, not a tuple/list) is rejected."""
+        with self.assertRaisesRegex(TypeError, 'kernel_size should be a tuple'):
+            nn.MaxPool2d(range(2))
+
+    def test_maxpool_stride_sequence_not_tuple_raises(self):
+        """A ``range`` stride (a Sequence, not a tuple/list) is rejected."""
+        with self.assertRaisesRegex(TypeError, 'stride should be a tuple'):
+            nn.MaxPool2d(2, stride=range(2))
+
+    def test_maxpool_stride_non_int_elements_raises(self):
+        """A stride tuple containing a non-int element is rejected."""
+        with self.assertRaisesRegex(TypeError, 'stride should be a tuple of ints'):
+            nn.MaxPool2d(2, stride=(2.0, 2))
+
+    def test_maxpool_padding_tuple_sequence_wrong_length_raises(self):
+        """A sequence of ``(lo, hi)`` padding pairs of the wrong length is rejected.
+
+        Each entry is a valid 2-tuple, so validation falls through to the final
+        length check, which must reject a length that is neither 1 nor ``pool_dim``.
+        """
+        with self.assertRaisesRegex(ValueError, 'padding should has the length of 2'):
+            nn.MaxPool2d(2, padding=[(1, 1), (1, 1), (1, 1)])
+
+    # ---------------------------------------------------------------- _MaxUnpool
+
+    def test_maxunpool_kernel_size_sequence_not_tuple_raises(self):
+        """A ``range`` unpool kernel_size is rejected."""
+        with self.assertRaisesRegex(TypeError, 'kernel_size should be a tuple'):
+            nn.MaxUnpool2d(range(2))
+
+    def test_maxunpool_kernel_size_non_int_elements_raises(self):
+        """An unpool kernel tuple with a non-int element is rejected."""
+        with self.assertRaisesRegex(TypeError, 'kernel_size should be a tuple of ints'):
+            nn.MaxUnpool2d((2.0, 2))
+
+    def test_maxunpool_stride_sequence_not_tuple_raises(self):
+        """A ``range`` unpool stride is rejected."""
+        with self.assertRaisesRegex(TypeError, 'stride should be a tuple'):
+            nn.MaxUnpool2d(2, stride=range(2))
+
+    def test_maxunpool_stride_non_int_elements_raises(self):
+        """An unpool stride tuple with a non-int element is rejected."""
+        with self.assertRaisesRegex(TypeError, 'stride should be a tuple of ints'):
+            nn.MaxUnpool2d(2, stride=(2.0, 2))
+
+    def test_maxunpool_channel_axis_non_int_raises(self):
+        """A non-int, non-None unpool ``channel_axis`` is rejected."""
+        with self.assertRaisesRegex(TypeError, 'channel_axis should be an int'):
+            nn.MaxUnpool2d(2, channel_axis=1.5)
+
+    # ------------------------------------------------------------------- _LPPool
+
+    def test_lppool_kernel_size_sequence_not_tuple_raises(self):
+        """A ``range`` LP kernel_size is rejected."""
+        with self.assertRaisesRegex(TypeError, 'kernel_size should be a tuple'):
+            nn.LPPool2d(2, range(2))
+
+    def test_lppool_kernel_size_non_int_elements_raises(self):
+        """An LP kernel tuple with a non-int element is rejected."""
+        with self.assertRaisesRegex(TypeError, 'kernel_size should be a tuple of ints'):
+            nn.LPPool2d(2, (2.0, 2))
+
+    def test_lppool_stride_sequence_not_tuple_raises(self):
+        """A ``range`` LP stride is rejected."""
+        with self.assertRaisesRegex(TypeError, 'stride should be a tuple'):
+            nn.LPPool2d(2, 2, stride=range(2))
+
+    def test_lppool_padding_tuple_sequence_wrong_length_raises(self):
+        """A sequence of LP padding pairs of the wrong length is rejected."""
+        with self.assertRaisesRegex(ValueError, 'padding should has the length of 2'):
+            nn.LPPool2d(2, 2, padding=[(1, 1), (1, 1), (1, 1)])
+
+    def test_lppool_channel_axis_non_int_raises(self):
+        """A non-int, non-None LP ``channel_axis`` is rejected."""
+        with self.assertRaisesRegex(TypeError, 'channel_axis should be an int'):
+            nn.LPPool2d(2, 2, channel_axis=1.5)
+
+
+class TestAdaptivePoolHelperValidation(unittest.TestCase):
+    """Cover the lower-bound and element-type guards of adaptive pooling."""
+
+    def test_adaptive_pool1d_target_size_below_one_raises(self):
+        """The 1D helper rejects ``target_size < 1`` before any reshape.
+
+        This guard sits ahead of the ``size < target_size`` check, so it is only
+        reachable by calling the helper directly with a non-positive target (the
+        public layers reject ``target_size <= 0`` earlier in their constructor).
+        """
+        from brainstate.nn._poolings import _adaptive_pool1d
+        with self.assertRaisesRegex(ValueError, 'target_size must be >= 1'):
+            _adaptive_pool1d(jnp.arange(4.0), 0, jnp.mean)
+        with self.assertRaisesRegex(ValueError, 'target_size must be >= 1'):
+            _adaptive_pool1d(jnp.arange(4.0), -3, jnp.mean)
+
+    def test_adaptive_pool_target_size_non_int_entry_raises(self):
+        """A target-size tuple with a non-int, non-None entry is rejected.
+
+        This is distinct from the non-positive-entry case (``(2, -1)``): here the
+        offending entry is a float, so the ``isinstance(t, int)`` guard fires with
+        a ``TypeError`` rather than the value-range ``ValueError``.
+        """
+        with self.assertRaisesRegex(TypeError, 'target_size.*entries must be ints or None'):
+            nn.AdaptiveAvgPool2d((2, 2.5))
+        with self.assertRaisesRegex(TypeError, 'target_size.*entries must be ints or None'):
+            nn.AdaptiveMaxPool2d((2, 2.5))
+
+
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/nn/_regularization.py
+++ b/brainstate/nn/_regularization.py
@@ -155,15 +155,17 @@ class ChainedReg(Regularization):
         Overall regularization weight (lambda) that scales the combined loss.
         Default is 1.0.
     fit_hyper : bool, optional
-        Whether to optimize weight as a trainable parameter.
+        Stored on the instance and forwarded to component regularizations that
+        support trainable shape hyperparameters. The overall ``weight`` of the
+        chain itself is always a fixed constant and is never made trainable.
         Default is ``False``.
 
     Attributes
     ----------
     regularizations : tuple of Regularization
         The regularizations being combined.
-    weight : array_like or ParamState
-        Regularization weight (trainable if ``fit_hyper=True``).
+    weight : array_like
+        Fixed regularization weight (a constant, never trainable).
 
     Examples
     --------
@@ -283,7 +285,8 @@ class GaussianReg(Regularization):
     weight : float, optional
         Regularization weight (lambda). Default is 1.0.
     fit_hyper : bool, optional
-        Whether to optimize mean, precision, and weight as trainable parameters.
+        Whether to optimize ``mean`` and ``precision`` as trainable parameters.
+        The ``weight`` is always a fixed constant and is never made trainable.
         Default is ``False``.
 
     Attributes
@@ -292,8 +295,8 @@ class GaussianReg(Regularization):
         Prior mean (trainable if ``fit_hyper=True``).
     precision : array_like or ParamState
         Prior precision (trainable if ``fit_hyper=True``).
-    weight : array_like or ParamState
-        Regularization weight (trainable if ``fit_hyper=True``).
+    weight : array_like
+        Fixed regularization weight (a constant, never trainable).
 
     Examples
     --------
@@ -392,13 +395,14 @@ class L1Reg(Regularization):
     weight : float, optional
         Regularization weight (lambda). Default is 1.0.
     fit_hyper : bool, optional
-        Whether to optimize weight as a trainable parameter.
+        Stored on the instance for API consistency. ``L1Reg`` has no trainable
+        shape hyperparameters, so ``weight`` is always a fixed constant.
         Default is ``False``.
 
     Attributes
     ----------
-    weight : array_like or ParamState
-        Regularization weight (trainable if ``fit_hyper=True``).
+    weight : array_like
+        Fixed regularization weight (a constant, never trainable).
 
     Examples
     --------
@@ -488,13 +492,14 @@ class L2Reg(Regularization):
     weight : float, optional
         Regularization weight (lambda). Default is 1.0.
     fit_hyper : bool, optional
-        Whether to optimize weight as a trainable parameter.
+        Stored on the instance for API consistency. ``L2Reg`` has no trainable
+        shape hyperparameters, so ``weight`` is always a fixed constant.
         Default is ``False``.
 
     Attributes
     ----------
-    weight : array_like or ParamState
-        Regularization weight (trainable if ``fit_hyper=True``).
+    weight : array_like
+        Fixed regularization weight (a constant, never trainable).
 
     Examples
     --------
@@ -552,8 +557,10 @@ class L2Reg(Regularization):
         array_like
             Sample from N(0, 1/weight).
         """
-        # L2 prior corresponds to Gaussian with zero mean
-        std = 1.0 / u.math.sqrt(self.weight + 1e-8)
+        # L2 prior corresponds to Gaussian with zero mean. Clamp the weight with
+        # ``relu`` (matching ``loss``) before the sqrt so a negative weight yields
+        # a finite (large-variance) std instead of NaN.
+        std = 1.0 / u.math.sqrt(brainstate.nn.relu(get_value(self.weight)) + 1e-8)
         return std * brainstate.random.randn(*get_size(shape))
 
     def reset_value(self) -> Data:
@@ -589,8 +596,9 @@ class ElasticNetReg(Regularization):
         Mixing ratio between L1 and L2 (0 = pure L2, 1 = pure L1).
         Default is 0.5.
     fit_hyper : bool, optional
-        Whether to optimize weights as trainable parameters.
-        Default is ``False``.
+        Whether to optimize the mixing ratio ``alpha`` as a trainable parameter.
+        The ``l1_weight`` and ``l2_weight`` are always fixed constants and are
+        never made trainable. Default is ``False``.
 
     Examples
     --------
@@ -781,8 +789,10 @@ class HuberReg(Regularization):
         array_like
             Sample approximately from Huber prior (using Gaussian).
         """
-        # Approximate with Gaussian for simplicity
-        std = 1.0 / u.math.sqrt(self.weight)
+        # Approximate with Gaussian for simplicity. Clamp the weight with ``relu``
+        # (matching ``loss``) and add an epsilon so a non-positive weight yields a
+        # finite std instead of NaN/inf.
+        std = 1.0 / u.math.sqrt(brainstate.nn.relu(get_value(self.weight)) + 1e-8)
         return std * brainstate.random.randn(*get_size(shape))
 
     def reset_value(self) -> Data:
@@ -844,6 +854,15 @@ class GroupLassoReg(Regularization):
     ):
         super().__init__(fit_hyper)
 
+        # ``group_size`` is used as a divisor (``n % group_size``) and reshape
+        # dimension, so it must be a positive integer. A value of 0 raises
+        # ZeroDivisionError and a negative value silently mis-groups via Python's
+        # modulo semantics; reject both up front.
+        if not isinstance(group_size, int):
+            raise TypeError(f"group_size must be an int, but got {type(group_size)}.")
+        if group_size <= 0:
+            raise ValueError(f"group_size must be a positive integer, but got {group_size}.")
+
         weight_t = u.math.asarray(weight, dtype=brainstate.environ.dftype())
         self.weight = weight_t
         self.group_size = group_size
@@ -903,7 +922,9 @@ class GroupLassoReg(Regularization):
         array_like
             Sample (using Gaussian approximation).
         """
-        std = 1.0 / u.math.sqrt(self.weight)
+        # Clamp the weight with ``relu`` (matching ``loss``) and add an epsilon so
+        # a non-positive weight yields a finite std instead of NaN/inf.
+        std = 1.0 / u.math.sqrt(brainstate.nn.relu(get_value(self.weight)) + 1e-8)
         return std * brainstate.random.randn(*get_size(shape))
 
     def reset_value(self) -> Data:
@@ -967,6 +988,12 @@ class TotalVariationReg(Regularization):
     ):
         super().__init__(fit_hyper)
 
+        # Only first- and second-order finite differences are implemented; any
+        # other value was previously silently treated as order 2. Reject it so a
+        # typo (e.g. ``order=3``) does not produce a misleading result.
+        if order not in (1, 2):
+            raise ValueError(f"order must be 1 or 2, but got {order}.")
+
         weight_t = u.math.asarray(weight, dtype=brainstate.environ.dftype())
         self.weight = weight_t
         self.order = order
@@ -1012,7 +1039,9 @@ class TotalVariationReg(Regularization):
         array_like
             Smooth sample using cumulative sum of noise.
         """
-        std = 1.0 / u.math.sqrt(self.weight)
+        # Clamp the weight with ``relu`` (matching ``loss``) and add an epsilon so
+        # a non-positive weight yields a finite std instead of NaN/inf.
+        std = 1.0 / u.math.sqrt(brainstate.nn.relu(get_value(self.weight)) + 1e-8)
         # Generate smooth samples using cumulative sum
         noise = std * brainstate.random.randn(*get_size(shape))
         return u.math.cumsum(noise.flatten()).reshape(get_size(shape)) / u.math.sqrt(
@@ -1178,6 +1207,11 @@ class EntropyReg(Regularization):
     -----
     Entropy regularization is useful in attention mechanisms and
     reinforcement learning to encourage exploration.
+
+    The softmax is computed over **all** elements flattened together (one global
+    distribution), not per-row. For a ``(batch, K)`` input this yields a single
+    ``batch * K``-way distribution rather than ``batch`` independent ``K``-way
+    ones, so the per-element wording above only matches a 1-D input.
     """
 
     __module__ = 'brainstate.nn'
@@ -1529,14 +1563,17 @@ class SpectralNormReg(Regularization):
 
         sample = brainstate.random.randn(*shape_tuple)
 
-        # Scale by max_value / estimated_norm
+        # Rescale the sample so its (estimated) spectral norm matches the requested
+        # ``max_value`` -- i.e. it sits right at the constraint boundary that
+        # ``loss`` penalises. The previous extra ``* 0.5`` factor systematically
+        # produced samples at only half the requested spectral norm.
         if len(shape_tuple) >= 2:
             sigma = self._estimate_spectral_norm(sample)
-            scale = max_val / (sigma + 1e-8) * 0.5
+            scale = max_val / (sigma + 1e-8)
             return sample * scale
         else:
             norm = u.math.sqrt(u.math.sum(sample ** 2) + 1e-8)
-            return sample * max_val / (norm + 1e-8) * 0.5
+            return sample * max_val / (norm + 1e-8)
 
     def reset_value(self) -> Data:
         """
@@ -2906,6 +2943,10 @@ class DirichletReg(Regularization):
     Dirichlet prior is appropriate for attention weights, mixture proportions,
     and other probability simplexes. alpha=1 is uniform, alpha<1 encourages
     sparsity, alpha>1 encourages uniformity.
+
+    The softmax/simplex is formed over **all** elements flattened together (one
+    global simplex), not per-row: a ``(batch, K)`` input becomes a single
+    ``batch * K``-way simplex rather than ``batch`` independent ``K``-way ones.
     """
 
     __module__ = 'brainstate.nn'

--- a/brainstate/nn/_regularization.py
+++ b/brainstate/nn/_regularization.py
@@ -26,6 +26,7 @@ from abc import ABC, abstractmethod
 
 import brainstate
 import brainunit as u
+from jax.scipy.special import gammaln
 
 from ._module import Module
 from ._utils import get_size, get_value
@@ -1120,9 +1121,13 @@ class MaxNormReg(Regularization):
         # Sample from Gaussian and project to ball
         sample = brainstate.random.randn(*get_size(shape))
         norm = u.math.sqrt(u.math.sum(sample ** 2) + 1e-8)
-        # Scale to be within the ball
+        # Scale to be within the ball. The scale (max_val / norm * 0.5) already
+        # places the sample safely inside the ball of radius max_val, so it must
+        # be applied directly. Clamping it with ``minimum(scale, 1.0)`` wrongly
+        # capped the scale at 1.0 and prevented scaling *up* toward large
+        # max_value targets (e.g. max_value=100 collapsed the norm to ~1).
         scale = max_val / (norm + 1e-8) * 0.5  # 0.5 to be safely inside
-        return sample * u.math.minimum(scale, 1.0)
+        return sample * scale
 
     def reset_value(self) -> Data:
         """
@@ -1314,6 +1319,12 @@ class OrthogonalReg(Regularization):
             Orthogonality penalty.
         """
 
+        # 0-d (scalar) weight: there is no matrix to orthogonalize, so fall back
+        # to a scalar penalty driving |value| toward 1 (an orthogonal 1x1 matrix
+        # has |entry| == 1). This avoids an IndexError from value.shape[0].
+        if len(value.shape) == 0:
+            return self.weight * (u.math.abs(value) - 1.0) ** 2
+
         # Ensure 2D matrix
         if len(value.shape) == 1:
             # For 1D, reshape to column vector
@@ -1444,7 +1455,15 @@ class SpectralNormReg(Regularization):
 
     def _estimate_spectral_norm(self, W: Data) -> Data:
         """
-        Estimate spectral norm using power iteration.
+        Compute the spectral norm (largest singular value) of ``W``.
+
+        For 2-D matrices the spectral norm is obtained deterministically via the
+        SVD (``svd(W, compute_uv=False)[0]`` returns the largest singular value,
+        which equals ``jnp.linalg.norm(W, ord=2)``). This makes :meth:`loss`
+        deterministic and differentiable, rather than depending on a freshly
+        drawn random vector for power iteration. The ``n_power_iterations``
+        attribute is retained for API compatibility but is unused by the 2-D
+        path. The random draw is reserved for :meth:`sample_init` only.
 
         Parameters
         ----------
@@ -1454,27 +1473,20 @@ class SpectralNormReg(Regularization):
         Returns
         -------
         array_like
-            Estimated spectral norm.
+            Spectral norm.
         """
+        # 0-d (scalar) weight: spectral norm of a scalar is its absolute value.
+        if len(W.shape) == 0:
+            return u.math.abs(W)
         # Ensure 2D
         if len(W.shape) == 1:
             return u.math.sqrt(u.math.sum(W ** 2))
         elif len(W.shape) > 2:
             W = u.math.reshape(W, (W.shape[0], -1))
 
-        # Power iteration
-        v = brainstate.random.randn(W.shape[1])
-        v = v / (u.math.sqrt(u.math.sum(v ** 2)) + 1e-8)
-
-        for _ in range(self.n_power_iterations):
-            u_ = u.math.matmul(W, v)
-            u_ = u_ / (u.math.sqrt(u.math.sum(u_ ** 2)) + 1e-8)
-            v = u.math.matmul(W.T, u_)
-            v = v / (u.math.sqrt(u.math.sum(v ** 2)) + 1e-8)
-
-        # Spectral norm estimate
-        Wv = u.math.matmul(W, v)
-        sigma = u.math.sqrt(u.math.sum(Wv ** 2) + 1e-8)
+        # Largest singular value via SVD (deterministic, differentiable).
+        # svd returns singular values in descending order, so [0] is the largest.
+        sigma = u.math.linalg.svd(W, compute_uv=False)[0]
         return sigma
 
     def loss(self, value: Data) -> Data:
@@ -1551,9 +1563,15 @@ class StudentTReg(Regularization):
     Student's t-distribution, which has heavier tails than Gaussian:
 
     .. math::
-        L = \lambda \sum_i \log\left(1 + \frac{(x_i / s)^2}{\nu}\right)
+        L = \lambda \left[ \sum_i \frac{\nu + 1}{2}
+            \log\left(1 + \frac{(x_i / s)^2}{\nu}\right)
+            + N \left( \log s + \log\Gamma(\tfrac{\nu}{2})
+            + \tfrac{1}{2}\log(\nu\pi) - \log\Gamma(\tfrac{\nu+1}{2}) \right) \right]
 
-    where :math:`\nu` is the degrees of freedom and :math:`s` is the scale.
+    where :math:`\nu` is the degrees of freedom, :math:`s` is the scale, and
+    :math:`N` is the number of elements. The :math:`\log s` and
+    :math:`\Gamma`-based terms form the scale/df log-normalizer, which keeps the
+    loss bounded below when ``scale``/``df`` are trained (``fit_hyper=True``).
 
     Parameters
     ----------
@@ -1625,7 +1643,18 @@ class StudentTReg(Regularization):
         # Student-t negative-log-likelihood data term: 0.5*(df+1)*log(1 + z**2/df).
         # The (df+1)/2 factor is df-dependent; without it the penalty wrongly
         # vanishes as df -> infinity instead of approaching the Gaussian 0.5*z**2.
-        return self.weight * u.math.sum(0.5 * (df + 1.0) * u.math.log(1.0 + z ** 2 / df))
+        data_term = u.math.sum(0.5 * (df + 1.0) * u.math.log(1.0 + z ** 2 / df))
+        # Scale/df log-normalizer of the Student-t NLL. Per element this is
+        # log(scale) + gammaln(df/2) + 0.5*log(df*pi) - gammaln((df+1)/2); without
+        # it the loss is unbounded below as scale (or df) is fit, so a fit_hyper
+        # gradient loop on scale/df diverges to +/- inf instead of converging.
+        log_norm = value.size * (
+            u.math.log(scale)
+            + gammaln(df / 2.0)
+            + 0.5 * u.math.log(df * math.pi)
+            - gammaln((df + 1.0) / 2.0)
+        )
+        return self.weight * (data_term + log_norm)
 
     def sample_init(self, shape: Size) -> Data:
         """
@@ -1668,7 +1697,10 @@ class CauchyReg(Regularization):
     Cauchy distribution (Student's t with df=1), which has very heavy tails:
 
     .. math::
-        L = \lambda \sum_i \log\left(1 + (x_i / s)^2\right)
+        L = \lambda \left[ \sum_i \log\left(1 + (x_i / s)^2\right) + N \log s \right]
+
+    where :math:`N` is the number of elements and :math:`N \log s` is the scale
+    log-normalizer that keeps the loss bounded below when ``scale`` is trained.
 
     Parameters
     ----------
@@ -1729,7 +1761,12 @@ class CauchyReg(Regularization):
         scale = u.math.relu(get_value(self.scale)) + 1e-8
 
         z = value / scale
-        return self.weight * u.math.sum(u.math.log(1.0 + z ** 2))
+        # log(1 + z**2) is the data term; value.size*log(scale) is the scale
+        # log-normalizer of the Cauchy NLL. Without it, the loss decreases without
+        # bound as ``scale`` grows, so a fit_hyper gradient loop on scale diverges.
+        data_term = u.math.sum(u.math.log(1.0 + z ** 2))
+        log_norm = value.size * u.math.log(scale)
+        return self.weight * (data_term + log_norm)
 
     def sample_init(self, shape: Size) -> Data:
         """
@@ -1881,7 +1918,12 @@ class LogNormalReg(Regularization):
     log-normal distribution:
 
     .. math::
-        L = \lambda \sum_i \left(\frac{(\log x_i - \mu)^2}{2\sigma^2} + \log x_i\right)
+        L = \lambda \left[ \sum_i \left(\frac{(\log x_i - \mu)^2}{2\sigma^2}
+            + \log x_i\right) + N \log\sigma \right]
+
+    where :math:`N` is the number of elements and :math:`N \log\sigma` is the
+    scale log-normalizer that keeps the loss bounded below when ``sigma`` is
+    trained.
 
     Parameters
     ----------
@@ -1951,7 +1993,13 @@ class LogNormalReg(Regularization):
         # Ensure positive values
         x_pos = u.math.relu(value) + 1e-8
         log_x = u.math.log(x_pos)
-        return self.weight * u.math.sum((log_x - mu) ** 2 / (2 * sigma ** 2) + log_x)
+        # (log_x - mu)**2 / (2 sigma**2) + log_x is the data term; value.size*
+        # log(sigma) is the scale log-normalizer of the log-normal NLL. Without
+        # it the loss decreases without bound as ``sigma`` grows, so a fit_hyper
+        # gradient loop on sigma diverges.
+        data_term = u.math.sum((log_x - mu) ** 2 / (2 * sigma ** 2) + log_x)
+        log_norm = value.size * u.math.log(sigma)
+        return self.weight * (data_term + log_norm)
 
     def sample_init(self, shape: Size) -> Data:
         """
@@ -2096,7 +2144,12 @@ class GammaReg(Regularization):
     Gamma distribution:
 
     .. math::
-        L = -\lambda \sum_i \left((\alpha - 1) \log x_i - \beta x_i\right)
+        L = \lambda \left[ \sum_i \left(-(\alpha - 1) \log x_i + \beta x_i\right)
+            + N \left( -\alpha \log\beta + \log\Gamma(\alpha) \right) \right]
+
+    where :math:`N` is the number of elements. The
+    :math:`-\alpha \log\beta + \log\Gamma(\alpha)` term is the log-normalizer
+    that keeps the loss bounded below when ``alpha``/``beta`` are trained.
 
     Parameters
     ----------
@@ -2165,8 +2218,13 @@ class GammaReg(Regularization):
 
         # Ensure positive values
         x_pos = u.math.relu(value) + 1e-8
-        # Negative log-likelihood (ignoring constants)
-        return self.weight * u.math.sum(-(alpha - 1) * u.math.log(x_pos) + beta * x_pos)
+        # Data term: -(alpha-1)*log(x) + beta*x. The per-element log-normalizer of
+        # the Gamma NLL is -alpha*log(beta) + gammaln(alpha); without it the loss
+        # is unbounded below as alpha/beta are fit, so a fit_hyper gradient loop
+        # diverges instead of converging.
+        data_term = u.math.sum(-(alpha - 1) * u.math.log(x_pos) + beta * x_pos)
+        log_norm = value.size * (-alpha * u.math.log(beta) + gammaln(alpha))
+        return self.weight * (data_term + log_norm)
 
     def sample_init(self, shape: Size) -> Data:
         """
@@ -2211,7 +2269,13 @@ class BetaReg(Regularization):
     Beta distribution:
 
     .. math::
-        L = -\lambda \sum_i \left((a - 1) \log x_i + (b - 1) \log(1 - x_i)\right)
+        L = \lambda \left[ \sum_i \left(-(a - 1) \log x_i - (b - 1) \log(1 - x_i)\right)
+            + N \left( \log\Gamma(a) + \log\Gamma(b) - \log\Gamma(a + b) \right) \right]
+
+    where :math:`N` is the number of elements. The
+    :math:`\log B(a, b) = \log\Gamma(a) + \log\Gamma(b) - \log\Gamma(a + b)` term
+    is the log-normalizer that keeps the loss bounded below when ``a``/``b`` are
+    trained.
 
     Parameters
     ----------
@@ -2280,8 +2344,13 @@ class BetaReg(Regularization):
 
         # Clip to (0, 1) for numerical stability
         x_clip = u.math.clip(value, 1e-8, 1.0 - 1e-8)
-        # Negative log-likelihood (ignoring constants)
-        return self.weight * u.math.sum(-(a - 1) * u.math.log(x_clip) - (b - 1) * u.math.log(1 - x_clip))
+        # Data term: -(a-1)*log(x) - (b-1)*log(1-x). The per-element
+        # log-normalizer of the Beta NLL is log B(a, b) = gammaln(a) + gammaln(b)
+        # - gammaln(a+b); without it the loss is unbounded below as a/b are fit,
+        # so a fit_hyper gradient loop diverges instead of converging.
+        data_term = u.math.sum(-(a - 1) * u.math.log(x_clip) - (b - 1) * u.math.log(1 - x_clip))
+        log_norm = value.size * (gammaln(a) + gammaln(b) - gammaln(a + b))
+        return self.weight * (data_term + log_norm)
 
     def sample_init(self, shape: Size) -> Data:
         """
@@ -2324,7 +2393,10 @@ class HorseshoeReg(Regularization):
     log-penalty formulation:
 
     .. math::
-        L = \lambda \sum_i \log\left(1 + (x_i / \tau)^2\right)
+        L = \lambda \left[ \sum_i \log\left(1 + (x_i / \tau)^2\right) + N \log\tau \right]
+
+    where :math:`N` is the number of elements and :math:`N \log\tau` is the scale
+    log-normalizer that keeps the loss bounded below when ``tau`` is trained.
 
     Parameters
     ----------
@@ -2386,7 +2458,12 @@ class HorseshoeReg(Regularization):
         tau = u.math.relu(get_value(self.tau)) + 1e-8
 
         z = value / tau
-        return self.weight * u.math.sum(u.math.log(1.0 + z ** 2))
+        # log(1 + z**2) is the data term; value.size*log(tau) is the scale
+        # log-normalizer. Without it, the penalty decreases without bound as
+        # ``tau`` grows, so a fit_hyper gradient loop on tau diverges.
+        data_term = u.math.sum(u.math.log(1.0 + z ** 2))
+        log_norm = value.size * u.math.log(tau)
+        return self.weight * (data_term + log_norm)
 
     def sample_init(self, shape: Size) -> Data:
         """
@@ -2429,7 +2506,12 @@ class InverseGammaReg(Regularization):
     Inverse-Gamma distribution:
 
     .. math::
-        L = \lambda \sum_i \left((\alpha + 1) \log x_i + \frac{\beta}{x_i}\right)
+        L = \lambda \left[ \sum_i \left((\alpha + 1) \log x_i + \frac{\beta}{x_i}\right)
+            + N \left( -\alpha \log\beta + \log\Gamma(\alpha) \right) \right]
+
+    where :math:`N` is the number of elements. The
+    :math:`-\alpha \log\beta + \log\Gamma(\alpha)` term is the log-normalizer
+    that keeps the loss bounded below when ``alpha``/``beta`` are trained.
 
     Parameters
     ----------
@@ -2498,8 +2580,13 @@ class InverseGammaReg(Regularization):
 
         # Ensure positive values
         x_pos = u.math.relu(value) + 1e-8
-        # Negative log-likelihood (ignoring constants)
-        return self.weight * u.math.sum((alpha + 1) * u.math.log(x_pos) + beta / x_pos)
+        # Data term: (alpha+1)*log(x) + beta/x. The per-element log-normalizer of
+        # the Inverse-Gamma NLL is -alpha*log(beta) + gammaln(alpha); without it
+        # the loss is unbounded below as alpha/beta are fit, so a fit_hyper
+        # gradient loop diverges instead of converging.
+        data_term = u.math.sum((alpha + 1) * u.math.log(x_pos) + beta / x_pos)
+        log_norm = value.size * (-alpha * u.math.log(beta) + gammaln(alpha))
+        return self.weight * (data_term + log_norm)
 
     def sample_init(self, shape: Size) -> Data:
         """

--- a/brainstate/nn/_regularization_test.py
+++ b/brainstate/nn/_regularization_test.py
@@ -389,6 +389,32 @@ class TestGroupLassoReg(unittest.TestCase):
         reg = GroupLassoReg(weight=1.0, group_size=2, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
 
+    def test_non_int_group_size_raises_typeerror(self):
+        """A non-integer ``group_size`` raises TypeError, not a later crash.
+
+        ``group_size`` is used as a divisor and reshape dimension, so it must be
+        an int. A float (even one with integer value) must be rejected up front
+        with a clear ``TypeError`` naming the offending type.
+        """
+        with self.assertRaises(TypeError) as ctx:
+            GroupLassoReg(weight=1.0, group_size=2.0)
+        self.assertIn('group_size', str(ctx.exception))
+        self.assertIn('int', str(ctx.exception))
+        with self.assertRaises(TypeError):
+            GroupLassoReg(weight=1.0, group_size='2')
+
+    def test_non_positive_group_size_raises_valueerror(self):
+        """A zero or negative ``group_size`` raises ValueError.
+
+        Zero would raise ``ZeroDivisionError`` and a negative value would
+        silently mis-group via Python modulo semantics, so both are rejected.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            GroupLassoReg(weight=1.0, group_size=0)
+        self.assertIn('positive', str(ctx.exception))
+        with self.assertRaises(ValueError):
+            GroupLassoReg(weight=1.0, group_size=-3)
+
 
 class TestTotalVariationReg(unittest.TestCase):
     """Tests for Total Variation regularization."""

--- a/brainstate/nn/_regularization_test.py
+++ b/brainstate/nn/_regularization_test.py
@@ -19,8 +19,28 @@ import unittest
 
 import brainstate
 import brainunit as u
+import jax
 import jax.numpy as jnp
 import numpy as np
+
+
+def _fit_scalar_hyper(make_reg, value, init, steps=300, lr=0.05):
+    """Gradient-descent on a single scalar hyperparameter.
+
+    ``make_reg(h)`` must build a fresh regularizer whose trainable scale/shape
+    hyperparameter is set to ``h``; the loss is taken from that regularizer's
+    ``loss(value)``. Returns ``(final_h, final_loss)``. Used to verify that the
+    distribution log-normalizer keeps the loss bounded below, so descent
+    converges to a finite interior optimum instead of diverging to +/- inf.
+    """
+    def loss_of(h):
+        return make_reg(h).loss(value)
+
+    h = jnp.asarray(init, dtype=brainstate.environ.dftype())
+    grad_fn = jax.grad(loss_of)
+    for _ in range(steps):
+        h = h - lr * grad_fn(h)
+    return float(h), float(loss_of(h))
 
 from brainstate.nn import (
     ChainedReg,
@@ -445,6 +465,17 @@ class TestMaxNormReg(unittest.TestCase):
         norm = jnp.sqrt(jnp.sum(sample ** 2))
         self.assertLessEqual(float(norm), 2.0 + 1e-5)
 
+    def test_sample_init_scales_up_to_large_max_value(self):
+        """sample_init must scale toward large max_value, not cap at ~1 (bug M19)."""
+        # A single scalar sample has |sample| as its norm; the projection target
+        # is max_value * 0.5. With max_value=100 the resulting norm must be ~50,
+        # not ~1 (which the old ``minimum(scale, 1.0)`` cap produced).
+        brainstate.random.seed(0)
+        reg = MaxNormReg(weight=1.0, max_value=100.0)
+        sample = reg.sample_init(shape=(1,))
+        norm = float(jnp.sqrt(jnp.sum(sample ** 2)))
+        np.testing.assert_allclose(norm, 50.0, rtol=1e-4)
+
     def test_reset_value(self):
         """Test reset_value returns zero."""
         reg = MaxNormReg(weight=1.0, max_value=1.0)
@@ -530,6 +561,17 @@ class TestOrthogonalReg(unittest.TestCase):
             sample = reg.sample_init((n,))
             self.assertEqual(sample.shape, (n,))
 
+    def test_loss_scalar_weight_no_indexerror(self):
+        """0-d (scalar) value must not raise IndexError and stays finite (bug L14)."""
+        reg = OrthogonalReg(weight=1.0)
+        # |1.0| == 1 -> an orthogonal 1x1 matrix -> zero penalty.
+        loss_one = reg.loss(jnp.array(1.0))
+        np.testing.assert_allclose(float(loss_one), 0.0, atol=1e-6)
+        self.assertTrue(np.isfinite(float(loss_one)))
+        # weight * (|value| - 1)**2 = 2 * (3 - 1)**2 = 8.
+        reg2 = OrthogonalReg(weight=2.0)
+        np.testing.assert_allclose(float(reg2.loss(jnp.array(3.0))), 8.0, rtol=1e-6)
+
     def test_reset_value(self):
         """Test reset_value returns zero."""
         reg = OrthogonalReg(weight=1.0)
@@ -559,6 +601,48 @@ class TestSpectralNormReg(unittest.TestCase):
         loss = reg.loss(W)
         # (3 - 1)^2 = 4
         np.testing.assert_allclose(loss, 4.0, rtol=0.1)
+
+    def test_loss_deterministic_2d(self):
+        """2-D loss must be deterministic across calls (bugs H10, M20).
+
+        Uses the DEFAULT n_power_iterations; the old power-iteration path drew a
+        fresh random vector per call, making loss/grad non-deterministic.
+        """
+        reg = SpectralNormReg(weight=1.0, max_value=1.0)  # default n_power_iterations
+        W = jnp.diag(jnp.array([2.0, 0.5]))
+        losses = [float(reg.loss(W)) for _ in range(5)]
+        # All identical across repeated calls.
+        for l in losses[1:]:
+            self.assertEqual(l, losses[0])
+        # Equals the analytic top-singular-value penalty:
+        # sigma = 2 (largest singular value of diag([2, 0.5])); max_val = 1 + 1e-8;
+        # loss = weight * relu(sigma - max_val)**2.
+        max_val = 1.0 + 1e-8
+        expected = (2.0 - max_val) ** 2
+        np.testing.assert_allclose(losses[0], expected, rtol=1e-5)
+
+    def test_grad_stable_2d(self):
+        """jax.grad of the 2-D loss must be stable across calls (bugs H10, M20)."""
+        reg = SpectralNormReg(weight=1.0, max_value=1.0)  # default n_power_iterations
+        W = jnp.diag(jnp.array([2.0, 0.5]))
+        grad_fn = jax.grad(lambda w: reg.loss(w))
+        g1 = grad_fn(W)
+        g2 = grad_fn(W)
+        np.testing.assert_array_equal(np.asarray(g1), np.asarray(g2))
+        self.assertTrue(np.all(np.isfinite(np.asarray(g1))))
+
+    def test_loss_scalar_weight_no_indexerror(self):
+        """0-d (scalar) value must not raise IndexError (bug L14)."""
+        reg = SpectralNormReg(weight=1.0, max_value=1.0)
+        # Spectral norm of a scalar is its absolute value.
+        np.testing.assert_allclose(
+            float(reg._estimate_spectral_norm(jnp.array(3.0))), 3.0, rtol=1e-6
+        )
+        # loss must run without raising and be finite.
+        loss = reg.loss(jnp.array(3.0))
+        self.assertTrue(np.isfinite(float(loss)))
+        # sigma = 3, max_val = 1 + 1e-8 -> weight * relu(3 - max_val)**2 ~ 4.
+        np.testing.assert_allclose(float(loss), (3.0 - (1.0 + 1e-8)) ** 2, rtol=1e-5)
 
     def test_sample_init_shape(self):
         """Test sample_init returns correct shape."""
@@ -631,37 +715,60 @@ class TestStudentTReg(unittest.TestCase):
     """Tests for Student's t-distribution regularization."""
 
     def test_basic_loss(self):
-        """Test Student-t loss computation."""
+        """Test Student-t loss computation at x=0 (data term vanishes)."""
+        from scipy.special import gammaln as sp_gammaln
         reg = StudentTReg(weight=1.0, df=3.0, scale=1.0)
         value = jnp.array([0.0])
         loss = reg.loss(value)
-        # At x=0, loss = log(1 + 0) = 0
-        np.testing.assert_allclose(loss, 0.0, atol=1e-5)
+        # At x=0 the data term log(1 + 0) = 0, so the loss equals the scale/df
+        # log-normalizer: log(scale) + gammaln(df/2) + 0.5*log(df*pi)
+        #                 - gammaln((df+1)/2).
+        df = 3.0
+        expected = (
+            np.log(1.0)
+            + sp_gammaln(df / 2.0)
+            + 0.5 * np.log(df * np.pi)
+            - sp_gammaln((df + 1.0) / 2.0)
+        )
+        np.testing.assert_allclose(float(loss), expected, rtol=1e-5)
 
     def test_nll_factor_df3(self):
         """Per-element penalty must include the (df+1)/2 factor (bug R1)."""
+        from scipy.special import gammaln as sp_gammaln
         reg = StudentTReg(weight=1.0, df=3.0, scale=1.0)
         value = jnp.array([2.0])
         loss = reg.loss(value)
         # Correct Student-t NLL data term: 0.5*(df+1)*log(1 + z**2/df)
         # df=3, z=2 -> 0.5*4*log(1 + 4/3) = 2*log(7/3) ~ 1.6946
-        expected = 0.5 * (3.0 + 1.0) * np.log(1.0 + 4.0 / 3.0)
+        df = 3.0
+        data_term = 0.5 * (df + 1.0) * np.log(1.0 + 4.0 / 3.0)
+        # Plus the scale/df log-normalizer (bug M18).
+        log_norm = (
+            np.log(1.0)
+            + sp_gammaln(df / 2.0)
+            + 0.5 * np.log(df * np.pi)
+            - sp_gammaln((df + 1.0) / 2.0)
+        )
+        expected = data_term + log_norm
         np.testing.assert_allclose(float(loss), expected, rtol=1e-5)
-        # And it must NOT equal the unfactored value ~0.847
+        # The data term must NOT equal the unfactored value ~0.847.
         unfactored = np.log(1.0 + 4.0 / 3.0)
-        self.assertGreater(float(loss), unfactored * 1.5)
+        self.assertGreater(data_term, unfactored * 1.5)
 
     def test_gaussian_limit_large_df(self):
-        """As df -> infinity the penalty approaches the Gaussian 0.5*z**2 (bug R1)."""
+        """As df -> infinity the full NLL approaches the Gaussian NLL (bugs R1, M18)."""
         # Use float64 so the assertion exercises the math, not float32 rounding
-        # of log(1 + 4e-6). Under float32 the value is ~2.027 (a precision
-        # artifact); the limit itself is correct.
+        # of log(1 + 4e-6). Under float32 the value is a precision artifact; the
+        # limit itself is correct.
         with brainstate.environ.context(precision=64):
             reg = StudentTReg(weight=1.0, df=1e6, scale=1.0)
             value = jnp.asarray([2.0], dtype=brainstate.environ.dftype())
             loss = reg.loss(value)
-        gaussian_limit = 0.5 * 2.0 ** 2  # 2.0
-        np.testing.assert_allclose(float(loss), gaussian_limit, rtol=1e-3)
+        # With the scale/df log-normalizer included, the full Student-t NLL
+        # converges to the Gaussian NLL = 0.5*z**2 + 0.5*log(2*pi) + log(scale),
+        # not to the bare 0.5*z**2 data term.
+        gaussian_nll = 0.5 * 2.0 ** 2 + 0.5 * np.log(2.0 * np.pi) + np.log(1.0)
+        np.testing.assert_allclose(float(loss), gaussian_nll, rtol=1e-3)
 
     def test_loss_increases_with_distance(self):
         """Test that loss increases with distance from zero."""
@@ -700,6 +807,21 @@ class TestStudentTReg(unittest.TestCase):
         """Test that fit_hyper=True is stored correctly."""
         reg = StudentTReg(weight=1.0, df=3.0, scale=1.0, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
+
+    def test_fit_scale_converges(self):
+        """Fitting the scale converges to a finite interior value (bug M18).
+
+        Without the scale log-normalizer the loss decreases without bound as
+        scale grows, so gradient descent diverges.
+        """
+        value = jnp.array([0.5, -0.3, 0.8, 1.2, -0.6])
+        final_scale, final_loss = _fit_scalar_hyper(
+            lambda h: StudentTReg(weight=1.0, df=3.0, scale=h), value, init=2.0
+        )
+        self.assertTrue(np.isfinite(final_scale))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_scale, 1e-3)  # interior, not collapsed/diverged
+        self.assertLess(final_scale, 1e3)
 
     def test_inherits_from_module(self):
         """Test StudentTReg inherits from brainstate.nn.Module."""
@@ -742,6 +864,17 @@ class TestCauchyReg(unittest.TestCase):
         """Test that fit_hyper=True is stored correctly."""
         reg = CauchyReg(weight=1.0, scale=1.0, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
+
+    def test_fit_scale_converges(self):
+        """Fitting the scale converges to a finite interior value (bug M18)."""
+        value = jnp.array([0.5, -0.3, 0.8, 1.2, -0.6])
+        final_scale, final_loss = _fit_scalar_hyper(
+            lambda h: CauchyReg(weight=1.0, scale=h), value, init=2.0
+        )
+        self.assertTrue(np.isfinite(final_scale))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_scale, 1e-3)
+        self.assertLess(final_scale, 1e3)
 
     def test_inherits_from_module(self):
         """Test CauchyReg inherits from brainstate.nn.Module."""
@@ -839,6 +972,17 @@ class TestLogNormalReg(unittest.TestCase):
         reg = LogNormalReg(weight=1.0, mu=0.0, sigma=1.0, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
 
+    def test_fit_sigma_converges(self):
+        """Fitting sigma converges to a finite interior value (bug M18)."""
+        value = jnp.array([0.5, 1.0, 2.0, 1.5, 0.8])
+        final_sigma, final_loss = _fit_scalar_hyper(
+            lambda h: LogNormalReg(weight=1.0, mu=0.0, sigma=h), value, init=2.0
+        )
+        self.assertTrue(np.isfinite(final_sigma))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_sigma, 1e-3)
+        self.assertLess(final_sigma, 1e3)
+
     def test_inherits_from_module(self):
         """Test LogNormalReg inherits from brainstate.nn.Module."""
         reg = LogNormalReg(weight=1.0, mu=0.0, sigma=1.0)
@@ -928,6 +1072,28 @@ class TestGammaReg(unittest.TestCase):
         reg = GammaReg(weight=1.0, alpha=2.0, beta=1.0, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
 
+    def test_fit_beta_converges(self):
+        """Fitting beta converges to a finite interior value (bug M21)."""
+        value = jnp.array([0.5, 1.0, 2.0, 1.5, 0.8])
+        final_beta, final_loss = _fit_scalar_hyper(
+            lambda h: GammaReg(weight=1.0, alpha=2.0, beta=h), value, init=2.0
+        )
+        self.assertTrue(np.isfinite(final_beta))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_beta, 1e-3)
+        self.assertLess(final_beta, 1e3)
+
+    def test_fit_alpha_converges(self):
+        """Fitting alpha converges to a finite interior value (bug M21)."""
+        value = jnp.array([0.5, 1.0, 2.0, 1.5, 0.8])
+        final_alpha, final_loss = _fit_scalar_hyper(
+            lambda h: GammaReg(weight=1.0, alpha=h, beta=1.0), value, init=3.0
+        )
+        self.assertTrue(np.isfinite(final_alpha))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_alpha, 1e-3)
+        self.assertLess(final_alpha, 1e3)
+
     def test_inherits_from_module(self):
         """Test GammaReg inherits from brainstate.nn.Module."""
         reg = GammaReg(weight=1.0, alpha=2.0, beta=1.0)
@@ -968,6 +1134,17 @@ class TestBetaReg(unittest.TestCase):
         """Test that fit_hyper=True is stored correctly."""
         reg = BetaReg(weight=1.0, a=2.0, b=2.0, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
+
+    def test_fit_a_converges(self):
+        """Fitting shape parameter a converges to a finite interior value (bug M21)."""
+        value = jnp.array([0.3, 0.5, 0.7, 0.4, 0.6])
+        final_a, final_loss = _fit_scalar_hyper(
+            lambda h: BetaReg(weight=1.0, a=h, b=2.0), value, init=3.0
+        )
+        self.assertTrue(np.isfinite(final_a))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_a, 1e-3)
+        self.assertLess(final_a, 1e3)
 
     def test_inherits_from_module(self):
         """Test BetaReg inherits from brainstate.nn.Module."""
@@ -1012,6 +1189,17 @@ class TestHorseshoeReg(unittest.TestCase):
         reg = HorseshoeReg(weight=1.0, tau=1.0, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
 
+    def test_fit_tau_converges(self):
+        """Fitting tau converges to a finite interior value (bug M18)."""
+        value = jnp.array([0.5, -0.3, 0.8, 1.2, -0.6])
+        final_tau, final_loss = _fit_scalar_hyper(
+            lambda h: HorseshoeReg(weight=1.0, tau=h), value, init=2.0
+        )
+        self.assertTrue(np.isfinite(final_tau))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_tau, 1e-3)
+        self.assertLess(final_tau, 1e3)
+
     def test_inherits_from_module(self):
         """Test HorseshoeReg inherits from brainstate.nn.Module."""
         reg = HorseshoeReg(weight=1.0, tau=1.0)
@@ -1052,6 +1240,17 @@ class TestInverseGammaReg(unittest.TestCase):
         """Test that fit_hyper=True is stored correctly."""
         reg = InverseGammaReg(weight=1.0, alpha=2.0, beta=1.0, fit_hyper=True)
         self.assertTrue(reg.fit_hyper)
+
+    def test_fit_beta_converges(self):
+        """Fitting beta converges to a finite interior value (bug M21)."""
+        value = jnp.array([0.5, 1.0, 2.0, 1.5, 0.8])
+        final_beta, final_loss = _fit_scalar_hyper(
+            lambda h: InverseGammaReg(weight=1.0, alpha=2.0, beta=h), value, init=2.0
+        )
+        self.assertTrue(np.isfinite(final_beta))
+        self.assertTrue(np.isfinite(final_loss))
+        self.assertGreater(final_beta, 1e-3)
+        self.assertLess(final_beta, 1e3)
 
     def test_inherits_from_module(self):
         """Test InverseGammaReg inherits from brainstate.nn.Module."""

--- a/brainstate/nn/_regularization_test.py
+++ b/brainstate/nn/_regularization_test.py
@@ -1497,5 +1497,67 @@ class TestChainedReg(unittest.TestCase):
         np.testing.assert_allclose(chained.loss(value), expected, rtol=1e-5)
 
 
+class TestRegularizationAuditRegressions(unittest.TestCase):
+    """Regression tests for regularization audit findings (R9-R13)."""
+
+    def test_weight_is_not_paramstate_even_with_fit_hyper(self):
+        # R9: docstrings used to claim ``weight`` becomes trainable; it never
+        # does. Verify ``weight`` stays a plain (non-ParamState) constant.
+        for reg in (L1Reg(weight=0.1, fit_hyper=True),
+                    L2Reg(weight=0.1, fit_hyper=True),
+                    GaussianReg(mean=0.0, std=1.0, weight=0.1, fit_hyper=True)):
+            self.assertNotIsInstance(reg.weight, brainstate.ParamState)
+
+    def test_l2_sample_init_negative_weight_is_finite(self):
+        # R10: sample_init divided by sqrt(weight) without relu -> NaN for a
+        # negative weight. It must now be finite (matching loss()'s relu clamp).
+        s = L2Reg(weight=-1.0).sample_init((8,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(s))))
+
+    def test_huber_grouplasso_tv_sample_init_negative_weight_finite(self):
+        for reg in (HuberReg(weight=-1.0),
+                    GroupLassoReg(weight=-1.0, group_size=2),
+                    TotalVariationReg(weight=-1.0)):
+            s = reg.sample_init((6,))
+            self.assertTrue(bool(jnp.all(jnp.isfinite(s))), msg=type(reg).__name__)
+
+    def test_grouplasso_zero_group_size_rejected(self):
+        # R11: group_size=0 previously raised ZeroDivisionError inside loss().
+        with self.assertRaises(ValueError):
+            GroupLassoReg(weight=1.0, group_size=0)
+
+    def test_grouplasso_negative_group_size_rejected(self):
+        # R11: a negative group_size silently mis-grouped via Python modulo.
+        with self.assertRaises(ValueError):
+            GroupLassoReg(weight=1.0, group_size=-2)
+
+    def test_totalvariation_invalid_order_rejected(self):
+        # R12: any order != 1 was silently treated as order 2.
+        with self.assertRaises(ValueError):
+            TotalVariationReg(weight=1.0, order=3)
+        with self.assertRaises(ValueError):
+            TotalVariationReg(weight=1.0, order=0)
+        # Valid orders still accepted.
+        self.assertEqual(TotalVariationReg(order=1).order, 1)
+        self.assertEqual(TotalVariationReg(order=2).order, 2)
+
+    def test_spectralnorm_sample_init_targets_full_max_value(self):
+        # R13: sample_init multiplied by an extra 0.5, so samples sat at half the
+        # requested spectral norm. The estimated norm must now be ~max_value.
+        reg = SpectralNormReg(weight=1.0, max_value=4.0)
+        sample = reg.sample_init((8, 8))
+        sigma = float(reg._estimate_spectral_norm(sample))
+        # Power-iteration estimate -> generous tolerance, but it must clearly be
+        # near 4.0 rather than the old ~2.0.
+        self.assertGreater(sigma, 3.0)
+        np.testing.assert_allclose(sigma, 4.0, rtol=0.2)
+
+    def test_spectralnorm_sample_init_1d_targets_full_max_value(self):
+        reg = SpectralNormReg(weight=1.0, max_value=4.0)
+        sample = reg.sample_init((16,))
+        norm = float(jnp.sqrt(jnp.sum(sample ** 2)))
+        np.testing.assert_allclose(norm, 4.0, rtol=1e-3)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/nn/_transform.py
+++ b/brainstate/nn/_transform.py
@@ -409,7 +409,7 @@ class SigmoidT(Transform):
         """
         log_width = jnp.log(u.get_mantissa(self.width))
         log_s = jax.nn.log_sigmoid(x) + jax.nn.log_sigmoid(-x)
-        return jnp.sum(log_width + log_s, axis=-1)
+        return jnp.sum(log_width + log_s, axis=-1) if jnp.ndim(x) > 0 else jnp.sum(log_width + log_s)
 
 
 class SoftplusT(Transform):
@@ -539,7 +539,7 @@ class SoftplusT(Transform):
         For softplus: d/dx[log(1 + exp(x))] = sigmoid(x)
         log|det J| = sum(log(sigmoid(x))) = sum(x - softplus(x))
         """
-        return jnp.sum(jax.nn.log_sigmoid(x), axis=-1)
+        return jnp.sum(jax.nn.log_sigmoid(x), axis=-1) if jnp.ndim(x) > 0 else jnp.sum(jax.nn.log_sigmoid(x))
 
 
 class NegSoftplusT(SoftplusT):
@@ -704,7 +704,7 @@ class LogT(Transform):
 
     def log_abs_det_jacobian(self, x: ArrayLike, y: ArrayLike) -> Array:
         """For exp transform: d/dx[exp(x)] = exp(x), so log|det J| = sum(x)."""
-        return jnp.sum(x, axis=-1)
+        return jnp.sum(x, axis=-1) if jnp.ndim(x) > 0 else jnp.sum(x)
 
 
 class ExpT(Transform):
@@ -741,7 +741,7 @@ class ExpT(Transform):
 
     def log_abs_det_jacobian(self, x: ArrayLike, y: ArrayLike) -> Array:
         """For exp transform: d/dx[exp(x)] = exp(x), so log|det J| = sum(x)."""
-        return jnp.sum(x, axis=-1)
+        return jnp.sum(x, axis=-1) if jnp.ndim(x) > 0 else jnp.sum(x)
 
 
 class TanhT(Transform):
@@ -1238,10 +1238,10 @@ class MaskedT(Transform):
     """
     __module__ = 'brainstate.nn'
 
-    def __init__(self, mask: ArrayLike, transform: Transform) -> None:
+    def __init__(self, mask: ArrayLike, transform: Transform, safe_value: ArrayLike = 1.0) -> None:
         """
         Initialize the masked transformation.
-        
+
         Parameters
         ----------
         mask : array_like of bool
@@ -1249,7 +1249,15 @@ class MaskedT(Transform):
             Must be broadcastable with the input arrays.
         transform : Transform
             The transformation to apply to elements where mask is True.
-            
+        safe_value : array_like, optional
+            Placeholder value substituted into the masked-out positions before
+            the inner transform is evaluated, by default 1.0. This implements the
+            "double where" trick: because :func:`jax.numpy.where` evaluates the
+            inner transform over the *whole* array, masked-out entries could feed
+            invalid inputs (e.g. negatives into a square root) into the transform
+            and produce ``NaN`` gradients even though those outputs are discarded.
+            ``safe_value`` must lie in the transform's valid domain.
+
         Raises
         ------
         TypeError
@@ -1258,6 +1266,7 @@ class MaskedT(Transform):
         super().__init__()
         self.mask = mask
         self.transform = transform
+        self.safe_value = safe_value
 
     def __repr__(self) -> str:
         return f"MaskedT(mask=..., transform={repr(self.transform)})"
@@ -1280,9 +1289,13 @@ class MaskedT(Transform):
         Notes
         -----
         Uses element-wise conditional logic to apply transformation only
-        where mask is True.
+        where mask is True. The "double where" trick substitutes
+        ``self.safe_value`` into masked-out positions before evaluating the
+        inner transform so its gradient stays finite even where the original
+        input would be outside the transform's domain.
         """
-        return u.math.where(self.mask, self.transform.forward(x), x)
+        safe_x = u.math.where(self.mask, x, self.safe_value)
+        return u.math.where(self.mask, self.transform.forward(safe_x), x)
 
     def inverse(self, y: ArrayLike) -> Array:
         """
@@ -1302,9 +1315,12 @@ class MaskedT(Transform):
         Notes
         -----
         Applies inverse transformation only to elements where mask is True,
-        maintaining consistency with the forward operation.
+        maintaining consistency with the forward operation. Uses the same
+        "double where" trick as :meth:`forward` so the inner transform's
+        gradient stays finite at masked-out positions.
         """
-        return u.math.where(self.mask, self.transform.inverse(y), y)
+        safe_y = u.math.where(self.mask, y, self.safe_value)
+        return u.math.where(self.mask, self.transform.inverse(safe_y), y)
 
 
 class ReluT(Transform):
@@ -1383,7 +1399,7 @@ class PositiveT(Transform):
 
     def log_abs_det_jacobian(self, x: ArrayLike, y: ArrayLike) -> Array:
         """For exp transform: d/dx[exp(x)] = exp(x), so log|det J| = sum(x)."""
-        return jnp.sum(x, axis=-1)
+        return jnp.sum(x, axis=-1) if jnp.ndim(x) > 0 else jnp.sum(x)
 
 
 class NegativeT(Transform):
@@ -1680,14 +1696,27 @@ class SimplexT(Transform):
         return jnp.concatenate([y_head, y_tail], axis=-1)
 
     def inverse(self, y: ArrayLike) -> Array:
-        """Transform simplex back to unconstrained domain."""
+        """Transform simplex back to unconstrained domain.
+
+        Notes
+        -----
+        The inverse is well-defined on the *open* simplex (the interior, where
+        every component is strictly positive). Inputs touching a vertex or face
+        (a component equal to ``0`` or ``1``) would otherwise map a stick-breaking
+        ratio to ``0`` or ``1`` and produce ``+/-inf`` from the logit. To keep the
+        result finite the ratio is clamped into ``[eps, 1 - eps]`` with a
+        dtype-aware ``eps`` before the logit, which also removes the asymmetric
+        bias of the previous one-sided ``+ 1e-8`` denominator nudge.
+        """
         y_head = y[..., :-1]
         # Compute cumulative sum from left
         cumsum = jnp.cumsum(y_head, axis=-1)
         # remaining = 1 - cumsum + current = probability still available
         remaining = 1 - cumsum + y_head
-        # z_i = y_i / remaining
-        z = y_head / (remaining + 1e-8)
+        # z_i = y_i / remaining, clamped into (0, 1) with a dtype-aware eps so the
+        # logit stays finite on the simplex boundary (open-simplex domain).
+        eps = jnp.finfo(y.dtype).eps  # ~1e-7 float32
+        z = jnp.clip(y_head / (remaining + eps), eps, 1.0 - eps)
         return jax.scipy.special.logit(z)
 
 

--- a/brainstate/nn/_transform.py
+++ b/brainstate/nn/_transform.py
@@ -504,7 +504,10 @@ class SoftplusT(Transform):
         which is exact for all ``x`` (the previous ``log1p(exp(x))`` form saturated for
         ``x`` beyond ~20, breaking the forward map and round-trip).
         """
-        return jax.nn.softplus(x) * self.unit + self.lower
+        # ``maybe_decimal`` demotes the result back to a plain array when ``lower``
+        # carries no physical unit (``self.unit`` is dimensionless), so a plain
+        # float ``lower`` does not spuriously yield a dimensionless Quantity.
+        return u.maybe_decimal(jax.nn.softplus(x) * self.unit + self.lower)
 
     def inverse(self, y: ArrayLike) -> Array:
         """
@@ -633,7 +636,9 @@ class NegSoftplusT(SoftplusT):
         -----
         Implemented as: upper - softplus(-x), using the stable ``jax.nn.softplus``.
         """
-        return self.lower - jax.nn.softplus(-x) * self.unit
+        # ``maybe_decimal`` demotes the result to a plain array when ``upper``
+        # carries no physical unit, mirroring ``SoftplusT.forward``.
+        return u.maybe_decimal(self.lower - jax.nn.softplus(-x) * self.unit)
 
     def inverse(self, y: ArrayLike) -> Array:
         """
@@ -829,7 +834,9 @@ class ClipT(Transform):
     -----
     Clipping is a non-bijective transformation since multiple input values can
     map to the same output value at the bounds. Therefore, the inverse method
-    is not implemented.
+    cannot recover the original input; it provides a best-effort pseudo-inverse
+    that simply re-applies the clip (a passthrough for values already inside
+    ``[lower, upper]``).
 
     Examples
     --------
@@ -877,12 +884,23 @@ class ClipT(Transform):
 
     def inverse(self, y: ArrayLike) -> Array:
         """
-        Inverse transformation is not defined for clipping.
+        Best-effort inverse for the (non-bijective) clipping transform.
 
-        Raises
-        ------
-        NotImplementedError
-            Clipping is not bijective; inverse cannot be defined.
+        Clipping is not bijective, so a true inverse does not exist. As a
+        best-effort pseudo-inverse this re-applies the clip, which acts as the
+        identity for values already inside ``[lower, upper]`` and projects
+        out-of-range values back onto the nearest bound.
+
+        Parameters
+        ----------
+        y : array_like
+            Values in ``[lower, upper]`` (typically the output of ``forward``).
+
+        Returns
+        -------
+        Array
+            The values clipped to ``[lower, upper]`` (a passthrough for in-range
+            inputs).
         """
         return u.math.clip(y, a_min=self.lower, a_max=self.upper)
 
@@ -1499,6 +1517,13 @@ class ScaledSigmoidT(Transform):
             Sharpness parameter, by default 1.0.
         """
         super().__init__()
+        # ``beta`` is the sharpness of the sigmoid and must be a positive finite
+        # number. ``beta == 0`` collapses ``forward`` to the constant midpoint and
+        # makes ``inverse`` divide by zero (NaN); a negative ``beta`` silently
+        # reverses the monotonicity of the map. ``beta != beta`` catches NaN
+        # without importing ``math``.
+        if not (beta > 0) or beta == float('inf') or beta != beta:
+            raise ValueError(f"beta must be a positive finite number, but got {beta}.")
         self.lower = lower
         self.width = upper - lower
         self.beta = beta

--- a/brainstate/nn/_transform_test.py
+++ b/brainstate/nn/_transform_test.py
@@ -591,5 +591,44 @@ class TestTransformAuditRegressions(unittest.TestCase):
         np.testing.assert_allclose(np.asarray(xr), np.asarray(x), atol=1e-4)
 
 
+class TestTransformAuditRegressions2(unittest.TestCase):
+    """Regression tests for transform audit findings (T15-T17)."""
+
+    def test_softplus_float_lower_returns_plain_array(self):
+        # T15: a plain-float ``lower`` must not yield a dimensionless Quantity.
+        y = SoftplusT(2.0).forward(jnp.array([0.0, 1.0]))
+        self.assertNotIsInstance(y, u.Quantity)
+
+    def test_negsoftplus_float_upper_returns_plain_array(self):
+        y = NegSoftplusT(0.0).forward(jnp.array([0.0, 1.0]))
+        self.assertNotIsInstance(y, u.Quantity)
+
+    def test_softplus_unit_lower_still_carries_unit(self):
+        # The fix must not strip a genuine physical unit.
+        y = SoftplusT(2.0 * u.mV).forward(jnp.array([0.0]))
+        self.assertIsInstance(y, u.Quantity)
+        self.assertEqual(u.get_unit(y), u.get_unit(1.0 * u.mV))
+
+    def test_clip_inverse_reclips_out_of_range(self):
+        # T16: the docstring claimed inverse raises NotImplementedError, but it
+        # re-clips. Confirm the documented (and tested) re-clip behavior: an
+        # out-of-range value is projected onto the nearest bound.
+        t = ClipT(lower=0.0, upper=1.0)
+        np.testing.assert_allclose(np.asarray(t.inverse(jnp.array([2.0, -1.0]))),
+                                   np.array([1.0, 0.0]), rtol=1e-6)
+
+    def test_scaledsigmoid_rejects_nonpositive_beta(self):
+        # T17: beta=0 collapses forward and makes inverse divide by zero.
+        for bad in (0.0, -1.0):
+            with self.assertRaises(ValueError):
+                ScaledSigmoidT(0.0, 1.0, beta=bad)
+
+    def test_scaledsigmoid_valid_beta_roundtrips(self):
+        t = ScaledSigmoidT(0.0, 1.0, beta=2.0)
+        y = jnp.array([0.3, 0.6])
+        np.testing.assert_allclose(np.asarray(t.forward(t.inverse(y))),
+                                   np.asarray(y), atol=1e-5)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/nn/_transform_test.py
+++ b/brainstate/nn/_transform_test.py
@@ -15,6 +15,7 @@
 import unittest
 
 import brainunit as u
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -517,6 +518,77 @@ class TestTransformAuditRegressions(unittest.TestCase):
         ladj = t.log_abs_det_jacobian(x, None)
         self.assertTrue(np.all(np.isfinite(np.asarray(ladj))))
         np.testing.assert_allclose(np.asarray(ladj), 2 * np.log(2.0), rtol=1e-6)
+
+    def test_masked_forward_grad_finite_through_masked_positions(self):
+        # H11: jnp.where evaluates the inner transform over the WHOLE array, so a
+        # masked-out entry could feed an invalid value (here -1.0 into a sqrt) into
+        # the transform and yield NaN gradients. The double-where fix substitutes a
+        # safe value, keeping the gradient finite everywhere.
+        def loss(x):
+            return MaskedT(jnp.array([True, False]), PowerT(0.5)).forward(x).sum()
+
+        g = jax.grad(loss)(jnp.array([4.0, -1.0]))
+        self.assertTrue(np.all(np.isfinite(np.asarray(g))))
+
+    def test_masked_inverse_grad_finite_through_masked_positions(self):
+        # H11: analogous to forward, but for inverse. PowerT(2.0).inverse computes a
+        # square root, so a masked-out -1.0 would produce a NaN gradient without the
+        # double-where guard.
+        def loss(y):
+            return MaskedT(jnp.array([True, False]), PowerT(2.0)).inverse(y).sum()
+
+        g = jax.grad(loss)(jnp.array([4.0, -1.0]))
+        self.assertTrue(np.all(np.isfinite(np.asarray(g))))
+
+    def test_log_abs_det_jacobian_scalar_input(self):
+        # M22: jnp.sum(expr, axis=-1) raises on a 0-d (scalar) array. Each
+        # element-wise transform's log_abs_det_jacobian must return a finite scalar
+        # of shape () for a 0-d input.
+        x = jnp.array(1.5)
+        transforms = [
+            SigmoidT(0.0, 1.0),
+            SoftplusT(0.0),
+            LogT(0.0),
+            ExpT(0.0),
+            PositiveT(),
+        ]
+        for t in transforms:
+            ladj = t.log_abs_det_jacobian(x, t.forward(x))
+            self.assertEqual(np.shape(ladj), (), msg=f"{t!r} should give scalar shape")
+            self.assertTrue(np.isfinite(np.asarray(ladj)), msg=f"{t!r} should be finite")
+
+    def test_chain_log_abs_det_jacobian_scalar_input(self):
+        # M22: a chain of element-wise transforms must also work on a scalar input.
+        t = ChainT(SigmoidT(0.0, 1.0), AffineT(2.0, 0.0))
+        x = jnp.array(0.3)
+        ladj = t.log_abs_det_jacobian(x, t.forward(x))
+        self.assertEqual(np.shape(ladj), ())
+        self.assertTrue(np.isfinite(np.asarray(ladj)))
+
+    def test_log_abs_det_jacobian_batched_unchanged(self):
+        # M22: the scalar guard must not alter batched (1-d) behaviour.
+        x = jnp.array([0.0, 1.0, 2.0])
+        np.testing.assert_allclose(
+            np.asarray(ExpT(0.0).log_abs_det_jacobian(x, None)), np.sum(np.asarray(x)), rtol=1e-6
+        )
+        np.testing.assert_allclose(
+            np.asarray(PositiveT().log_abs_det_jacobian(x, None)), np.sum(np.asarray(x)), rtol=1e-6
+        )
+
+    def test_simplex_inverse_at_vertex_finite(self):
+        # M23: at a simplex vertex a stick-breaking ratio hits 0 or 1, and the old
+        # one-sided "+ 1e-8" denominator nudge let the logit overflow to +/-inf. The
+        # clamp into [eps, 1 - eps] must keep the inverse finite on the boundary.
+        x = SimplexT().inverse(jnp.array([1.0, 0.0, 0.0, 0.0]))
+        self.assertTrue(np.all(np.isfinite(np.asarray(x))))
+
+    def test_simplex_roundtrip_interior(self):
+        # M23: on the open simplex (interior) inverse(forward(x)) must still
+        # round-trip for moderate x after the clamp change.
+        t = SimplexT()
+        x = jnp.array([0.5, -0.5, 1.0])
+        xr = t.inverse(t.forward(x))
+        np.testing.assert_allclose(np.asarray(xr), np.asarray(x), atol=1e-4)
 
 
 if __name__ == '__main__':

--- a/brainstate/random/_fun.py
+++ b/brainstate/random/_fun.py
@@ -2206,7 +2206,8 @@ def chisquare(
     df: ArrayLike,
     size: Optional[Size] = None,
     key: Optional[SeedOrKey] = None,
-    dtype: Optional[DTypeLike] = None
+    dtype: Optional[DTypeLike] = None,
+    check_valid: bool = True
 ) -> jax.Array:
     r"""
     Draw samples from a chi-square distribution.
@@ -2276,7 +2277,7 @@ def chisquare(
         >>> print(samples.shape)  # (4,)
         >>> print((samples >= 0).all())  # True (chi-square is always non-negative)
     """
-    return DEFAULT.chisquare(df, size=size, key=key, dtype=dtype)
+    return DEFAULT.chisquare(df, size=size, key=key, dtype=dtype, check_valid=check_valid)
 
 
 @set_module_as('brainstate.random')
@@ -3175,7 +3176,8 @@ def power(
     a: ArrayLike,
     size: Optional[Size] = None,
     key: Optional[SeedOrKey] = None,
-    dtype: Optional[DTypeLike] = None
+    dtype: Optional[DTypeLike] = None,
+    check_valid: bool = True
 ) -> jax.Array:
     r"""
     Draws samples in [0, 1] from a power distribution with positive
@@ -3272,7 +3274,7 @@ def power(
     >>> plt.plot(xx,powpdf,'r-')  # doctest: +SKIP
     >>> plt.title('inverse of stats.pareto(5)')
     """
-    return DEFAULT.power(a, size=size, key=key, dtype=dtype)
+    return DEFAULT.power(a, size=size, key=key, dtype=dtype, check_valid=check_valid)
 
 
 @set_module_as('brainstate.random')

--- a/brainstate/random/_fun_test.py
+++ b/brainstate/random/_fun_test.py
@@ -972,3 +972,36 @@ class TestAuditRegressions(parameterized.TestCase):
         brainstate.random.seed(0)
         a = np.asarray(brainstate.random.chisquare(7.0, size=(100000,)))
         self.assertLess(abs(a.mean() - 7.0), 0.1)
+
+    # --- G: power() enforces the documented ``Raises ValueError if a <= 0`` -------
+
+    def test_power_nonpositive_a_raises(self):
+        """power(a<=0) raises, matching the documented numpy contract."""
+        brainstate.random.seed(0)
+        for bad in (0.0, -1.0):
+            with self.subTest(a=bad):
+                with self.assertRaises(Exception):
+                    np.asarray(brainstate.random.power(bad, 100))
+
+    def test_power_check_valid_false_skips_guard(self):
+        """power(check_valid=False) skips the a>0 guard."""
+        brainstate.random.seed(0)
+        out = brainstate.random.power(0.0, 100, check_valid=False)
+        self.assertTupleEqual(tuple(jnp.shape(out)), (100,))
+
+    def test_power_valid_a_unaffected(self):
+        """A valid positive ``a`` still samples within [0, 1]."""
+        brainstate.random.seed(0)
+        a = np.asarray(brainstate.random.power(2.0, 1000))
+        self.assertTupleEqual(a.shape, (1000,))
+        self.assertTrue((a >= 0).all() and (a <= 1).all())
+
+    # --- H: chisquare() enforces ``Raises ValueError when df <= 0`` (public API) --
+
+    def test_chisquare_nonpositive_df_raises(self):
+        """The public chisquare wrapper raises for df<=0."""
+        brainstate.random.seed(0)
+        for bad in (0.0, -2.0):
+            with self.subTest(df=bad):
+                with self.assertRaises(Exception):
+                    np.asarray(brainstate.random.chisquare(bad, 5))

--- a/brainstate/random/_impl.py
+++ b/brainstate/random/_impl.py
@@ -144,6 +144,11 @@ def von_mises_centered(
     else:
         raise ValueError(f"Unsupported dtype: {dtype}")
 
+    # Split off a dedicated key for the kappa<=0 uniform branch *before* the
+    # rejection loop so the uniform draw does not reuse (and thereby correlate
+    # with) the rejection-sampler keys.
+    uni_key, key = jr.split(key)
+
     r = 1.0 + jnp.sqrt(1.0 + 4.0 * concentration ** 2)
     rho = (r - jnp.sqrt(2.0 * r)) / (2.0 * concentration)
     s_exact = (1.0 + rho ** 2) / (2.0 * rho)
@@ -187,7 +192,17 @@ def von_mises_centered(
         init_val=(jnp.array(0), key, init_done, init_u, init_w),
     )
 
-    return jnp.sign(uu) * jnp.arccos(w)
+    samples = jnp.sign(uu) * jnp.arccos(w)
+
+    # For ``concentration <= 0`` the rejection-loop math is degenerate
+    # (``rho`` and ``s_approximate`` involve division by zero, producing NaN),
+    # so substitute a uniform draw on ``[-pi, pi]``. This matches numpy's
+    # treatment of ``kappa == 0`` as the uniform distribution and extends the
+    # limiting case to ``kappa < 0`` rather than poisoning the output with NaN.
+    # Both ``jnp.where`` operands are eagerly evaluated, so the NaN branch is
+    # cleanly masked out wherever the uniform branch is selected.
+    uniform = jr.uniform(uni_key, shape, dtype=concentration.dtype, minval=-jnp.pi, maxval=jnp.pi)
+    return jnp.where(concentration <= 0, uniform, samples)
 
 
 def _scatter_add_one(operand, indices, updates):

--- a/brainstate/random/_impl.py
+++ b/brainstate/random/_impl.py
@@ -92,9 +92,13 @@ def multinomial(
     if jnp.ndim(n) > 0:
         mask = _promote_shapes(jnp.arange(n_max) < jnp.expand_dims(n, -1), shape=shape + (n_max,))[0]
         mask = jnp.moveaxis(mask, -1, 0).astype(indices.dtype)
+        # ``excess`` must share ``indices``'s integer dtype: subtracting a
+        # float-typed ``excess`` (the previous ``jnp.zeros`` default) would promote
+        # the returned counts to floating point, violating the integer-counts
+        # contract for array-valued ``n``.
         excess = jnp.concatenate(
-            [jnp.expand_dims(n_max - n, -1),
-             jnp.zeros(u.math.shape(n) + (p.shape[-1] - 1,))],
+            [jnp.expand_dims((n_max - n).astype(indices.dtype), -1),
+             jnp.zeros(u.math.shape(n) + (p.shape[-1] - 1,), dtype=indices.dtype)],
             -1
         )
     else:

--- a/brainstate/random/_impl_test.py
+++ b/brainstate/random/_impl_test.py
@@ -68,6 +68,24 @@ class TestMultinomial(unittest.TestCase):
         self.assertEqual(counts.shape, (3,))
         self.assertEqual(int(jnp.sum(counts)), 4)
 
+    def test_array_valued_n_returns_integer_counts(self):
+        """Audit item 1: with an array-valued ``n`` the counts stay integer.
+
+        The heterogeneous-``n`` branch subtracts an ``excess`` term that used to be
+        built as float (``jnp.zeros`` default + a float concatenate), promoting the
+        returned counts to floating point and violating the integer-counts contract.
+        """
+        p = jnp.array([[0.2, 0.3, 0.5], [0.1, 0.1, 0.8]])
+        # Both a genuinely heterogeneous n and an array-but-equal n hit the same
+        # (previously float-producing) branch.
+        for n in (jnp.array([10, 5]), jnp.array([7, 7])):
+            with self.subTest(n=np.asarray(n).tolist()):
+                counts = _impl.multinomial(self.key, p, n, n_max=10)
+                self.assertTrue(jnp.issubdtype(counts.dtype, jnp.integer),
+                                msg=f'expected integer counts, got {counts.dtype}')
+                np.testing.assert_array_equal(
+                    np.asarray(jnp.sum(counts, axis=-1)), np.asarray(n))
+
 
 class TestVonMisesCentered(unittest.TestCase):
     """Validate the ``von_mises_centered`` rejection sampler in ``_impl.py``."""

--- a/brainstate/random/_impl_test.py
+++ b/brainstate/random/_impl_test.py
@@ -106,6 +106,41 @@ class TestVonMisesCentered(unittest.TestCase):
         self.assertEqual(out.shape, (4,))
         self.assertEqual(out.dtype, jnp.float16)
 
+    def test_zero_concentration_is_finite_uniform(self):
+        """concentration==0 yields finite samples on [-pi, pi] (the uniform
+        limiting case), not all-NaN. Regression test for M24."""
+        out = _impl.von_mises_centered(self.key, 0.0, (1000,), dtype=jnp.float32)
+        self.assertEqual(out.shape, (1000,))
+        self.assertFalse(bool(jnp.any(jnp.isnan(out))))
+        self.assertTrue(bool(jnp.all(jnp.abs(out) <= jnp.pi + 1e-4)))
+        # Empirically approximately uniform on [-pi, pi]: mean near 0.
+        self.assertLess(float(jnp.abs(jnp.mean(out))), 0.2)
+
+    def test_negative_concentration_is_finite_uniform(self):
+        """concentration<0 also maps to the uniform limiting case (finite,
+        bounded), rather than producing NaN. Regression test for M24."""
+        out = _impl.von_mises_centered(self.key, -1.0, (256,), dtype=jnp.float32)
+        self.assertFalse(bool(jnp.any(jnp.isnan(out))))
+        self.assertTrue(bool(jnp.all(jnp.abs(out) <= jnp.pi + 1e-4)))
+
+    def test_mixed_zero_and_positive_concentration(self):
+        """A broadcast concentration mixing 0 with a positive value keeps the
+        positive entry finite and the zero entry finite (NaN does not leak
+        across the jnp.where mask). Regression test for M24."""
+        concentration = jnp.array([0.0, 2.0])
+        out = _impl.von_mises_centered(self.key, concentration, (2,), dtype=jnp.float32)
+        self.assertFalse(bool(jnp.any(jnp.isnan(out))))
+        self.assertTrue(bool(jnp.all(jnp.abs(out) <= jnp.pi + 1e-4)))
+
+    def test_public_vonmises_zero_kappa_not_nan(self):
+        """RandomState.vonmises(mu, 0.0) returns finite uniform angles instead
+        of all-NaN. End-to-end regression test for M24."""
+        rs = brainstate.random.RandomState(42)
+        out = rs.vonmises(0.0, 0.0, size=(10,))
+        out = jnp.asarray(out)
+        self.assertFalse(bool(jnp.any(jnp.isnan(out))))
+        self.assertTrue(bool(jnp.all(jnp.abs(out) <= jnp.pi + 1e-4)))
+
 
 class TestReshapeAndPromote(unittest.TestCase):
     """Validate the ``_reshape`` and ``_promote_shapes`` array utilities."""

--- a/brainstate/random/_seed.py
+++ b/brainstate/random/_seed.py
@@ -60,7 +60,7 @@ import numpy as np
 
 from brainstate._utils import set_module_as
 from brainstate.typing import SeedOrKey
-from ._impl import _format_key, _is_typed_key
+from ._impl import _format_key
 from ._state import RandomState, DEFAULT
 
 __all__ = [
@@ -582,9 +582,13 @@ def seed(seed_or_key: Optional[SeedOrKey] = None) -> None:
     seed_or_key
         The seed or key to set. Can be:
         - None: Generates a random seed automatically
-        - int: An integer seed (0 to 2^32-1)
+        - int: An integer seed. Any Python integer is accepted; it is reduced
+          modulo ``2**32`` for NumPy (matching JAX, which reduces an integer
+          seed to its low 32 bits), so values outside ``[0, 2**32-1]`` (e.g.
+          ``hash(...)``, ``time.time_ns()`` or negative values) are valid.
         - JAX PRNG key: A JAX random key array
-        If None, a random seed is generated using NumPy's random generator.
+        If None, a random seed is generated without disturbing NumPy's global
+        random state.
 
     Raises
     ------
@@ -629,11 +633,16 @@ def seed(seed_or_key: Optional[SeedOrKey] = None) -> None:
     -----
         - This function affects the global random state used by all BrainState
           random functions and NumPy's global random state.
-        - When using automatic seeding (seed_or_key=None), NumPy's seed is not
-          set to maintain its current state.
+        - When using automatic seeding (seed_or_key=None), NumPy's global random
+          state is left untouched: the auto-key is drawn from an independent
+          ``numpy.random.default_rng`` Generator, so the current state is
+          maintained.
         - JAX compilation is handled automatically with compile-time evaluation.
-        - For JAX keys, only the first element is used to seed NumPy to maintain
-          compatibility between the two random systems.
+        - The input is first normalized to a typed JAX key; the first element of
+          that key's raw ``uint32[2]`` data is then used to seed NumPy, keeping
+          the two random systems consistent. Because the JAX key is validated
+          before any NumPy mutation, an invalid input raises without leaving the
+          JAX and NumPy states out of sync.
 
     See Also
     --------
@@ -644,31 +653,53 @@ def seed(seed_or_key: Optional[SeedOrKey] = None) -> None:
 
     """
     with jax.ensure_compile_time_eval():
-        _set_numpy_seed = True
         if seed_or_key is None:
-            seed_or_key = np.random.randint(0, 100000)
-            _set_numpy_seed = False
+            # Automatic seeding: draw a full uint32[2] key from a *fresh*
+            # ``default_rng`` Generator so the legacy global ``np.random`` state
+            # is left untouched (honoring the docstring's "maintain its current
+            # state") and the full 2**32 entropy range is used (matching
+            # ``RandomState.seed(None)`` rather than a reduced range).
+            seed_or_key = np.random.default_rng().integers(0, 2 ** 32, size=2, dtype=np.uint32)
+            DEFAULT.seed(seed_or_key)
+            return
 
-        # numpy random seed
-        if _set_numpy_seed:
-            try:
-                if isinstance(seed_or_key, int):
-                    np.random.seed(seed_or_key)
-                elif _is_typed_key(seed_or_key):  # typed JAX key (scalar): use its raw data
-                    np.random.seed(int(jax.random.key_data(seed_or_key)[0]))
-                elif np.size(seed_or_key) == 1:  # scalar seed array
-                    np.random.seed(int(np.asarray(seed_or_key)))
-                elif np.size(seed_or_key) == 2:  # legacy uint32[2] key
-                    np.random.seed(int(np.asarray(seed_or_key)[0]))
-                else:
-                    raise ValueError(f"seed_or_key should be an integer or a tuple of two integers.")
-            except (jax.errors.TracerArrayConversionError,
-                    jax.errors.ConcretizationTypeError):
-                # Inside a jit trace the key is abstract; skip NumPy seeding.
-                pass
+        # Normalize a NumPy integer scalar (e.g. ``np.int64(...)``) to a Python
+        # int so it follows the int-seed path below (``_format_key`` itself only
+        # accepts python ints, typed keys, or uint32[2] arrays).
+        if isinstance(seed_or_key, np.integer):
+            seed_or_key = int(seed_or_key)
 
-    # jax random seed
-    DEFAULT.seed(seed_or_key)
+        # Validate/normalize the JAX key *first* so that, on invalid input, no
+        # global state is mutated. ``_format_key`` raises TypeError/ValueError
+        # for anything that is not an int, a typed key, or a uint32[2] array,
+        # which is strictly stricter than the NumPy-seeding step below; doing it
+        # first eliminates the partial-mutation window (NumPy seeded, JAX not).
+        key = _format_key(seed_or_key)
+
+        # Set the JAX state from the validated key.
+        DEFAULT.set_key(key)
+
+        # Seed NumPy. ``np.random.seed`` only accepts [0, 2**32-1]; reduce the
+        # value modulo 2**32 (matching JAX, which reduces an integer seed to its
+        # low 32 bits) so out-of-range / negative ints no longer raise.
+        #
+        #   * For an integer seed ``v`` we seed NumPy with ``v % 2**32`` -- this
+        #     equals the low word of ``jax.random.key(v)`` so the two systems
+        #     stay consistent, and it preserves the historical NumPy stream for
+        #     in-range ints (``np.random.seed(v) == np.random.seed(v % 2**32)``).
+        #   * For a typed / legacy ``uint32[2]`` key we seed NumPy from the first
+        #     raw word of the key data, matching the documented "first element of
+        #     the key is used to seed NumPy" behavior.
+        try:
+            if isinstance(seed_or_key, int):
+                np_seed = seed_or_key % (2 ** 32)
+            else:
+                np_seed = int(jax.random.key_data(key)[0]) % (2 ** 32)
+            np.random.seed(np_seed)
+        except (jax.errors.TracerArrayConversionError,
+                jax.errors.ConcretizationTypeError):
+            # Inside a jit trace the key is abstract; skip NumPy seeding.
+            pass
 
 
 @contextmanager
@@ -753,7 +784,9 @@ def seed_context(seed_or_key: SeedOrKey) -> Iterator[None]:
     Notes
     -----
         - The context manager saves and restores the complete JAX random state
-        - NumPy's random state is also temporarily modified during the context
+        - NumPy's global random state is also seeded on entry and fully restored
+          on exit (via ``numpy.random.get_state``/``set_state``), so NumPy-backed
+          randomness inside the block is reproducible and leaves no side effect
         - Nested contexts work correctly - each level restores its own state
         - Exception safety is guaranteed - random state is restored even if
           exceptions occur within the context
@@ -768,12 +801,24 @@ def seed_context(seed_or_key: SeedOrKey) -> Iterator[None]:
     clone_rng : Create independent random states
 
     """
-    # get the old random key
+    # Snapshot BOTH the JAX key and the full NumPy generator state so the
+    # documented "affects both JAX and NumPy" contract holds and both are
+    # restored on exit. We restore the NumPy state with ``set_state`` (not a
+    # re-seed) because seeding on entry advances NumPy's position; re-seeding
+    # could not reproduce a mid-stream Mersenne-Twister state.
     old_jrand_key = DEFAULT.value
+    old_np_state = np.random.get_state()
     try:
-        # set the seed of jax random state
-        DEFAULT.seed(seed_or_key)
+        # Seed both the JAX key and NumPy via the module-level ``seed`` so the
+        # two systems stay consistent. ``seed(None)`` deliberately leaves
+        # NumPy's state untouched, so feed it a concrete key in that case to
+        # honor the documented NumPy-seeding behavior of this context manager.
+        if seed_or_key is None:
+            seed(int(np.random.default_rng().integers(0, 2 ** 32)))
+        else:
+            seed(seed_or_key)
         yield
     finally:
-        # restore the random state
+        # restore both the JAX key and the full NumPy MT state
         DEFAULT.seed(old_jrand_key)
+        np.random.set_state(old_np_state)

--- a/brainstate/random/_seed_test.py
+++ b/brainstate/random/_seed_test.py
@@ -109,9 +109,14 @@ class TestSeedUtilities(unittest.TestCase):
         self.assertEqual(drawn.shape, (2,))
 
     def test_seed_rejects_oversized_array(self):
-        """Seed raises ValueError for an array whose size exceeds two."""
+        """Seed rejects an array whose size exceeds two.
+
+        Validation is delegated to ``_format_key`` (which raises ``TypeError``
+        for a uint32 array that is not size 2); previously a hand-rolled
+        ``np.size`` branch raised ``ValueError``. Accept either so the test
+        documents the rejection rather than the precise error class."""
         bad = np.array([1, 2, 3], dtype=np.uint32)
-        with self.assertRaises(ValueError):
+        with self.assertRaises((TypeError, ValueError)):
             brainstate.random.seed(bad)
 
     # ------------------------------------------------------------------ #
@@ -389,3 +394,183 @@ class TestSeedUtilities(unittest.TestCase):
                 _ = brainstate.random.rand(2)
             self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), outer_after_enter)))
         self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), before)))
+
+
+class TestSeedGlobalStateEdgeCases(unittest.TestCase):
+    """Regression tests for seed()/seed_context() global-state correctness.
+
+    These tests deliberately exercise and inspect the global NumPy + JAX random
+    state, so each one restores a known state on exit (``tearDown``) to avoid
+    perturbing other tests in the suite.
+    """
+
+    def setUp(self):
+        brainstate.random.seed(1234)
+
+    def tearDown(self):
+        # Re-establish a deterministic global state for subsequent tests.
+        brainstate.random.seed(1234)
+
+    # ------------------------------------------------------------------ #
+    # M25: integer seeds outside [0, 2**32-1]                            #
+    # ------------------------------------------------------------------ #
+
+    def test_seed_large_int_does_not_raise(self):
+        """seed(2**33) succeeds (no ValueError from np.random.seed) and is
+        reproducible. Regression test for M25."""
+        brainstate.random.seed(2 ** 33)
+        a = brainstate.random.randn(5)
+        brainstate.random.seed(2 ** 33)
+        b = brainstate.random.randn(5)
+        self.assertTrue(bool(jnp.allclose(a, b)))
+
+    def test_seed_negative_int_does_not_raise(self):
+        """seed(-1) succeeds and is reproducible. Regression test for M25."""
+        brainstate.random.seed(-1)
+        a = brainstate.random.randn(5)
+        brainstate.random.seed(-1)
+        b = brainstate.random.randn(5)
+        self.assertTrue(bool(jnp.allclose(a, b)))
+
+    def test_seed_numpy_int64_out_of_range_does_not_raise(self):
+        """seed(np.int64(2**33)) succeeds via the size-1 array path.
+        Regression test for M25."""
+        brainstate.random.seed(np.int64(2 ** 33))
+        drawn = brainstate.random.randn(3)
+        self.assertEqual(drawn.shape, (3,))
+
+    def test_seed_out_of_range_int_matches_mod_2pow32_for_jax(self):
+        """An out-of-range int seed produces the same JAX key as its value
+        reduced modulo 2**32 (JAX uses the low 32 bits). Regression test for
+        M25."""
+        brainstate.random.seed(2 ** 33 + 7)
+        k1 = brainstate.random.get_key_data()
+        brainstate.random.seed((2 ** 33 + 7) % (2 ** 32))
+        k2 = brainstate.random.get_key_data()
+        self.assertTrue(bool(jnp.array_equal(k1, k2)))
+
+    def test_seed_out_of_range_int_seeds_numpy_in_range(self):
+        """After a large int seed, NumPy's state matches seeding NumPy with the
+        value reduced modulo 2**32. Regression test for M25."""
+        brainstate.random.seed(2 ** 32 + 7)
+        a = float(np.random.rand())
+        np.random.seed((2 ** 32 + 7) % (2 ** 32))
+        b = float(np.random.rand())
+        self.assertEqual(a, b)
+
+    # ------------------------------------------------------------------ #
+    # M26: size-2 tuple/list inputs must not partially seed NumPy        #
+    # ------------------------------------------------------------------ #
+
+    def test_seed_tuple_raises_and_leaves_numpy_state_unchanged(self):
+        """seed((5, 9)) raises and leaves NumPy's global state untouched (no
+        partial mutation before the JAX-key validation fails). Regression test
+        for M26."""
+        np.random.seed(777)
+        before = np.random.get_state()
+        before_key = brainstate.random.get_key()
+        with self.assertRaises((TypeError, ValueError)):
+            brainstate.random.seed((5, 9))
+        after = np.random.get_state()
+        # NumPy state vector unchanged.
+        self.assertEqual(before[0], after[0])
+        self.assertTrue(bool(np.array_equal(before[1], after[1])))
+        self.assertEqual(before[2], after[2])
+        # JAX key unchanged too.
+        self.assertTrue(bool(jnp.array_equal(before_key, brainstate.random.get_key())))
+
+    def test_seed_float_size2_array_raises_without_mutating_numpy(self):
+        """seed(np.array([5., 9.])) raises (float, not uint32) and does not
+        mutate NumPy's state. Regression test for M26."""
+        np.random.seed(777)
+        before = np.random.get_state()
+        with self.assertRaises((TypeError, ValueError)):
+            brainstate.random.seed(np.array([5.0, 9.0]))
+        after = np.random.get_state()
+        self.assertTrue(bool(np.array_equal(before[1], after[1])))
+        self.assertEqual(before[2], after[2])
+
+    def test_seed_int64_size2_array_raises_without_mutating_numpy(self):
+        """seed(np.array([5, 9], dtype=int64)) raises (not uint32) and does not
+        mutate NumPy's state. Regression test for M26."""
+        np.random.seed(777)
+        before = np.random.get_state()
+        with self.assertRaises((TypeError, ValueError)):
+            brainstate.random.seed(np.array([5, 9], dtype=np.int64))
+        after = np.random.get_state()
+        self.assertTrue(bool(np.array_equal(before[1], after[1])))
+        self.assertEqual(before[2], after[2])
+
+    # ------------------------------------------------------------------ #
+    # L15: seed(None) honors NumPy state and uses full entropy range     #
+    # ------------------------------------------------------------------ #
+
+    def test_seed_none_does_not_advance_numpy_global_state(self):
+        """seed(None) must NOT consume/advance NumPy's global RNG state, per the
+        docstring. Regression test for L15."""
+        np.random.seed(999)
+        before = np.random.get_state()
+        brainstate.random.seed(None)
+        after = np.random.get_state()
+        self.assertEqual(before[2], after[2])  # position counter unchanged
+        self.assertTrue(bool(np.array_equal(before[1], after[1])))
+        # The very next np.random draw matches what it would have been without
+        # the brainstate.random.seed(None) call.
+        np.random.seed(999)
+        expected = float(np.random.rand())
+        np.random.seed(999)
+        brainstate.random.seed(None)
+        got = float(np.random.rand())
+        self.assertEqual(expected, got)
+
+    def test_seed_none_yields_usable_full_uint32_key(self):
+        """seed(None) produces a usable typed key derived from a full
+        uint32[2] auto-key. Regression test for L15."""
+        brainstate.random.seed(None)
+        key = brainstate.random.get_key()
+        self.assertEqual(key.shape, ())
+        self.assertTrue(jnp.issubdtype(key.dtype, jax.dtypes.prng_key))
+        self.assertEqual(brainstate.random.randn(3).shape, (3,))
+
+    # ------------------------------------------------------------------ #
+    # M27: seed_context also seeds & restores NumPy's global state        #
+    # ------------------------------------------------------------------ #
+
+    def test_seed_context_makes_numpy_reproducible(self):
+        """Inside seed_context(seed), NumPy-backed randomness is reproducible
+        across two identically-seeded contexts. Regression test for M27."""
+        with brainstate.random.seed_context(42):
+            a = float(np.random.rand())
+        with brainstate.random.seed_context(42):
+            b = float(np.random.rand())
+        self.assertEqual(a, b)
+
+    def test_seed_context_restores_numpy_state_on_exit(self):
+        """seed_context restores NumPy's full global state on exit, so a draw
+        after the block matches the pre-context stream. Regression test for
+        M27."""
+        np.random.seed(2024)
+        before = np.random.get_state()
+        expected_next = float(np.random.rand())
+        # Re-establish the pre-draw state, run a context that perturbs NumPy,
+        # and confirm the next draw is unaffected.
+        np.random.set_state(before)
+        with brainstate.random.seed_context(123):
+            _ = np.random.rand(5)  # perturb NumPy inside the context
+        after = np.random.get_state()
+        self.assertEqual(before[2], after[2])
+        self.assertTrue(bool(np.array_equal(before[1], after[1])))
+        self.assertEqual(expected_next, float(np.random.rand()))
+
+    def test_seed_context_restores_numpy_state_on_exception(self):
+        """seed_context restores NumPy's state even when the block raises.
+        Regression test for M27."""
+        np.random.seed(2024)
+        before = np.random.get_state()
+        with self.assertRaises(ValueError):
+            with brainstate.random.seed_context(123):
+                _ = np.random.rand(5)
+                raise ValueError("boom")
+        after = np.random.get_state()
+        self.assertTrue(bool(np.array_equal(before[1], after[1])))
+        self.assertEqual(before[2], after[2])

--- a/brainstate/random/_seed_test.py
+++ b/brainstate/random/_seed_test.py
@@ -243,14 +243,16 @@ class TestSeedUtilities(unittest.TestCase):
             brainstate.random.split_keys(2.5)
 
     def test_split_key_with_backup_then_restore(self):
-        """split_key(backup=True) records a backup that restore_key can recover."""
+        """split_key(backup=True) backs up the pre-split key so restore_key rewinds."""
         brainstate.random.seed(5)
+        original = brainstate.random.get_key()  # capture BEFORE the split
         keys = brainstate.random.split_key(2, backup=True)
         self.assertEqual(keys.shape, (2,))
-        backed_up = brainstate.random.get_key()
         _ = brainstate.random.rand(2)  # advance state
         brainstate.random.restore_key()
-        self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), backed_up)))
+        # restore rewinds to the original pre-split key (documented contract),
+        # not the already-advanced key.
+        self.assertTrue(bool(jnp.array_equal(brainstate.random.get_key(), original)))
 
     # ------------------------------------------------------------------ #
     # restore_key                                                        #
@@ -272,7 +274,7 @@ class TestSeedUtilities(unittest.TestCase):
         brainstate.random.self_assign_multi_keys(3, backup=True)
         # the working value now holds the n multi-keys (batch of typed keys)
         self.assertEqual(brainstate.random.get_key().shape, (3,))
-        # restore_key recovers a usable single key (the intermediate split key)
+        # restore_key recovers the original pre-assignment single key
         brainstate.random.restore_key()
         restored = brainstate.random.get_key()
         self.assertEqual(restored.shape, ())

--- a/brainstate/random/_seed_test.py
+++ b/brainstate/random/_seed_test.py
@@ -576,3 +576,38 @@ class TestSeedGlobalStateEdgeCases(unittest.TestCase):
         after = np.random.get_state()
         self.assertTrue(bool(np.array_equal(before[1], after[1])))
         self.assertEqual(before[2], after[2])
+
+    # ------------------------------------------------------------------ #
+    # seed_context(None): auto-generate a concrete seed on entry          #
+    # ------------------------------------------------------------------ #
+
+    def test_seed_context_none_yields_usable_state_and_restores(self):
+        """seed_context(None) auto-generates a concrete seed on entry (so the
+        block has a usable, NumPy-seeding RNG state) yet still fully restores
+        both the JAX key and NumPy's global state on exit."""
+        brainstate.random.seed(7)
+        before_key = brainstate.random.get_key()
+        np.random.seed(555)
+        np_before = np.random.get_state()
+        with brainstate.random.seed_context(None):
+            drawn = brainstate.random.rand(3)
+            np_inside = float(np.random.rand())
+        # The context produced a usable JAX draw and a usable NumPy draw.
+        self.assertEqual(drawn.shape, (3,))
+        self.assertIsInstance(np_inside, float)
+        # Both backends are restored to their pre-context state on exit.
+        after_key = brainstate.random.get_key()
+        self.assertTrue(bool(jnp.array_equal(before_key, after_key)))
+        np_after = np.random.get_state()
+        self.assertTrue(bool(np.array_equal(np_before[1], np_after[1])))
+        self.assertEqual(np_before[2], np_after[2])
+
+    def test_seed_context_none_uses_fresh_seed_each_entry(self):
+        """seed_context(None) draws a fresh random seed on every entry (rather
+        than leaving the RNG unseeded), so two independent None-contexts almost
+        surely yield different draws."""
+        with brainstate.random.seed_context(None):
+            a = brainstate.random.rand(8)
+        with brainstate.random.seed_context(None):
+            b = brainstate.random.rand(8)
+        self.assertFalse(bool(jnp.allclose(a, b)))

--- a/brainstate/random/_state.py
+++ b/brainstate/random/_state.py
@@ -63,6 +63,24 @@ def _randn_static_argnums(self, *dn, **kwargs):
     return tuple(range(len(dn) + 1))
 
 
+def _static(*intended):
+    """Build a ``static_argnums`` callable that clamps the intended static indices
+    to the positional arguments actually supplied.
+
+    ``size``/``dtype``/``check_valid``/... are declared static so they stay static
+    when passed positionally, but ``_fun.py`` and ordinary calls pass them as
+    keywords. brainstate's ``StatefulFunction`` raises if a static index exceeds the
+    number of positional args (unlike ``jax.jit``), so we intersect the intended
+    indices with the provided positional slots (``+1`` accounts for ``self``). Names
+    passed as keywords are still marked static via ``static_argnames``.
+    """
+
+    def fn(self, *args, **kwargs):
+        return tuple(i for i in intended if i < 1 + len(args))
+
+    return fn
+
+
 class RandomState(State):
     """RandomState that track the random generator state. """
 
@@ -190,7 +208,12 @@ class RandomState(State):
           ``(n,)``.
         """
         if n is not None:
-            assert isinstance(n, int) and n >= 1, f'n should be an integer greater than 1, but we got {n}'
+            try:
+                n = index(n)
+            except TypeError:
+                raise TypeError(f'n must be an integer, but got {n!r}')
+            if n < 1:
+                raise ValueError(f'n should be a positive integer, but got {n}')
 
         # Reading ``self.value`` materializes a lazy placeholder into a typed key.
         keys = jr.split(self.value, num=2 if n is None else n + 1)
@@ -210,6 +233,12 @@ class RandomState(State):
         """
         Self-assign multiple keys to the current random state.
         """
+        try:
+            n = index(n)
+        except TypeError:
+            raise TypeError(f'n must be an integer, but got {n!r}')
+        if n < 1:
+            raise ValueError(f'n should be a positive integer, but got {n}')
         if backup:
             keys = jr.split(self.value, n + 1)
             self.value = keys[0]
@@ -239,7 +268,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 4),
+        static_argnums=_static(0, 3, 4),
         static_argnames=['dtype', 'size']
     )
     def randint(
@@ -270,7 +299,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5),
+        static_argnums=_static(0, 3, 5),
         static_argnames=['dtype', 'size']
     )
     def random_integers(
@@ -317,7 +346,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 1, 3),
+        static_argnums=_static(0, 1, 3),
         static_argnames=['dtype', 'size']
     )
     def random(
@@ -332,7 +361,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 1, 3),
+        static_argnums=_static(0, 1, 3),
         static_argnames=['dtype', 'size']
     )
     def random_sample(
@@ -346,7 +375,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 1, 3),
+        static_argnums=_static(0, 1, 3),
         static_argnames=['dtype', 'size']
     )
     def ranf(
@@ -358,7 +387,7 @@ class RandomState(State):
         r = self.random(size=size, key=key, dtype=dtype or environ.dftype())
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 1, 3), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 1, 3), static_argnames=['dtype', 'size'])
     def sample(
         self,
         size: Optional[Size] = None,
@@ -370,7 +399,10 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=lambda self, a, *args, **kwargs: (0, 1, 2, 3) if isinstance(a, int) else (0, 2, 3),
+        static_argnums=lambda self, a, *args, **kwargs: tuple(
+            i for i in ((0, 1, 2, 3) if isinstance(a, int) else (0, 2, 3))
+            if i < 2 + len(args)  # +1 for self, +1 for the always-present ``a``
+        ),
         static_argnames=['size', 'replace']
     )
     def choice(
@@ -381,16 +413,32 @@ class RandomState(State):
         p=None,
         key: Optional[SeedOrKey] = None
     ):
-        a = _check_py_seq(a)
-        a, unit = u.split_mantissa_unit(a)
         p = _check_py_seq(p)
         key = self.__get_key(key)
+        # Non-numeric array-likes (string/object/bytes) cannot be represented as a
+        # JAX array, so ``_check_py_seq``/``split_mantissa_unit``/``jr.choice`` would
+        # raise. Detect them on the raw input *before* any jax coercion (JAX tracers
+        # and arrays are always numeric, so we never materialize a tracer here), then
+        # sample integer indices and gather from a plain numpy array.
+        if not isinstance(a, int) and not isinstance(a, (jax.Array, u.Quantity)):
+            arr = np.asarray(a)
+            if arr.dtype.kind not in 'biufc':
+                idx = jr.choice(
+                    key,
+                    a=np.arange(arr.shape[0]),
+                    shape=_size2shape(size),
+                    replace=replace,
+                    p=p,
+                )
+                return arr[np.asarray(idx)]
+        a = _check_py_seq(a)
+        a, unit = u.split_mantissa_unit(a)
         r = jr.choice(key, a=a, shape=_size2shape(size), replace=replace, p=p)
         return u.maybe_decimal(r * unit)
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 2, 3),
+        static_argnums=_static(0, 2, 3),
         static_argnames=['axis', 'independent']
     )
     def permutation(
@@ -406,7 +454,7 @@ class RandomState(State):
         r = jr.permutation(key, x, axis, independent=independent)
         return u.maybe_decimal(r * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 2), static_argnames=['axis'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2), static_argnames=['axis'])
     def shuffle(
         self,
         x,
@@ -415,7 +463,7 @@ class RandomState(State):
     ):
         return self.permutation(x, axis=axis, key=key, independent=False)
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def beta(
         self,
         a,
@@ -432,7 +480,7 @@ class RandomState(State):
         r = jr.beta(key, a=a, b=b, shape=_size2shape(size), dtype=dtype or environ.dftype())
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def exponential(
         self,
         scale=None,
@@ -453,7 +501,7 @@ class RandomState(State):
             r = r * u.math.asarray(scale_m, dtype=dtype)
         return u.maybe_decimal(r * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def gamma(
         self,
         shape,
@@ -475,7 +523,7 @@ class RandomState(State):
             r = r * scale_m
         return u.maybe_decimal(r * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def gumbel(
         self,
         loc=None,
@@ -494,7 +542,7 @@ class RandomState(State):
         r = _loc_scale(loc, scale, jr.gumbel(key, shape=_size2shape(size), dtype=dtype or environ.dftype()))
         return u.maybe_decimal(r * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def laplace(
         self,
         loc=None,
@@ -513,7 +561,7 @@ class RandomState(State):
         r = _loc_scale(loc, scale, jr.laplace(key, shape=_size2shape(size), dtype=dtype or environ.dftype()))
         return u.maybe_decimal(r * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def logistic(
         self,
         loc=None,
@@ -532,7 +580,7 @@ class RandomState(State):
         r = _loc_scale(loc, scale, jr.logistic(key, shape=_size2shape(size), dtype=dtype or environ.dftype()))
         return u.maybe_decimal(r * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def normal(
         self,
         loc=None,
@@ -552,7 +600,7 @@ class RandomState(State):
         r = _loc_scale(loc, scale, jr.normal(key, shape=_size2shape(size), dtype=dtype))
         return u.maybe_decimal(r * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def pareto(
         self,
         a,
@@ -569,7 +617,7 @@ class RandomState(State):
         r = jr.pareto(key, b=a, shape=_size2shape(size), dtype=dtype)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def poisson(
         self,
         lam=1.0,
@@ -585,7 +633,7 @@ class RandomState(State):
         r = jr.poisson(key, lam=lam, shape=_size2shape(size), dtype=dtype)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 1, 3), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 1, 3), static_argnames=['dtype', 'size'])
     def standard_cauchy(
         self,
         size: Optional[Size] = None,
@@ -597,7 +645,7 @@ class RandomState(State):
         r = jr.cauchy(key, shape=_size2shape(size), dtype=dtype)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 1, 3), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 1, 3), static_argnames=['dtype', 'size'])
     def standard_exponential(
         self,
         size: Optional[Size] = None,
@@ -609,7 +657,7 @@ class RandomState(State):
         r = jr.exponential(key, shape=_size2shape(size), dtype=dtype)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def standard_gamma(
         self,
         shape,
@@ -625,7 +673,7 @@ class RandomState(State):
         r = jr.gamma(key, a=shape, shape=_size2shape(size), dtype=dtype)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 1, 3), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 1, 3), static_argnames=['dtype', 'size'])
     def standard_normal(
         self,
         size: Optional[Size] = None,
@@ -637,7 +685,7 @@ class RandomState(State):
         r = jr.normal(key, shape=_size2shape(size), dtype=dtype)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def standard_t(
         self,
         df,
@@ -657,7 +705,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5),
+        static_argnums=_static(0, 3, 5),
         static_argnames=['dtype', 'size']
     )
     def uniform(
@@ -685,7 +733,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 7, 8),
+        static_argnums=_static(0, 3, 7, 8),
         static_argnames=['dtype', 'size', 'check_valid'],
     )
     def truncated_normal(
@@ -773,7 +821,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 2, 4),
+        static_argnums=_static(0, 2, 4),
         static_argnames=['size', 'check_valid']
     )
     def bernoulli(
@@ -795,7 +843,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5),
+        static_argnums=_static(0, 3, 5),
         static_argnames=['dtype', 'size']
     )
     def lognormal(
@@ -825,7 +873,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5, 6),
+        static_argnums=_static(0, 3, 5, 6),
         static_argnames=['dtype', 'size', 'check_valid']
     )
     def binomial(
@@ -855,17 +903,21 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 2, 4),
-        static_argnames=['dtype', 'size']
+        static_argnums=_static(0, 2, 4, 5),
+        static_argnames=['dtype', 'size', 'check_valid']
     )
     def chisquare(
         self,
         df,
         size: Optional[Size] = None,
         key: Optional[SeedOrKey] = None,
-        dtype: DTypeLike = None
+        dtype: DTypeLike = None,
+        check_valid: bool = True
     ):
         df = _remove_unit_param('df', _check_py_seq(df))
+        if check_valid:
+            from brainstate.transform._error_if import jit_error_if
+            jit_error_if(jnp.any(jnp.asarray(df) <= 0), 'df must be > 0, but we got {df}', df=df)
         key = self.__get_key(key)
         dtype = dtype or environ.dftype()
         if size is None:
@@ -880,7 +932,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 2, 4),
+        static_argnums=_static(0, 2, 4),
         static_argnames=['dtype', 'size']
     )
     def dirichlet(
@@ -898,7 +950,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 2, 4),
+        static_argnums=_static(0, 2, 4),
         static_argnames=['dtype', 'size']
     )
     def geometric(
@@ -922,11 +974,13 @@ class RandomState(State):
         return u.math.asarray(r, dtype=dtype or environ.ditype())
 
     def _check_p2(self, p):
-        raise ValueError(f'We require `sum(pvals[:-1]) <= 1`. But we got {p}')
+        raise ValueError(
+            f'We require `sum(pvals[..., :-1], axis=-1) <= 1` for every distribution. But we got {p}'
+        )
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5, 6),
+        static_argnums=_static(0, 3, 5, 6),
         static_argnames=['dtype', 'size', 'check_valid']
     )
     def multinomial(
@@ -943,7 +997,7 @@ class RandomState(State):
         pvals = _remove_unit_param('pvals', _check_py_seq(pvals))
         if check_valid:
             from brainstate.transform._error_if import jit_error_if
-            jit_error_if(jnp.sum(pvals[:-1]) > 1., self._check_p2, pvals)
+            jit_error_if(jnp.any(jnp.sum(pvals[..., :-1], axis=-1) > 1.), self._check_p2, pvals)
         if isinstance(n, Tracer):
             raise ValueError("The total count parameter `n` should not be a jax abstract array.")
         size = _size2shape(size)
@@ -955,7 +1009,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 4, 6),
+        static_argnums=_static(0, 3, 4, 6),
         static_argnames=['dtype', 'size', 'method']
     )
     def multivariate_normal(
@@ -973,8 +1027,12 @@ class RandomState(State):
         mean = u.math.asarray(_check_py_seq(mean), dtype=dtype)
         cov = u.math.asarray(_check_py_seq(cov), dtype=dtype)
         if isinstance(mean, u.Quantity):
-            assert isinstance(cov, u.Quantity), 'cov must carry a unit when mean does.'
-            assert mean.unit ** 2 == cov.unit, 'cov unit must equal mean unit squared.'
+            if not isinstance(cov, u.Quantity):
+                raise u.UnitMismatchError('cov must carry a unit when mean does; '
+                                          f'got mean.unit={mean.unit} but a unitless cov.')
+            if mean.unit ** 2 != cov.unit:
+                raise u.UnitMismatchError('cov unit must equal mean unit squared; '
+                                          f'expected {mean.unit ** 2}, got {cov.unit}.')
         # Capture the output unit *before* stripping the mantissa from ``mean``.
         unit = mean.unit if isinstance(mean, u.Quantity) else u.UNITLESS
         mean = mean.mantissa if isinstance(mean, u.Quantity) else mean
@@ -1009,7 +1067,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 2, 4),
+        static_argnums=_static(0, 2, 4),
         static_argnames=['dtype', 'size']
     )
     def rayleigh(
@@ -1030,7 +1088,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 4, 6),
+        static_argnums=_static(0, 4, 6),
         static_argnames=['dtype', 'size']
     )
     def triangular(
@@ -1086,7 +1144,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5),
+        static_argnums=_static(0, 3, 5),
         static_argnames=['dtype', 'size']
     )
     def vonmises(
@@ -1115,7 +1173,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 2, 4),
+        static_argnums=_static(0, 2, 4),
         static_argnames=['dtype', 'size']
     )
     def weibull(
@@ -1140,7 +1198,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5),
+        static_argnums=_static(0, 3, 5),
         static_argnames=['dtype', 'size']
     )
     def weibull_min(
@@ -1172,7 +1230,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 1, 3),
+        static_argnums=_static(0, 1, 3),
         static_argnames=['dtype', 'size']
     )
     def maxwell(
@@ -1190,7 +1248,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5),
+        static_argnums=_static(0, 3, 5),
         static_argnames=['dtype', 'size']
     )
     def negative_binomial(
@@ -1217,7 +1275,7 @@ class RandomState(State):
 
     @named_scope(
         'brainstate/random',
-        static_argnums=(0, 3, 5),
+        static_argnums=_static(0, 3, 5),
         static_argnames=['dtype', 'size']
     )
     def wald(
@@ -1236,8 +1294,13 @@ class RandomState(State):
         if size is None:
             size = lax.broadcast_shapes(u.math.shape(mean), u.math.shape(scale))
         size = _size2shape(size)
-        sampled_chi2 = jnp.square(self.randn(*size))
-        sampled_uniform = self.uniform(size=size, key=key, dtype=dtype)
+        # Derive two independent sub-keys from the (already normalized) key so both
+        # draws are reproducible in the supplied key and neither consumes the global
+        # RNG stream. Threading dtype keeps the chi-square draw consistent with the
+        # uniform draw (e.g. float16).
+        k_chi2, k_uni = jr.split(key, 2)
+        sampled_chi2 = jnp.square(self.randn(*size, key=k_chi2, dtype=dtype))
+        sampled_uniform = self.uniform(size=size, key=k_uni, dtype=dtype)
         # Wikipedia defines an intermediate x with the formula
         #   x = loc + loc ** 2 * y / (2 * conc) - loc / (2 * conc) * sqrt(4 * loc * conc * y + loc ** 2 * y ** 2)
         # where y ~ N(0, 1)**2 (sampled_chi2 above) and conc is the concentration.
@@ -1269,7 +1332,7 @@ class RandomState(State):
                         jnp.square(mean) / sampled)
         return u.maybe_decimal(res * unit)
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def t(
         self,
         df,
@@ -1295,7 +1358,7 @@ class RandomState(State):
         r = n * jnp.sqrt(half_df / g)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 1, 2, 4), static_argnames=['n', 'dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 1, 2, 4), static_argnames=['n', 'dtype', 'size'])
     def orthogonal(
         self,
         n: int,
@@ -1314,7 +1377,7 @@ class RandomState(State):
         r = q * jnp.expand_dims(d / abs(d), -2)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def noncentral_chisquare(
         self,
         df,
@@ -1341,7 +1404,7 @@ class RandomState(State):
         r = jnp.where(cond, chi2 + n * n, chi2)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def loggamma(
         self,
         a,
@@ -1357,7 +1420,7 @@ class RandomState(State):
         r = jr.loggamma(key, a, shape=_size2shape(size), dtype=dtype)
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 3), static_argnames=['dtype', 'size', 'axis'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 3), static_argnames=['dtype', 'size', 'axis'])
     def categorical(
         self,
         logits,
@@ -1373,7 +1436,7 @@ class RandomState(State):
         r = jr.categorical(key, logits, axis=axis, shape=_size2shape(size))
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def zipf(
         self,
         a,
@@ -1392,15 +1455,19 @@ class RandomState(State):
         )
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4, 5), static_argnames=['dtype', 'size', 'check_valid'])
     def power(
         self,
         a,
         size: Optional[Size] = None,
         key: Optional[SeedOrKey] = None,
-        dtype: DTypeLike = None
+        dtype: DTypeLike = None,
+        check_valid: bool = True
     ):
         a = _remove_unit_param('a', _check_py_seq(a))
+        if check_valid:
+            from brainstate.transform._error_if import jit_error_if
+            jit_error_if(jnp.any(jnp.asarray(a) <= 0), 'Parameter a must be > 0, but we got {a}', a=a)
         if size is None:
             size = u.math.shape(a)
         size = _size2shape(size)
@@ -1412,7 +1479,7 @@ class RandomState(State):
         )
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 3, 5), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 3, 5), static_argnames=['dtype', 'size'])
     def f(
         self,
         dfnum,
@@ -1435,7 +1502,7 @@ class RandomState(State):
         )
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 4, 6), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 4, 6), static_argnames=['dtype', 'size'])
     def hypergeometric(
         self,
         ngood,
@@ -1465,7 +1532,7 @@ class RandomState(State):
         )
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 2, 4), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2, 4), static_argnames=['dtype', 'size'])
     def logseries(
         self,
         p,
@@ -1485,7 +1552,7 @@ class RandomState(State):
         )
         return r
 
-    @named_scope('brainstate/random', static_argnums=(0, 4, 6), static_argnames=['dtype', 'size'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 4, 6), static_argnames=['dtype', 'size'])
     def noncentral_f(
         self,
         dfnum,
@@ -1516,7 +1583,7 @@ class RandomState(State):
     # PyTorch compatibility #
     # --------------------- #
 
-    @named_scope('brainstate/random', static_argnums=(0, 2), static_argnames=['dtype'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2), static_argnames=['dtype'])
     def rand_like(
         self,
         input,
@@ -1539,9 +1606,10 @@ class RandomState(State):
         -------
         The random data.
         """
+        dtype = dtype if dtype is not None else u.math.get_dtype(input)
         return self.random(u.math.shape(input), key=key).astype(dtype)
 
-    @named_scope('brainstate/random', static_argnums=(0, 2), static_argnames=['dtype'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 2), static_argnames=['dtype'])
     def randn_like(
         self,
         input,
@@ -1564,9 +1632,10 @@ class RandomState(State):
         -------
         The random data.
         """
+        dtype = dtype if dtype is not None else u.math.get_dtype(input)
         return self.randn(*u.math.shape(input), key=key).astype(dtype)
 
-    @named_scope('brainstate/random', static_argnums=(0, 4), static_argnames=['dtype'])
+    @named_scope('brainstate/random', static_argnums=_static(0, 4), static_argnames=['dtype'])
     def randint_like(
         self,
         input,
@@ -1579,7 +1648,11 @@ class RandomState(State):
             # ``max`` (the Python builtin) raises on multi-dimensional arrays; use an
             # array reduction so any-rank templates work.
             high = u.math.max(input)
-        return self.randint(low, high, size=u.math.shape(input), dtype=dtype, key=key)
+        # Default to the template's dtype when ``dtype`` is None (PyTorch contract).
+        # ``self.randint`` only accepts integer dtypes, so sample with its default
+        # integer dtype and cast afterward (``out_dtype`` may be a float template).
+        out_dtype = dtype if dtype is not None else u.math.get_dtype(input)
+        return self.randint(low, high, size=u.math.shape(input), key=key).astype(out_dtype)
 
 
 # default random generator

--- a/brainstate/random/_state.py
+++ b/brainstate/random/_state.py
@@ -15,6 +15,7 @@
 
 # -*- coding: utf-8 -*-
 
+import threading
 from operator import index
 from typing import Optional
 
@@ -57,6 +58,16 @@ __all__ = [
     'RandomState',
     'DEFAULT',
 ]
+
+# Serializes the read-modify-write of a RandomState's key (read ``self.value``,
+# ``jr.split``, write ``keys[0]`` back). The module-global ``DEFAULT`` is shared
+# across threads, so an unguarded RMW could let two threads observe the same key
+# and produce correlated streams, or lose an update. A module-level (rather than
+# per-instance) lock keeps RandomState free of an unpicklable / non-pytree
+# attribute; the guarded section is a tiny pure-Python critical region, so
+# serializing it across instances is negligible overhead. Reentrant so that a
+# guarded method may call another guarded helper without self-deadlock.
+_KEY_RMW_LOCK = threading.RLock()
 
 
 def _randn_static_argnums(self, *dn, **kwargs):
@@ -145,7 +156,10 @@ class RandomState(State):
             self.seed()
 
     def _numpy_keys(self, batch_size):
-        return np.random.randint(0, 10000, (batch_size, 2), dtype=np.uint32)
+        # Draw seeds from the full uint32 range. The previous ``[0, 10000)`` range
+        # was small enough to make collisions (and thus correlated keys) likely; the
+        # full range matches the seeding used elsewhere in this class.
+        return np.random.randint(0, 2 ** 32, (batch_size, 2), dtype=np.uint32)
 
     # ------------------- #
     # seed and random key #
@@ -215,11 +229,18 @@ class RandomState(State):
             if n < 1:
                 raise ValueError(f'n should be a positive integer, but got {n}')
 
-        # Reading ``self.value`` materializes a lazy placeholder into a typed key.
-        keys = jr.split(self.value, num=2 if n is None else n + 1)
-        self.value = keys[0]
-        if backup:
-            self.backup_key()
+        # Hold the lock across the whole read-modify-write so a concurrent splitter
+        # (notably on the shared ``DEFAULT``) cannot observe the same key.
+        with _KEY_RMW_LOCK:
+            # Reading ``self.value`` materializes a lazy placeholder into a typed key.
+            keys = jr.split(self.value, num=2 if n is None else n + 1)
+            if backup:
+                # ``self.value`` is still the pre-split key here. Back it up so
+                # ``restore_key`` rewinds to the original state (the documented
+                # contract); backing up after ``self.value = keys[0]`` would record
+                # the already-advanced key and make restore a no-op.
+                self.backup_key()
+            self.value = keys[0]
         if n is None:
             return keys[1]
         else:
@@ -239,13 +260,15 @@ class RandomState(State):
             raise TypeError(f'n must be an integer, but got {n!r}')
         if n < 1:
             raise ValueError(f'n should be a positive integer, but got {n}')
-        if backup:
-            keys = jr.split(self.value, n + 1)
-            self.value = keys[0]
-            self.backup_key()
-            self.value = keys[1:]
-        else:
-            self.value = jr.split(self.value, n)
+        with _KEY_RMW_LOCK:
+            # ``jr.split`` reads (and materializes) the current pre-assignment key.
+            new_keys = jr.split(self.value, n)
+            if backup:
+                # ``self.value`` is still the pre-assignment key here; back it up so
+                # ``restore_key`` rewinds to the original single-key state rather than
+                # an intermediate advanced key.
+                self.backup_key()
+            self.value = new_keys
 
     def __get_key(self, key):
         return self.split_key() if key is None else _format_key(key)
@@ -961,6 +984,16 @@ class RandomState(State):
         dtype: DTypeLike = None
     ):
         p = _remove_unit_param('p', _check_py_seq(p))
+        # NumPy raises for ``p <= 0`` or ``p > 1``; without this guard those inputs
+        # silently yield garbage (e.g. ``p == 0`` produces the integer-overflow
+        # sentinel instead of an error). Use ``jit_error_if`` so the check also
+        # holds under ir_compilation.
+        from brainstate.transform._error_if import jit_error_if
+        jit_error_if(
+            jnp.any(jnp.logical_or(jnp.asarray(p) <= 0, jnp.asarray(p) > 1)),
+            'Parameter p must be in the half-open interval (0, 1], but got {p}',
+            p=p
+        )
         if size is None:
             size = u.math.shape(p)
         key = self.__get_key(key)
@@ -1083,7 +1116,9 @@ class RandomState(State):
         key = self.__get_key(key)
         dtype = dtype or environ.dftype()
         x = jnp.sqrt(-2. * jnp.log(jr.uniform(key, shape=_size2shape(size), dtype=dtype)))
-        r = x * scale_m
+        # ``scale=None`` (an explicitly passed default) means unit scale; multiplying
+        # ``x * None`` would raise a TypeError, so only apply the scale when present.
+        r = x if scale_m is None else x * scale_m
         return u.maybe_decimal(r * unit)
 
     @named_scope(
@@ -1120,6 +1155,22 @@ class RandomState(State):
             return q.mantissa if q.is_unitless else q.in_unit(unit).mantissa
 
         left, mode, right = (_to_shared_unit(v) for v in values)
+
+        # NumPy requires ``left <= mode <= right`` with ``left < right`` and raises
+        # otherwise; without this guard invalid bounds silently produce samples from
+        # the wrong distribution (the inverse-CDF branch selection masks the NaN that
+        # a negative ``sqrt`` argument would otherwise create, so the failure is
+        # silent). ``jit_error_if`` keeps the check valid under ir_compilation.
+        from brainstate.transform._error_if import jit_error_if
+        left_a = jnp.asarray(left)
+        mode_a = jnp.asarray(mode)
+        right_a = jnp.asarray(right)
+        jit_error_if(
+            jnp.any(left_a > mode_a) | jnp.any(mode_a > right_a) | jnp.any(left_a >= right_a),
+            'triangular requires left <= mode <= right and left < right, '
+            'but got left={left}, mode={mode}, right={right}',
+            left=left, mode=mode, right=right
+        )
 
         if size is None:
             size = lax.broadcast_shapes(
@@ -1445,6 +1496,16 @@ class RandomState(State):
         dtype: DTypeLike = None
     ):
         a = _remove_unit_param('a', _check_py_seq(a))
+        # NumPy requires ``a > 1`` and raises ("a <= 1 or a is NaN") otherwise; the
+        # sampler silently returns garbage (it collapses to all-ones) for ``a <= 1``.
+        # ``jit_error_if`` keeps the check valid under ir_compilation. ``a > 1`` is
+        # negated as ``not (a > 1)`` so NaN (which fails every comparison) is rejected.
+        from brainstate.transform._error_if import jit_error_if
+        jit_error_if(
+            jnp.any(jnp.logical_not(jnp.asarray(a) > 1)),
+            'Parameter a must be greater than 1, but got {a}',
+            a=a
+        )
         if size is None:
             size = u.math.shape(a)
         r = zipf(

--- a/brainstate/random/_state_test.py
+++ b/brainstate/random/_state_test.py
@@ -806,16 +806,14 @@ class TestRandomStateMisc(unittest.TestCase):
             self.rs.restore_key()
 
     def test_split_key_with_backup(self):
-        """split_key(backup=True) records the post-split key as the restore point."""
-        # split_key advances the internal key to keys[0] and *then* backs it up,
-        # so the backed-up value is the advanced key, not the pre-split key.
+        """split_key(backup=True) records the pre-split key as the restore point."""
+        # split_key backs up the current key *before* advancing, so restore_key
+        # rewinds to the original pre-split key (the documented contract).
+        pre_split = _key_data(self.rs.value)
         self.rs.split_key(backup=True)
-        post_split = _key_data(self.rs.value)
-        # Advance again, then restore back to the post-split key.
-        self.rs.split_key()
-        self.assertFalse(np.array_equal(_key_data(self.rs.value), post_split))
+        self.assertFalse(np.array_equal(_key_data(self.rs.value), pre_split))
         self.rs.restore_key()
-        np.testing.assert_array_equal(_key_data(self.rs.value), post_split)
+        np.testing.assert_array_equal(_key_data(self.rs.value), pre_split)
 
 
 class TestRandomStateMoreDistributions(unittest.TestCase):
@@ -1369,6 +1367,110 @@ class TestRandomStateAuditFixes(unittest.TestCase):
         """A valid df still samples normally."""
         rs = RandomState(0)
         self.assertEqual(jnp.asarray(rs.chisquare(3.0, 5)).shape, (5,))
+
+    # --- Audit item 8: geometric validates p in (0, 1] --------------------------
+
+    def test_geometric_invalid_p_raises(self):
+        """geometric(p) with p<=0 or p>1 raises (NumPy raises; previously p=0
+        silently returned the int-overflow sentinel)."""
+        rs = RandomState(0)
+        for bad in (0.0, -0.5, 1.5):
+            with self.subTest(p=bad):
+                with self.assertRaises(Exception):
+                    np.asarray(rs.geometric(bad))
+
+    def test_geometric_valid_p_unaffected(self):
+        """A valid p still samples positive integers."""
+        rs = RandomState(0)
+        out = np.asarray(rs.geometric(0.5, size=(50,)))
+        self.assertEqual(out.shape, (50,))
+        self.assertTrue((out >= 1).all())
+
+    # --- Audit item 3: zipf validates a > 1 -------------------------------------
+
+    def test_zipf_invalid_a_raises(self):
+        """zipf(a) with a<=1 raises (NumPy raises 'a <= 1 or a is NaN';
+        previously it silently collapsed to all-ones)."""
+        rs = RandomState(0)
+        for bad in (1.0, 0.5, -1.0):
+            with self.subTest(a=bad):
+                with self.assertRaises(Exception):
+                    np.asarray(rs.zipf(bad, size=(3,)))
+
+    def test_zipf_valid_a_unaffected(self):
+        """A valid a > 1 still samples positive integers."""
+        rs = RandomState(0)
+        out = np.asarray(rs.zipf(2.0, size=(20,)))
+        self.assertEqual(out.shape, (20,))
+        self.assertTrue((out >= 1).all())
+
+    # --- Audit item 9: rayleigh(scale=None) no longer crashes -------------------
+
+    def test_rayleigh_scale_none(self):
+        """rayleigh(scale=None) treats the missing scale as unit scale instead of
+        crashing on ``x * None``."""
+        rs = RandomState(0)
+        out = np.asarray(rs.rayleigh(None, size=(4,)))
+        self.assertEqual(out.shape, (4,))
+        self.assertTrue((out >= 0).all())
+
+    def test_rayleigh_scale_none_matches_unit_scale(self):
+        """scale=None is equivalent to scale=1.0 for the same key."""
+        rs = RandomState(0)
+        key = formalize_key(7)
+        none_out = np.asarray(rs.rayleigh(None, size=(4,), key=key))
+        one_out = np.asarray(rs.rayleigh(1.0, size=(4,), key=key))
+        np.testing.assert_allclose(none_out, one_out)
+
+    # --- Audit item 10: triangular validates left <= mode <= right --------------
+
+    def test_triangular_invalid_bounds_raises(self):
+        """triangular rejects mode>right, left>mode, and left>=right (NumPy
+        raises; previously these silently sampled the wrong distribution)."""
+        rs = RandomState(0)
+        for left, mode, right in [(0.0, 2.0, 1.0), (0.0, -1.0, 1.0), (1.0, 0.5, 1.0)]:
+            with self.subTest(left=left, mode=mode, right=right):
+                with self.assertRaises(Exception):
+                    np.asarray(rs.triangular(left, mode, right, size=(4,)))
+
+    def test_triangular_valid_bounds_unaffected(self):
+        """Valid bounds still produce samples within [left, right]."""
+        rs = RandomState(0)
+        out = np.asarray(rs.triangular(-1.0, 0.0, 1.0, size=(200,)))
+        self.assertTrue((out >= -1.0).all() and (out <= 1.0).all())
+
+    # --- Audit item 5: _numpy_keys draws from the full uint32 range --------------
+
+    def test_numpy_keys_uses_full_uint32_range(self):
+        """_numpy_keys no longer caps seeds at 10000 (which invited collisions)."""
+        rs = RandomState(0)
+        keys = rs._numpy_keys(20000)
+        self.assertEqual(keys.dtype, np.uint32)
+        # With the old [0, 10000) range this maximum could never exceed 9999.
+        self.assertGreater(int(keys.max()), 10000)
+
+    # --- Audit item 4: split_key RMW is serialized under threads (defensive) ----
+
+    def test_split_key_threadsafe_no_duplicate_keys(self):
+        """Concurrent split_key calls on a shared state never hand out the same
+        key (the read-modify-write is lock-guarded). Defensive: scheduling makes
+        a pre-fix failure likely but not strictly deterministic."""
+        import threading
+        rs = RandomState(0)
+        results = []
+        lock = threading.Lock()
+
+        def worker():
+            k = rs.split_key()
+            with lock:
+                results.append(tuple(_key_data(k).tolist()))
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(len(results), len(set(results)))
 
 
 if __name__ == '__main__':

--- a/brainstate/random/_state_test.py
+++ b/brainstate/random/_state_test.py
@@ -1347,6 +1347,50 @@ class TestRandomStateAuditFixes(unittest.TestCase):
         self.assertEqual(jnp.asarray(out).shape, (5,))
         self.assertTrue(bool(jnp.all(jnp.isin(out, jnp.array([10, 20, 30, 40])))))
 
+    def test_choice_numeric_python_list_takes_jax_path(self):
+        """A *numeric* array-like that is neither an int nor a jax.Array/Quantity
+        (e.g. a plain Python list of numbers) passes the early non-numeric guard
+        but, being numeric, falls through to the normal jax.choice path and
+        returns a jax array (the documented numeric behaviour)."""
+        rs = RandomState(0)
+        out = rs.choice([10, 20, 30, 40], size=(5,))
+        # The jax path is taken: result is a numeric jax array, not a numpy gather.
+        self.assertIsInstance(out, jax.Array)
+        self.assertEqual(jnp.asarray(out).shape, (5,))
+        self.assertTrue(bool(jnp.all(jnp.isin(out, jnp.array([10, 20, 30, 40])))))
+
+    def test_choice_numeric_numpy_array_takes_jax_path(self):
+        """A numeric numpy array (not a jax.Array) also routes through the jax
+        choice path rather than the string/object numpy-gather branch."""
+        rs = RandomState(0)
+        out = rs.choice(np.array([1.0, 2.0, 3.0]), size=(4,))
+        self.assertIsInstance(out, jax.Array)
+        self.assertEqual(jnp.asarray(out).shape, (4,))
+        self.assertTrue(bool(jnp.all(jnp.isin(out, jnp.array([1.0, 2.0, 3.0])))))
+
+    # --- self_assign_multi_keys: non-integer n raises TypeError -----------------
+
+    def test_self_assign_multi_keys_non_integer_raises_typeerror(self):
+        """RandomState.self_assign_multi_keys rejects a non-integer n with a
+        TypeError (operator.index fails and is re-raised with a clear message),
+        leaving the state's key unchanged."""
+        rs = RandomState(42)
+        before = _key_data(rs.value)
+        for bad in (1.5, 'x', None, [1, 2]):
+            with self.subTest(n=bad):
+                with self.assertRaises(TypeError):
+                    rs.self_assign_multi_keys(bad)
+        # A rejected call must not have advanced/replaced the key.
+        np.testing.assert_array_equal(_key_data(rs.value), before)
+
+    def test_self_assign_multi_keys_typeerror_message(self):
+        """The TypeError from a non-integer n echoes the offending value."""
+        rs = RandomState(42)
+        with self.assertRaises(TypeError) as ctx:
+            rs.self_assign_multi_keys(1.5)
+        self.assertIn('integer', str(ctx.exception))
+        self.assertIn('1.5', str(ctx.exception))
+
     # --- L17: chisquare raises when df <= 0 -------------------------------------
 
     def test_chisquare_nonpositive_df_raises(self):

--- a/brainstate/random/_state_test.py
+++ b/brainstate/random/_state_test.py
@@ -157,12 +157,34 @@ class TestRandomStateKeyManagement(unittest.TestCase):
                     self.assertFalse(np.array_equal(key, other_key))
 
     def test_split_key_invalid_n(self):
-        """Test split_key with invalid n raises error."""
-        with self.assertRaises(AssertionError):
+        """Test split_key with invalid n raises a (-O-proof) ValueError."""
+        with self.assertRaises(ValueError):
             self.rs.split_key(0)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.rs.split_key(-1)
+
+    def test_split_key_accepts_numpy_int(self):
+        """split_key accepts numpy integer scalars (operator.index), not just int."""
+        keys = self.rs.split_key(np.int64(3))
+        self.assertEqual(len(keys), 3)
+
+    def test_split_key_non_integer_raises_typeerror(self):
+        """split_key rejects a non-integer n with TypeError (e.g. a float)."""
+        with self.assertRaises(TypeError):
+            self.rs.split_key(1.5)
+
+    def test_self_assign_multi_keys_invalid_n(self):
+        """self_assign_multi_keys validates n with a real (-O-proof) ValueError."""
+        with self.assertRaises(ValueError):
+            self.rs.self_assign_multi_keys(0)
+        with self.assertRaises(ValueError):
+            self.rs.self_assign_multi_keys(-2)
+
+    def test_self_assign_multi_keys_accepts_numpy_int(self):
+        """self_assign_multi_keys accepts numpy integer scalars."""
+        self.rs.self_assign_multi_keys(np.int64(3), backup=False)
+        self.assertEqual(self.rs.value.shape, (3,))
 
     def test_backup_restore_key(self):
         """Test backup and restore functionality."""
@@ -1164,6 +1186,189 @@ class TestRandomStateEdgeCases(unittest.TestCase):
         """standard_t honours an explicit size argument."""
         rs = RandomState(9)
         self.assertEqual(rs.standard_t(3.0, size=(3,)).shape, (3,))
+
+
+class TestRandomStateAuditFixes(unittest.TestCase):
+    """Regression tests for the brainstate.random audit fixes."""
+
+    def setUp(self):
+        TRACE_CONTEXT.state_stack.append(StateTraceStack())
+
+    def tearDown(self):
+        TRACE_CONTEXT.state_stack.pop()
+
+    # --- H12 / M29: wald threads the explicit key into BOTH draws ---------------
+
+    def test_wald_same_key_is_reproducible(self):
+        """wald(...) with the same explicit key twice yields identical samples."""
+        rs = RandomState(123)
+        key = formalize_key(42)
+        a = rs.wald(3.0, 2.0, size=4, key=key)
+        b = rs.wald(3.0, 2.0, size=4, key=key)
+        np.testing.assert_array_equal(np.asarray(a), np.asarray(b))
+
+    def test_wald_different_keys_differ(self):
+        """wald(...) with different explicit keys yields different samples."""
+        rs = RandomState(123)
+        a = rs.wald(3.0, 2.0, size=4, key=formalize_key(42))
+        b = rs.wald(3.0, 2.0, size=4, key=formalize_key(7))
+        self.assertFalse(bool(jnp.allclose(jnp.asarray(a), jnp.asarray(b))))
+
+    def test_wald_explicit_key_does_not_mutate_state(self):
+        """Passing an explicit key to wald leaves the instance key unchanged."""
+        rs = RandomState(123)
+        before = _key_data(rs.value)
+        rs.wald(3.0, 2.0, size=4, key=formalize_key(42))
+        np.testing.assert_array_equal(_key_data(rs.value), before)
+
+    def test_wald_seed_independent_of_global_state(self):
+        """wald with a fixed key is deterministic regardless of ambient RNG state."""
+        key = formalize_key(42)
+        rs1 = RandomState(123)
+        rs2 = RandomState(999)
+        np.testing.assert_array_equal(
+            np.asarray(rs1.wald(3.0, 2.0, size=4, key=key)),
+            np.asarray(rs2.wald(3.0, 2.0, size=4, key=key)),
+        )
+
+    def test_wald_honors_dtype_end_to_end(self):
+        """wald respects an explicit float16 dtype on the chi-square draw too."""
+        rs = RandomState(0)
+        out = rs.wald(3.0, 2.0, size=4, dtype=jnp.float16)
+        self.assertEqual(jnp.asarray(out).dtype, jnp.float16)
+
+    # --- H13: multinomial validates the simplex along the last axis -------------
+
+    def test_multinomial_batched_pvals_valid(self):
+        """Batched (B, K) pvals summing to 1 per row no longer falsely raise."""
+        rs = RandomState(0)
+        pvals = jnp.array([[0.5, 0.4, 0.1]] * 3)
+        out = rs.multinomial(jnp.array([10, 10, 10]), pvals)
+        self.assertEqual(out.shape, (3, 3))
+        np.testing.assert_array_equal(np.asarray(out).sum(axis=-1), 10)
+
+    def test_multinomial_batched_invalid_row_raises(self):
+        """A batched pvals with a row whose leading sum exceeds 1 still raises."""
+        rs = RandomState(0)
+        pvals = jnp.array([[0.6, 0.6, 0.5], [0.5, 0.4, 0.1], [0.5, 0.4, 0.1]])
+        with self.assertRaises(Exception):
+            np.asarray(rs.multinomial(jnp.array([10, 10, 10]), pvals))
+
+    def test_multinomial_1d_invalid_still_raises(self):
+        """The 1-D simplex check is preserved (leading sum > 1 rejected)."""
+        rs = RandomState(0)
+        with self.assertRaises(Exception):
+            np.asarray(rs.multinomial(10, jnp.array([0.6, 0.6, 0.5])))
+
+    # --- M28: *_like preserve the template dtype when dtype is None -------------
+
+    def test_rand_like_preserves_input_dtype(self):
+        """rand_like with dtype=None preserves the template's float dtype."""
+        rs = RandomState(0)
+        for dt in (jnp.float16, jnp.bfloat16, jnp.float32):
+            with self.subTest(dtype=dt):
+                self.assertEqual(rs.rand_like(jnp.ones(3, dtype=dt)).dtype, dt)
+
+    def test_randn_like_preserves_input_dtype(self):
+        """randn_like with dtype=None preserves the template's float dtype."""
+        rs = RandomState(0)
+        for dt in (jnp.float16, jnp.bfloat16, jnp.float32):
+            with self.subTest(dtype=dt):
+                self.assertEqual(rs.randn_like(jnp.ones(3, dtype=dt)).dtype, dt)
+
+    def test_randint_like_preserves_integer_dtype(self):
+        """randint_like with dtype=None preserves the template's integer dtype."""
+        rs = RandomState(0)
+        for dt in (jnp.int8, jnp.int16, jnp.int32):
+            with self.subTest(dtype=dt):
+                out = rs.randint_like(jnp.arange(5, dtype=dt), 0, 3)
+                self.assertEqual(out.dtype, dt)
+
+    def test_randint_like_float_template_preserved(self):
+        """randint_like preserves a float template dtype (ints sampled, then cast)."""
+        rs = RandomState(0)
+        out = rs.randint_like(jnp.ones(4, dtype=jnp.float32), 0, 3)
+        self.assertEqual(out.dtype, jnp.float32)
+
+    def test_like_explicit_dtype_still_honored(self):
+        """An explicit dtype still overrides the template dtype for *_like."""
+        rs = RandomState(0)
+        self.assertEqual(rs.rand_like(jnp.ones(3, dtype=jnp.float16), dtype=jnp.float32).dtype,
+                         jnp.float32)
+
+    # --- M30: the full API runs under environ ir_compilation=True ---------------
+
+    def test_api_runs_under_ir_compilation(self):
+        """Public random methods no longer break under ir_compilation=True."""
+        rs = RandomState(0)
+        calls = {
+            'randint': lambda: rs.randint(0, 10, size=(3,)),
+            'random_integers': lambda: rs.random_integers(1, 6, size=(3,)),
+            'random': lambda: rs.random(size=(3,)),
+            'uniform': lambda: rs.uniform(0.0, 1.0, size=(3,)),
+            'normal': lambda: rs.normal(0.0, 1.0, size=(3,)),
+            'choice_int': lambda: rs.choice(5, size=(3,)),
+            'choice_arr': lambda: rs.choice(jnp.arange(5), size=(3,)),
+            'poisson': lambda: rs.poisson(3.0, size=(3,)),
+            'bernoulli': lambda: rs.bernoulli(0.5, size=(3,)),
+            'beta': lambda: rs.beta(2.0, 3.0, size=(3,)),
+            'gamma': lambda: rs.gamma(2.0, size=(3,)),
+            'exponential': lambda: rs.exponential(1.0, size=(3,)),
+            'truncated_normal': lambda: rs.truncated_normal(-1.0, 1.0, size=(3,)),
+            'rand': lambda: rs.rand(3),
+            'randn': lambda: rs.randn(3),
+            'wald': lambda: rs.wald(1.0, 2.0, size=(3,)),
+            'power': lambda: rs.power(2.0, size=(3,)),
+            'chisquare': lambda: rs.chisquare(3.0, size=(3,)),
+            'dirichlet': lambda: rs.dirichlet(jnp.array([1.0, 2.0, 3.0]), size=(2,)),
+            'rayleigh': lambda: rs.rayleigh(1.0, size=(3,)),
+            'triangular': lambda: rs.triangular(-1.0, 0.0, 1.0, size=(3,)),
+            'categorical': lambda: rs.categorical(jnp.zeros((3, 5))),
+        }
+        with brainstate.environ.context(ir_compilation=True):
+            for name, fn in calls.items():
+                with self.subTest(distribution=name):
+                    self.assertTrue(bool(jnp.all(jnp.isfinite(jnp.asarray(fn()).astype(float)))))
+
+    # --- L16: choice supports string/object array-likes -------------------------
+
+    def test_choice_string_array(self):
+        """choice over a string array returns string samples (the documented case)."""
+        rs = RandomState(0)
+        out = rs.choice(['pooh', 'rabbit', 'piglet', 'Christopher'], 5,
+                        p=[0.5, 0.1, 0.1, 0.3])
+        arr = np.asarray(out)
+        self.assertEqual(arr.dtype.kind, 'U')
+        self.assertEqual(arr.shape, (5,))
+        self.assertTrue(set(arr.tolist()).issubset({'pooh', 'rabbit', 'piglet', 'Christopher'}))
+
+    def test_choice_numeric_unaffected(self):
+        """The numeric choice path is unchanged (returns a jax array)."""
+        rs = RandomState(0)
+        out = rs.choice(jnp.array([10, 20, 30, 40]), size=(5,))
+        self.assertEqual(jnp.asarray(out).shape, (5,))
+        self.assertTrue(bool(jnp.all(jnp.isin(out, jnp.array([10, 20, 30, 40])))))
+
+    # --- L17: chisquare raises when df <= 0 -------------------------------------
+
+    def test_chisquare_nonpositive_df_raises(self):
+        """chisquare(df<=0) raises (documented Raises ValueError contract)."""
+        rs = RandomState(0)
+        for bad in (0.0, -2.0):
+            with self.subTest(df=bad):
+                with self.assertRaises(Exception):
+                    np.asarray(rs.chisquare(bad, 5))
+
+    def test_chisquare_check_valid_false_skips_guard(self):
+        """chisquare(check_valid=False) skips the df>0 guard."""
+        rs = RandomState(0)
+        out = rs.chisquare(0.0, 5, check_valid=False)
+        self.assertEqual(jnp.asarray(out).shape, (5,))
+
+    def test_chisquare_valid_df_unaffected(self):
+        """A valid df still samples normally."""
+        rs = RandomState(0)
+        self.assertEqual(jnp.asarray(rs.chisquare(3.0, 5)).shape, (5,))
 
 
 if __name__ == '__main__':

--- a/brainstate/random/_unit_test.py
+++ b/brainstate/random/_unit_test.py
@@ -222,17 +222,17 @@ class TestMultivariateNormalUnits(unittest.TestCase):
         self.assertNotIsInstance(out, u.Quantity)
 
     def test_plain_cov_with_unit_mean_raises(self):
-        """A dimensional mean with a plain ``cov`` is rejected."""
+        """A dimensional mean with a plain ``cov`` is rejected (-O-proof)."""
         mean = jnp.array([0.0, 1.0]) * u.mV
         cov = jnp.array([[1.0, 0.0], [0.0, 1.0]])
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(u.UnitMismatchError):
             _rng().multivariate_normal(mean, cov, size=(5,))
 
     def test_cov_wrong_unit_power_raises(self):
         """``cov`` must be the *square* of the mean's unit (mV, not mV**2 → error)."""
         mean = jnp.array([0.0, 1.0]) * u.mV
         cov = jnp.array([[1.0, 0.0], [0.0, 1.0]]) * u.mV
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(u.UnitMismatchError):
             _rng().multivariate_normal(mean, cov, size=(5,))
 
 

--- a/brainstate/transform/_checkify.py
+++ b/brainstate/transform/_checkify.py
@@ -20,7 +20,7 @@ from typing import Any, Callable
 
 from jax.experimental import checkify as _cfy
 
-from brainstate._state import StateTraceStack
+from brainstate._state import StateTraceStack, TRACE_CONTEXT
 from brainstate._utils import set_module_as
 from brainstate.typing import ArrayLike
 from ._make_jaxpr import StatefulFunction
@@ -194,9 +194,43 @@ def checkify(fun: Callable, errors: Any = user_checks) -> Callable:
 
         # 4. Restore ALL states: writes -> new values, reads -> originals
         #    (prevents tracers leaking into the global State objects).
+        #
+        #    ``restore_value`` deliberately bypasses the tracer-write guard that
+        #    the ``value`` setter enforces. That is safe for read-only states
+        #    (their originals are concrete) and for write-backs performed while a
+        #    brainstate trace is active (the tracers die with that trace). But
+        #    when ``checkify(fun)(...)`` is composed under a *raw* JAX transform
+        #    (jax.jit/vmap/grad/...) and no brainstate trace is active, the
+        #    written values are tracers of that outer trace; restoring them via
+        #    ``restore_value`` would silently store a dead tracer in the global
+        #    State. Route those write-backs through the ``value`` setter so the
+        #    standard guard fires with a descriptive TraceContextError, steering
+        #    users to brainstate.transform.jit/vmap/grad/scan instead.
+        guard_active = not TRACE_CONTEXT.state_stack
         wv_by_id = {id(st): v for st, v in zip(write_states, write_vals)}
-        for st, ov in zip(all_states, orig_vals):
-            st.restore_value(wv_by_id[id(st)] if id(st) in wv_by_id else ov)
+        try:
+            for st, ov in zip(all_states, orig_vals):
+                if id(st) in wv_by_id:
+                    wv = wv_by_id[id(st)]
+                    if guard_active:
+                        # No brainstate trace active: write the value through the
+                        # ``value`` setter so its tracer-write guard runs. The
+                        # setter only rejects tracers whose owning trace differs
+                        # from the current one (raw jax.jit/vmap/grad composition);
+                        # states created inside the current trace are exempted
+                        # there and so restore harmlessly.
+                        st.value = wv
+                    else:
+                        st.restore_value(wv)
+                else:
+                    st.restore_value(ov)
+        except Exception:
+            # The guard fired (raw-transform composition). Roll every state back
+            # to its concrete original so the loud TraceContextError is raised
+            # WITHOUT leaving a dead tracer behind in any global State.
+            for st, ov in zip(all_states, orig_vals):
+                st.restore_value(ov)
+            raise
 
         return err, out
 

--- a/brainstate/transform/_checkify_test.py
+++ b/brainstate/transform/_checkify_test.py
@@ -143,3 +143,78 @@ class TestFailedCheckifyRestoresStates(unittest.TestCase):
             checked(jnp.asarray(3.0))
         self.assertFalse(isinstance(s.value, jax.core.Tracer))
         self.assertEqual(float(s.value), 0.0)
+
+
+class TestCheckifyRawTransformGuard(unittest.TestCase):
+    """A checkify-wrapped function that WRITES a State must not silently leak a
+    tracer into the global State when composed under a *raw* JAX transform
+    (jax.jit/vmap/...). It must raise TraceContextError instead, and the same
+    code under brainstate.transform.jit must succeed and update the state
+    (audit M32)."""
+
+    def test_raw_jit_state_write_raises(self):
+        from brainstate._state import TraceContextError
+
+        s = brainstate.State(jnp.asarray(1.0))
+
+        def f(x):
+            s.value = s.value + x
+            return s.value
+
+        @jax.jit
+        def run(x):
+            return brainstate.transform.checkify(f)(x)[1]
+
+        with self.assertRaises(TraceContextError):
+            run(jnp.asarray(2.0))
+        # The global state must not have been poisoned with a dead tracer.
+        self.assertFalse(isinstance(s.value, jax.core.Tracer))
+
+    def test_raw_vmap_state_write_raises(self):
+        from brainstate._state import TraceContextError
+
+        s = brainstate.State(jnp.asarray(0.0))
+
+        def f(x):
+            s.value = s.value + x
+            return s.value
+
+        def run(x):
+            return brainstate.transform.checkify(f)(x)[1]
+
+        with self.assertRaises(TraceContextError):
+            jax.vmap(run)(jnp.arange(3.0))
+        self.assertFalse(isinstance(s.value, jax.core.Tracer))
+
+    def test_brainstate_jit_state_write_succeeds(self):
+        s = brainstate.State(jnp.asarray(1.0))
+
+        def f(x):
+            s.value = s.value + x
+            return s.value
+
+        @brainstate.transform.jit
+        def run(x):
+            return brainstate.transform.checkify(f)(x)[1]
+
+        out = run(jnp.asarray(2.0))
+        self.assertFalse(isinstance(s.value, jax.core.Tracer))
+        self.assertEqual(float(s.value), 3.0)
+        self.assertEqual(float(out), 3.0)
+
+    def test_raw_jit_read_only_state_still_ok(self):
+        # A checkify-wrapped function that only READS a state composes fine under
+        # raw jax.jit: read-only states are restored to their concrete originals,
+        # so the guard does not spuriously fire.
+        s = brainstate.State(jnp.asarray(5.0))
+
+        def f(x):
+            return s.value + x
+
+        @jax.jit
+        def run(x):
+            return brainstate.transform.checkify(f)(x)[1]
+
+        out = run(jnp.asarray(2.0))
+        self.assertEqual(float(out), 7.0)
+        self.assertEqual(float(s.value), 5.0)

--- a/brainstate/transform/_conditions.py
+++ b/brainstate/transform/_conditions.py
@@ -316,10 +316,13 @@ def ifelse(
     branches = tuple(branches)
     if len(branches) == 0:
         raise ValueError("Empty branch sequence")
-    elif len(branches) == 1:
-        return branches[0](*operands)
+    # Validate the condition/branch length contract before any short-circuit so a
+    # single branch paired with a mismatched number of conditions cannot silently
+    # ignore the conditions.
     if len(conditions) != len(branches):
         raise ValueError("The number of conditions should be equal to the number of branches.")
+    if len(branches) == 1:
+        return branches[0](*operands)
 
     # format index
     conditions = jnp.asarray(conditions, np.int32)

--- a/brainstate/transform/_conditions.py
+++ b/brainstate/transform/_conditions.py
@@ -22,7 +22,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from brainstate._compatible_import import to_concrete_aval, Tracer
+from brainstate._compatible_import import Tracer
 from brainstate._utils import set_module_as
 from brainstate.typing import ArrayLike
 from ._error_if import jit_error_if
@@ -111,7 +111,7 @@ def cond(pred: ArrayLike, true_fun: Callable, false_fun: Callable, *operands) ->
             raise TypeError("Pred type must be either boolean or number, got {}.".format(pred_dtype))
 
     # not jit
-    if jax.config.jax_disable_jit and not isinstance(to_concrete_aval(pred), Tracer):
+    if jax.config.jax_disable_jit and not isinstance(pred, Tracer):
         if pred:
             return true_fun(*operands)
         else:
@@ -222,7 +222,7 @@ def switch(index: ArrayLike, branches: Sequence[Callable], *operands) -> Any:
     index = jax.lax.clamp(lo, index, hi)
 
     # not jit
-    if jax.config.jax_disable_jit and not isinstance(to_concrete_aval(index), Tracer):
+    if jax.config.jax_disable_jit and not isinstance(index, Tracer):
         return branches[int(index)](*operands)
 
     # evaluate jaxpr

--- a/brainstate/transform/_conditions_test.py
+++ b/brainstate/transform/_conditions_test.py
@@ -370,6 +370,13 @@ class TestIfElseValidation(unittest.TestCase):
         with self.assertRaises(ValueError):
             brainstate.transform.ifelse([True, False, False], [lambda: 1, lambda: 2])
 
+    def test_single_branch_mismatched_conditions_raise(self):
+        """A single branch with >1 conditions must not silently short-circuit."""
+        # Previously the single-branch early return bypassed the length check and
+        # silently ignored the extra conditions, returning the lone branch's value.
+        with self.assertRaises(ValueError):
+            brainstate.transform.ifelse([True, False], [lambda: 42.0])
+
     def test_check_cond_false_skips_validation(self):
         """``check_cond=False`` skips the one-hot validation."""
         out = brainstate.transform.ifelse(

--- a/brainstate/transform/_conditions_test.py
+++ b/brainstate/transform/_conditions_test.py
@@ -273,6 +273,24 @@ class TestCondValidation(unittest.TestCase):
             self.assertEqual(brainstate.transform.cond(True, lambda: 1, lambda: 2), 1)
             self.assertEqual(brainstate.transform.cond(False, lambda: 1, lambda: 2), 2)
 
+    def test_vmap_traced_predicate_under_disable_jit(self):
+        """``vmap`` over ``cond`` with a traced predicate works under ``disable_jit``.
+
+        The eager fast-path must be gated on the *predicate* being concrete, not
+        on ``disable_jit`` alone; otherwise a traced ``pred`` from ``vmap`` would
+        reach ``if pred:`` and raise ``TracerBoolConversionError``.
+        """
+        def f(pred, x):
+            return brainstate.transform.cond(pred, lambda v: v + 1.0, lambda v: v - 1.0, x)
+
+        preds = jnp.array([True, False])
+        xs = jnp.array([10.0, 20.0])
+        with jax.disable_jit():
+            out = jax.vmap(f)(preds, xs)
+        # True -> +1, False -> -1, selected per element.
+        self.assertEqual(float(out[0]), 11.0)
+        self.assertEqual(float(out[1]), 19.0)
+
 
 class TestSwitchValidation(unittest.TestCase):
     """Argument validation and the disable-jit fast path for ``switch``."""
@@ -307,6 +325,26 @@ class TestSwitchValidation(unittest.TestCase):
         with jax.disable_jit():
             out = brainstate.transform.switch(1, [lambda x: x, lambda x: x + 100], 1.0)
             self.assertEqual(int(out), 101)
+
+    def test_vmap_traced_index_under_disable_jit(self):
+        """``vmap`` over ``switch`` with a traced index works under ``disable_jit``.
+
+        The eager fast-path must be gated on the *index* being concrete, not on
+        ``disable_jit`` alone; otherwise a traced ``index`` from ``vmap`` would
+        reach ``int(index)`` and raise a concretization error.
+        """
+        branches = [lambda x: x + 1.0, lambda x: x + 10.0, lambda x: x + 100.0]
+
+        def f(index, x):
+            return brainstate.transform.switch(index, branches, x)
+
+        indices = jnp.array([0, 1, 2])
+        xs = jnp.array([1.0, 1.0, 1.0])
+        with jax.disable_jit():
+            out = jax.vmap(f)(indices, xs)
+        self.assertEqual(float(out[0]), 2.0)
+        self.assertEqual(float(out[1]), 11.0)
+        self.assertEqual(float(out[2]), 101.0)
 
 
 class TestIfElseValidation(unittest.TestCase):

--- a/brainstate/transform/_error_if.py
+++ b/brainstate/transform/_error_if.py
@@ -40,7 +40,14 @@ def _err_jit_false_branch(args, kwargs):
 
 def _error_msg(msg, *arg, **kwargs):
     if len(arg):
-        msg = msg % arg
+        # Positional args historically use %-formatting (e.g. "value is %d").
+        # Brace-style positional messages (e.g. "bad value {}") are also natural,
+        # so fall back to str.format when %-formatting does not apply, instead of
+        # raising an opaque "not all arguments converted" TypeError.
+        try:
+            msg = msg % arg
+        except (TypeError, ValueError):
+            msg = msg.format(*arg)
     if len(kwargs):
         msg = msg.format(**kwargs)
     raise ValueError(msg)

--- a/brainstate/transform/_error_if_test.py
+++ b/brainstate/transform/_error_if_test.py
@@ -73,3 +73,24 @@ class TestErrorMsgDirect(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             _error_msg('plain message')
         self.assertIn('plain message', str(ctx.exception))
+
+    def test_positional_brace_style_message(self):
+        """A natural brace-style positional message must format, not raise TypeError."""
+        from brainstate.transform._error_if import _error_msg
+        with self.assertRaises(ValueError) as ctx:
+            _error_msg('bad value {}', 5)
+        self.assertIn('bad value 5', str(ctx.exception))
+
+    def test_positional_brace_style_multiple(self):
+        """Multiple positional args with brace-style placeholders format in order."""
+        from brainstate.transform._error_if import _error_msg
+        with self.assertRaises(ValueError) as ctx:
+            _error_msg('{} vs {}', 1, 2)
+        self.assertIn('1 vs 2', str(ctx.exception))
+
+    def test_jit_error_if_positional_brace_message(self):
+        """jit_error_if with a brace-style positional message raises ValueError, not an opaque format error."""
+        with self.assertRaises(Exception) as ctx:
+            brainstate.transform.jit_error_if(jnp.asarray(True), 'bad value {}', jnp.asarray(5))
+        # The original bug surfaced as "not all arguments converted during string formatting".
+        self.assertNotIn('not all arguments converted', str(ctx.exception))

--- a/brainstate/transform/_eval_shape.py
+++ b/brainstate/transform/_eval_shape.py
@@ -124,7 +124,13 @@ def eval_shape(
         return out_tree
 
     # One abstract trace via the canonical stateful wrapper.
-    stateful_fn = StatefulFunction(_wrapped, name='eval_shape')
+    # ``return_only_write=False`` makes ``get_out_shapes`` carry a proper
+    # ``jax.ShapeDtypeStruct`` for EVERY state the function touches (read or
+    # write), aligned 1:1 with ``state_trace.states``. With the default
+    # (write-only) the read-only slots come back as ``None``, which would map
+    # read-only states to ``None`` in ``state_shape_map`` and break the
+    # documented ``State -> ShapeDtypeStruct`` contract.
+    stateful_fn = StatefulFunction(_wrapped, name='eval_shape', return_only_write=False)
     try:
         stateful_fn.make_jaxpr(*g_args, **g_kwargs)
         out_shapes, state_shapes = stateful_fn.get_out_shapes(*g_args, **g_kwargs)

--- a/brainstate/transform/_eval_shape_test.py
+++ b/brainstate/transform/_eval_shape_test.py
@@ -178,3 +178,39 @@ class TestFailedEvalShapeUnwindsNewStates:
         assert st.stack_level == 0
         st.value = jnp.ones(3)
         assert bool(jnp.allclose(st.value, jnp.ones(3)))
+
+
+class TestEvalShapeReadOnlyStateShapes:
+    """``eval_shape(return_state_shapes=True)`` must return a real
+    ``jax.ShapeDtypeStruct`` for read-only states too, not ``None`` (audit
+    M33)."""
+
+    def test_read_only_state_gets_shapedtypestruct(self):
+        s_read = brainstate.State(jnp.ones(3))
+        s_write = brainstate.State(jnp.zeros(4))
+
+        def f(x):
+            a = s_read.value
+            s_write.value = s_write.value + 1.
+            return a.sum() + x
+
+        sm, out = brainstate.transform.eval_shape(
+            f, jnp.ones(()), return_state_shapes=True
+        )
+        assert isinstance(sm[s_read], jax.ShapeDtypeStruct)
+        assert sm[s_read].shape == (3,)
+        assert isinstance(sm[s_write], jax.ShapeDtypeStruct)
+        assert sm[s_write].shape == (4,)
+
+    def test_pure_read_only_state(self):
+        # A state that is ONLY read (never written) still maps to a shape.
+        s_read = brainstate.State(jnp.ones((2, 5)))
+
+        def f(x):
+            return s_read.value.sum() + x
+
+        sm, out = brainstate.transform.eval_shape(
+            f, jnp.ones(()), return_state_shapes=True
+        )
+        assert isinstance(sm[s_read], jax.ShapeDtypeStruct)
+        assert sm[s_read].shape == (2, 5)

--- a/brainstate/transform/_grad_grad.py
+++ b/brainstate/transform/_grad_grad.py
@@ -336,13 +336,18 @@ def _fwd_grad(
 ) -> Callable:
     tangent_size = () if tangent_size is None else (tangent_size,)
     from brainstate.random._seed import split_key
+    from brainstate.random._impl import _format_key
 
     def wrapper(*args, **kwargs):
         f_partial, params = warp_grad_fn(fun, argnums, args, kwargs)
+        # ``key`` is advertised as ``SeedOrKey`` (int | array). ``jax.random.split``
+        # only accepts a typed/array PRNG key, so normalize any int / size-1
+        # integer-array seed through the canonical formatter before splitting.
+        k = split_key() if key is None else _format_key(key)
         v = jax.tree.map(
-            lambda x, k: jax.random.normal(k, tangent_size + x.shape, x.dtype),
+            lambda x, kk: jax.random.normal(kk, tangent_size + x.shape, x.dtype),
             params,
-            tree_random_split(split_key() if key is None else key, params)
+            tree_random_split(k, params)
         )
         if len(tangent_size) == 0:
             r = jax.jvp(f_partial, (params,), (v,), has_aux=has_aux)

--- a/brainstate/transform/_grad_grad.py
+++ b/brainstate/transform/_grad_grad.py
@@ -344,8 +344,23 @@ def _fwd_grad(
         # only accepts a typed/array PRNG key, so normalize any int / size-1
         # integer-array seed through the canonical formatter before splitting.
         k = split_key() if key is None else _format_key(key)
+
+        def _sample_tangent(x, kk):
+            # ``jax.random.normal`` only accepts inexact (float/complex) dtypes.
+            # Forward-mode gradients w.r.t. an integer/bool parameter are
+            # mathematically undefined (their tangent space is ``float0``), so
+            # raise a clear, actionable error instead of the opaque
+            # "dtype argument to `normal` must be a float or complex dtype".
+            if not jnp.issubdtype(x.dtype, jnp.inexact):
+                raise TypeError(
+                    f"fwd_grad requires differentiable (inexact) parameters, but "
+                    f"got a parameter with dtype {x.dtype}. Cast integer/boolean "
+                    f"parameters to a floating dtype before differentiating."
+                )
+            return jax.random.normal(kk, tangent_size + x.shape, x.dtype)
+
         v = jax.tree.map(
-            lambda x, kk: jax.random.normal(kk, tangent_size + x.shape, x.dtype),
+            _sample_tangent,
             params,
             tree_random_split(k, params)
         )
@@ -355,6 +370,16 @@ def _fwd_grad(
                 loss_value, drct_drv, aux = r
             else:
                 loss_value, drct_drv = r
+            # The single-direction estimator ``v * (J . v)`` is only valid for a
+            # scalar function output: a non-scalar ``drct_drv`` would broadcast
+            # against the tangent leaves and yield a wrong result (or crash on a
+            # shape mismatch). Reject it explicitly.
+            if jnp.ndim(drct_drv) != 0:
+                raise ValueError(
+                    f"fwd_grad only supports scalar-output functions, but the "
+                    f"function output has shape {jnp.shape(drct_drv)}. Use vector_grad "
+                    f"or jacfwd/jacrev for non-scalar outputs."
+                )
             if drct_der_clip is not None:
                 drct_drv = jnp.clip(drct_drv, -drct_der_clip, drct_der_clip)
             grads = jax.tree.map(lambda v_leaf: v_leaf * drct_drv, v)
@@ -366,6 +391,15 @@ def _fwd_grad(
                 aux = jax.tree.map(lambda x: x[0], aux)
             else:
                 loss_value, drct_drv = r
+            # ``drct_drv`` carries a leading sample axis of length ``tangent_size``;
+            # per sample it must be scalar (scalar function output), otherwise the
+            # averaged estimator broadcasts incorrectly.
+            if jnp.ndim(drct_drv) != 1:
+                raise ValueError(
+                    f"fwd_grad only supports scalar-output functions, but the "
+                    f"function output has shape {jnp.shape(drct_drv)[1:]}. Use vector_grad "
+                    f"or jacfwd/jacrev for non-scalar outputs."
+                )
             loss_value = loss_value[0]
             if drct_der_clip is not None:
                 drct_drv = jnp.clip(drct_drv, -drct_der_clip, drct_der_clip)
@@ -426,53 +460,63 @@ def fwd_grad(
     return_value : bool, default False
         Whether to return the loss value.
     has_aux : bool, optional
-        Indicates whether ``fun`` returns a pair where the
+        Indicates whether ``func`` returns a pair where the
         first element is considered the output of the mathematical function to be
         differentiated and the second element is auxiliary data.
-    unit_aware : bool, default False
-        Whether to return the gradient in the unit-aware mode.
-    check_states : bool, default True
-        Whether to check that all grad_states are found in the function.
+    tangent_size : int, optional
+        Number of random tangent directions to average over. ``None`` (the
+        default) uses a single random direction; a positive integer averages the
+        estimator over that many directions.
+    drct_der_clip : float, optional
+        If given, clip each directional derivative to ``[-drct_der_clip,
+        drct_der_clip]`` before forming the gradient estimate.
+    key : int or jax.Array, optional
+        Seed or PRNG key controlling the random tangent directions. When ``None``
+        a key is drawn from the global RNG state.
 
     Returns
     -------
     GradientTransform or callable
-        The vector gradient function.
+        The forward-mode gradient function. The wrapped function must return a
+        scalar (use :func:`vector_grad`, :func:`jacfwd`, or :func:`jacrev` for
+        non-scalar outputs).
+
+    Notes
+    -----
+    ``fwd_grad`` is a stochastic forward-mode estimator: it draws random tangent
+    directions and combines them with the directional derivative, so successive
+    calls with different keys yield different estimates of the same gradient.
 
     Examples
     --------
-    Basic vector gradient computation:
+    Basic forward-mode gradient estimation of a scalar function:
 
     .. code-block:: python
 
         >>> import brainstate
         >>> import jax.numpy as jnp
         >>>
-        >>> # Vector-valued function
+        >>> # Scalar-valued function
         >>> def f(x):
-        ...     return jnp.array([x[0]**2, x[1]**3, x[0]*x[1]])
+        ...     return jnp.sum(x ** 2)
         >>>
-        >>> vector_grad_f = brainstate.transform.vector_grad(f)
+        >>> fwd_grad_f = brainstate.transform.fwd_grad(f, key=0)
         >>> x = jnp.array([2.0, 3.0])
-        >>> gradients = vector_grad_f(x)  # Shape: (3, 2)
+        >>> gradients = fwd_grad_f(x)  # Estimate of [4.0, 6.0]
 
     With states:
 
     .. code-block:: python
 
-        >>> params = brainstate.State(jnp.array([1.0, 2.0]))
+        >>> params = brainstate.ParamState(jnp.array([1.0, 2.0]))
         >>>
-        >>> def model(x):
-        ...     return jnp.array([
-        ...         x * params.value[0],
-        ...         x**2 * params.value[1]
-        ...     ])
+        >>> def model():
+        ...     return jnp.sum(params.value ** 2)
         >>>
-        >>> vector_grad_fn = brainstate.transform.vector_grad(
-        ...     model, grad_states=[params]
+        >>> fwd_grad_fn = brainstate.transform.fwd_grad(
+        ...     model, grad_states=[params], key=0
         ... )
-        >>> x = 3.0
-        >>> param_grads = vector_grad_fn(x)
+        >>> param_grads = fwd_grad_fn()
     """
 
     if isinstance(func, Missing):

--- a/brainstate/transform/_grad_grad_test.py
+++ b/brainstate/transform/_grad_grad_test.py
@@ -612,6 +612,53 @@ class TestForwardGrad(unittest.TestCase):
         self.assertEqual(leaf.shape, (2,))
         self.assertTrue(bool(jnp.all(jnp.isfinite(leaf))))
 
+    def test_fwd_grad_integer_param_raises_clear_error(self):
+        """Integer-dtype params are not differentiable; raise a clear error
+        rather than the opaque ``dtype argument to normal`` from jax.random."""
+        key = brainstate.random.split_key()
+        g = brainstate.transform.fwd_grad(
+            lambda x: jnp.sum(x.astype(jnp.float32) ** 2), key=key
+        )
+        with self.assertRaises(TypeError) as ctx:
+            g(jnp.array([2, 3], dtype=jnp.int32))
+        msg = str(ctx.exception)
+        self.assertNotIn('dtype argument to', msg)
+        self.assertIn('inexact', msg.lower())
+
+    def test_fwd_grad_nonscalar_output_single_direction_raises(self):
+        """A non-scalar function output makes the single-direction estimator
+        ill-defined; raise instead of silently broadcasting (or crashing on a
+        shape mismatch when output and param shapes happen to differ)."""
+        key = brainstate.random.split_key()
+        g = brainstate.transform.fwd_grad(
+            lambda x: jnp.array([x[0] ** 2, x[1] ** 3, x[0] * x[1]]), key=key
+        )
+        with self.assertRaises(ValueError) as ctx:
+            g(jnp.array([2.0, 3.0]))
+        self.assertIn('scalar', str(ctx.exception).lower())
+
+    def test_fwd_grad_nonscalar_output_same_shape_raises(self):
+        """Even when output and param shapes coincide (silent wrong result
+        previously), a non-scalar output must raise."""
+        key = brainstate.random.split_key()
+        g = brainstate.transform.fwd_grad(
+            lambda x: jnp.array([x[0] ** 2, x[1] ** 3]), key=key
+        )
+        with self.assertRaises(ValueError) as ctx:
+            g(jnp.array([2.0, 3.0]))
+        self.assertIn('scalar', str(ctx.exception).lower())
+
+    def test_fwd_grad_nonscalar_output_averaged_raises(self):
+        """The ``tangent_size`` (averaged) path must also reject non-scalar output."""
+        key = brainstate.random.split_key()
+        g = brainstate.transform.fwd_grad(
+            lambda x: jnp.array([x[0] ** 2, x[1] ** 3, x[0] * x[1]]),
+            tangent_size=4, key=key,
+        )
+        with self.assertRaises(ValueError) as ctx:
+            g(jnp.array([2.0, 3.0]))
+        self.assertIn('scalar', str(ctx.exception).lower())
+
 
 class TestArgnumsValidation(unittest.TestCase):
     """Negative or non-integer ``argnums`` must be rejected (audit H3).

--- a/brainstate/transform/_grad_grad_test.py
+++ b/brainstate/transform/_grad_grad_test.py
@@ -585,6 +585,33 @@ class TestForwardGrad(unittest.TestCase):
         self.assertEqual(leaf.shape, (2,))
         self.assertTrue(bool(jnp.all(jnp.isfinite(leaf))))
 
+    def test_fwd_grad_int_seed(self):
+        """A plain ``int`` seed (documented by ``SeedOrKey``) must be accepted
+        and normalized to a typed PRNG key, not crash in ``jax.random.split``
+        (audit M34)."""
+        w = brainstate.ParamState(jnp.array([1.0, 2.0, 3.0]))
+
+        g = brainstate.transform.fwd_grad(
+            lambda: jnp.sum(w.value ** 2), grad_states=w, key=0
+        )()
+        leaf = jax.tree.leaves(g)[0]
+        self.assertEqual(leaf.shape, (3,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(leaf))))
+
+    def test_fwd_grad_size1_array_seed(self):
+        """A size-1 integer array seed (e.g. ``np.array([42])``) must also be
+        accepted (audit M34: the naive ``ndim==0`` check would miss it)."""
+        import numpy as np
+
+        w = brainstate.ParamState(jnp.array([1.0, 2.0]))
+
+        g = brainstate.transform.fwd_grad(
+            lambda: jnp.sum(w.value ** 2), grad_states=w, key=np.array([42])
+        )()
+        leaf = jax.tree.leaves(g)[0]
+        self.assertEqual(leaf.shape, (2,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(leaf))))
+
 
 class TestArgnumsValidation(unittest.TestCase):
     """Negative or non-integer ``argnums`` must be rejected (audit H3).

--- a/brainstate/transform/_grad_transform.py
+++ b/brainstate/transform/_grad_transform.py
@@ -53,7 +53,11 @@ def _check_nan_jit_compatible(values) -> jax.Array:
     leaves = jax.tree.leaves(values)
     has_bad = jnp.array(False)
     for leaf in leaves:
-        if hasattr(leaf, 'dtype') and jnp.issubdtype(leaf.dtype, jnp.floating):
+        # ``jnp.inexact`` covers both real (floating) and complex
+        # (complexfloating) dtypes, so NaN/Inf in holomorphic/complex gradients
+        # is detected too. ``jnp.isnan``/``jnp.isinf`` flag a complex value when
+        # either its real or imaginary component is NaN/Inf.
+        if hasattr(leaf, 'dtype') and jnp.issubdtype(leaf.dtype, jnp.inexact):
             has_bad = has_bad | jnp.any(jnp.isnan(leaf) | jnp.isinf(leaf))
     return has_bad
 
@@ -388,7 +392,13 @@ class GradientTransform(PrettyRepr):
         # >>> # 2. example of return multiple data
         # >>> return scalar_loss, (data1, data2, ...)
         write_state_vals, outs = self._call_target(grad_vals, other_vals, *args, **kwargs)
-        assert isinstance(outs, (tuple, list))
+        if not isinstance(outs, (tuple, list)):
+            raise TypeError(
+                "When has_aux=True, the differentiated function must return a "
+                "(loss, aux) pair (a tuple or list), but got a return value of "
+                f"type {type(outs).__name__}. Return the auxiliary data alongside "
+                "the loss, e.g. `return loss, aux`."
+            )
         return outs[0], (outs, write_state_vals)
 
     def _fun_without_aux(self, grad_vals: Dict, other_vals: Dict, *args, **kwargs):

--- a/brainstate/transform/_grad_transform_test.py
+++ b/brainstate/transform/_grad_transform_test.py
@@ -165,6 +165,41 @@ class TestGradientTransformDebugNaN(unittest.TestCase):
         grads = gt()
         self.assertTrue(bool(jnp.allclose(grads, jnp.array([6.0, 8.0]))))
 
+    def test_nan_check_detects_complex(self):
+        """The JIT-compatible NaN check must flag NaN in complex gradients."""
+        from brainstate.transform._grad_transform import _check_nan_jit_compatible
+        clean = jnp.array([1.0 + 2.0j], dtype=jnp.complex64)
+        nan_real = jnp.array([complex(float('nan'), 1.0)], dtype=jnp.complex64)
+        nan_imag = jnp.array([complex(1.0, float('nan'))], dtype=jnp.complex64)
+        self.assertFalse(bool(_check_nan_jit_compatible(clean)))
+        self.assertTrue(bool(_check_nan_jit_compatible(nan_real)))
+        self.assertTrue(bool(_check_nan_jit_compatible(nan_imag)))
+
+
+class TestHasAuxValidation(unittest.TestCase):
+    """``has_aux=True`` requires the function to return a (loss, aux) pair."""
+
+    def test_non_tuple_aux_return_raises_type_error(self):
+        """A non-(tuple/list) return under has_aux=True raises a clear TypeError,
+        not a bare assertion stripped under ``python -O``."""
+
+        def f(x):
+            return jnp.sum(x ** 2)  # forgot to return aux
+
+        with self.assertRaises(TypeError) as ctx:
+            brainstate.transform.grad(f, has_aux=True)(jnp.ones((3,)))
+        self.assertIn('has_aux', str(ctx.exception))
+
+    def test_tuple_aux_return_ok(self):
+        """A proper (loss, aux) pair works under has_aux=True."""
+
+        def f(x):
+            return jnp.sum(x ** 2), {'n': x.shape[0]}
+
+        grads, aux = brainstate.transform.grad(f, has_aux=True)(jnp.ones((2,)))
+        self.assertTrue(bool(jnp.allclose(grads, 2.0 * jnp.ones((2,)))))
+        self.assertEqual(aux['n'], 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/transform/_grad_transform_test.py
+++ b/brainstate/transform/_grad_transform_test.py
@@ -201,5 +201,37 @@ class TestHasAuxValidation(unittest.TestCase):
         self.assertEqual(aux['n'], 2)
 
 
+class TestNanCheckNonInexactLeaves(unittest.TestCase):
+    """``_check_nan_jit_compatible`` only inspects inexact (float/complex)
+    leaves. Integer leaves -- and leaves without a ``dtype`` -- take the False
+    side of the ``hasattr(leaf, 'dtype') and issubdtype(..., inexact)`` guard and
+    are skipped, so they can never (spuriously) report NaN/Inf."""
+
+    def test_integer_leaf_is_skipped(self):
+        from brainstate.transform._grad_transform import _check_nan_jit_compatible
+        # An all-integer pytree has no inexact leaf to test; the guard is False
+        # for every leaf, so the result is a clean False.
+        tree = {'a': jnp.array([1, 2, 3], dtype=jnp.int32),
+                'b': jnp.array([-4, 5], dtype=jnp.int64)}
+        self.assertFalse(bool(_check_nan_jit_compatible(tree)))
+
+    def test_mixed_int_and_float_only_checks_float(self):
+        from brainstate.transform._grad_transform import _check_nan_jit_compatible
+        # The integer leaf is skipped; the NaN in the float leaf is still found.
+        clean = {'i': jnp.array([7, 8], dtype=jnp.int32),
+                 'f': jnp.array([1.0, 2.0], dtype=jnp.float32)}
+        self.assertFalse(bool(_check_nan_jit_compatible(clean)))
+
+        with_nan = {'i': jnp.array([7, 8], dtype=jnp.int32),
+                    'f': jnp.array([1.0, float('nan')], dtype=jnp.float32)}
+        self.assertTrue(bool(_check_nan_jit_compatible(with_nan)))
+
+    def test_bool_leaf_is_skipped(self):
+        from brainstate.transform._grad_transform import _check_nan_jit_compatible
+        # Booleans are integral, not inexact: they are skipped, never flagged.
+        tree = {'mask': jnp.array([True, False, True])}
+        self.assertFalse(bool(_check_nan_jit_compatible(tree)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/transform/_ir_tocode.py
+++ b/brainstate/transform/_ir_tocode.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import ast
 import enum
+import keyword
+import threading
 import warnings
 from collections.abc import MutableMapping, MutableSet
 from contextlib import contextmanager
@@ -145,6 +147,16 @@ class SourcerorState:
 
             name = name[::-1]
 
+            # The base-26 scheme can land on Python (soft) keywords -- e.g.
+            # index 213 -> 'if', 221 -> 'in', 2137 -> 'def' -- which would emit
+            # invalid source such as ``if = ie + 1.0``. Suffix an underscore to
+            # disambiguate. This is collision-safe: no generated name contains
+            # '_', so ``name + '_'`` cannot clash with another generated name.
+            # The adjusted value is what gets cached, so the fast-path above
+            # stays stable.
+            if keyword.iskeyword(name) or keyword.issoftkeyword(name):
+                name = name + '_'
+
             self._var_names[var] = name
 
             return name
@@ -154,7 +166,46 @@ class SourcerorState:
         return f"{prefix}_{self._skolem_count}"
 
 
-prefix_imports = set()
+class _ThreadLocalImports(threading.local):
+    """Thread-local accumulator for the ``import`` lines a generation needs.
+
+    ``prefix_imports`` used to be a single module-global ``set``. Because both
+    public entry points clear it on enter/exit and handlers mutate it during
+    generation, concurrent code generation in two threads could corrupt each
+    other's output (one thread clearing the set mid-generation in another,
+    dropping a required import and producing source with a ``NameError``).
+
+    Subclassing ``threading.local`` (matching the codebase's established
+    ``ThreadLocalStack`` idiom) gives each thread its own backing ``set`` while
+    keeping the set-like API (``add``/``clear``/``in``/``len``/iteration) that
+    the rest of the module -- and existing callers/tests -- rely on.
+    """
+
+    def __init__(self):
+        # ``threading.local.__init__`` runs once per thread the first time the
+        # instance is touched from that thread, giving each thread a fresh set.
+        self._data = set()
+
+    def add(self, value):
+        self._data.add(value)
+
+    def discard(self, value):
+        self._data.discard(value)
+
+    def clear(self):
+        self._data.clear()
+
+    def __contains__(self, value):
+        return value in self._data
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+
+prefix_imports = _ThreadLocalImports()
 
 
 @contextmanager
@@ -389,13 +440,46 @@ def _call_noparams(fn_name: str):
 for _name in (
     'sin', 'cos', 'tan', 'tanh', 'sinh', 'cosh', 'asin', 'acos', 'atan',
     'exp', 'exp2', 'log', 'log1p', 'expm1', 'sqrt', 'rsqrt', 'cbrt',
-    'abs', 'sign', 'floor', 'ceil', 'round', 'erf', 'erfc', 'erf_inv',
+    'abs', 'sign', 'floor', 'ceil', 'erf', 'erfc', 'erf_inv',
     'is_finite', 'logistic', 'square', 'reciprocal', 'not',
     'pow', 'rem', 'atan2', 'nextafter', 'and', 'or', 'xor',
     'shift_left', 'shift_right_logical', 'shift_right_arithmetic',
 ):
     if _name not in prim_to_python:
         register_prim_handler(_name, _call_noparams(f'jax.lax.{_name}'))
+
+
+def _round_handler(state, eqn):
+    """Handle the ``round`` primitive, forwarding its ``rounding_method``.
+
+    ``jax.lax.round`` defaults to ``RoundingMethod.AWAY_FROM_ZERO`` while
+    ``jnp.round``/``jnp.around`` lower with ``RoundingMethod.TO_NEAREST_EVEN``
+    (banker's rounding). Dropping the param (as the generic ``_call_noparams``
+    loop did) silently changes results on every half-integer. We emit the
+    method as a fully-qualified, namespace-resolvable
+    ``jax.lax.RoundingMethod(<int>)`` so it works in the generated namespace
+    (which only has jax/jnp/np) and is robust across JAX versions (reconstruct
+    by value rather than by member name).
+    """
+    invars = [_astify_atom(state, v) for v in eqn.invars]
+    outvars = _astify_outvars(state, eqn.outvars)
+    rm = eqn.params['rounding_method']  # a jax.lax.RoundingMethod enum
+    method_ast = ast.Call(
+        func=ast.Name(id='jax.lax.RoundingMethod', ctx=ast.Load()),
+        args=[ast.Constant(value=int(rm))],
+        keywords=[],
+    )
+    return ast.Assign(
+        outvars,
+        ast.Call(
+            func=ast.Name(id='jax.lax.round', ctx=ast.Load()),
+            args=invars + [method_ast],
+            keywords=[],
+        ),
+    )
+
+
+register_prim_handler('round', _round_handler)
 
 
 def _integer_pow_handler(state, eqn):
@@ -501,8 +585,14 @@ def _maybe_wrap_fn_for_leaves(node, f, num_args):
     if len(node.args.args) == num_args:
         return node
 
+    # Reuse the inner def's already-sanitized name (``node.name``) rather than
+    # re-reading the raw ``f.__name__``: a lambda would otherwise yield the
+    # invalid ``def <lambda>(*args, **kwargs):``, and callables lacking
+    # ``__name__`` (e.g. functools.partial) would raise AttributeError. The
+    # caller (fn_to_python_code) already sanitized this name to a valid
+    # identifier (falling back to 'generated_function').
     wrapped_node = ast.FunctionDef(
-        name=f.__name__,
+        name=node.name,
         args=ast.arguments(
             args=[],
             vararg=ast.arg(arg="args", annotation=None),
@@ -864,11 +954,21 @@ def _astify_array(value):
         return ast.Constant(value=value.item())
 
     if value.ndim == 0:
+        # ``_astify_value(dtype)`` returns a ``jax.numpy.dtype('...')`` instance
+        # for dtypes outside the named set (uint8/16/32/64, int8/16, complex*),
+        # and a DType instance is NOT callable -- ``dtype('uint16')(3)`` raises
+        # ``TypeError`` at runtime. Emit ``jax.numpy.array(value, dtype=...)``
+        # instead (mirroring the multi-element branch below); this preserves
+        # ndim==0 and the exact dtype and works for every dtype.
         dtype_value = _astify_value(value.dtype)
         return ast.Call(
-            dtype_value,
+            func=ast.Attribute(
+                value=ast.Name(id='jax.numpy', ctx=ast.Load()),
+                attr='array',
+                ctx=ast.Load(),
+            ),
             args=[ast.Constant(value=value.item())],
-            keywords=[],
+            keywords=[ast.keyword(arg='dtype', value=dtype_value)],
         )
 
     values = value.tolist()
@@ -946,11 +1046,20 @@ def _astify_value(value):
         prefix_imports.add('from jax._src.sharding_impls import UNSPECIFIED')
         return ast.Name(id='UNSPECIFIED', ctx=ast.Load())
     elif isinstance(value, enum.Enum):
-        return ast.Attribute(
-            value=ast.Name(id=value.__class__.__qualname__, ctx=ast.Load()),
-            attr=value.name,
-            ctx=ast.Load()
-        )
+        # Emit a fully-qualified, importable reference and register the import,
+        # mirroring the UNSPECIFIED branch. A bare ``ClassName.MEMBER`` has no
+        # binding in the generated namespace (only jax/jnp/np) and raises
+        # ``NameError``. Build ``module.qualname.MEMBER`` as a chained
+        # Attribute, which also handles nested enums whose ``__qualname__``
+        # contains dots (``from m import Outer.Inner`` is not valid syntax).
+        cls = value.__class__
+        module = cls.__module__
+        qualname = cls.__qualname__  # may contain dots for nested enums
+        prefix_imports.add(f'import {module}')
+        node = ast.Name(id=module.split('.')[0], ctx=ast.Load())
+        for part in module.split('.')[1:] + qualname.split('.') + [value.name]:
+            node = ast.Attribute(value=node, attr=part, ctx=ast.Load())
+        return node
 
     else:
         warnings.warn(f"Unknown value type {type(value)}")

--- a/brainstate/transform/_ir_tocode.py
+++ b/brainstate/transform/_ir_tocode.py
@@ -92,6 +92,11 @@ class IdentityMap(MutableMapping):
     """
 
     def __init__(self, iterable=None):
+        # Map id(key) -> (key, value). The original key object is retained so
+        # that ``__iter__`` can yield keys (the Mapping contract), which the
+        # mixin methods ``keys``/``values``/``items``/``__eq__`` and ``dict(m)``
+        # all rely on. Storing only ``id(key) -> value`` made ``__iter__`` yield
+        # values, silently breaking every one of those.
         self._data = {}
         if iterable is not None:
             self.update(iterable)
@@ -100,25 +105,25 @@ class IdentityMap(MutableMapping):
         return id(key) in self._data
 
     def __getitem__(self, key):
-        return self._data[id(key)]
+        return self._data[id(key)][1]
 
     def __setitem__(self, key, value):
-        self._data[id(key)] = value
+        self._data[id(key)] = (key, value)
 
     def __delitem__(self, key):
         del self._data[id(key)]
 
     def __iter__(self):
-        return iter(self._data.values())
+        return iter(key for key, _ in self._data.values())
 
     def __len__(self):
         return len(self._data)
 
     def __repr__(self):
-        return f"IdentityMap({list(repr(x) for x in self._data.values())})"
+        return f"IdentityMap({dict((repr(k), repr(v)) for k, v in self._data.values())})"
 
     def __str__(self):
-        return f"IdentityMap({list(str(x) for x in self._data.values())})"
+        return f"IdentityMap({dict((str(k), str(v)) for k, v in self._data.values())})"
 
 
 @dataclass
@@ -1129,8 +1134,18 @@ def _astify_scan(state, eqn):
         # fn_name = lambda carry, xs: fn_name(*carry, *xs)
         # jax.lax.scan(fn_name, (carries...), (xs...))
 
+        # The wrapper's parameter/result names must not collide with the
+        # variable namer's output. ``str_name`` emits base-26 names (``a``..``z``,
+        # ``ba``..) which CAN land on ``carry``/``x``/``ys`` (e.g. ``x`` is index
+        # 23, ``ys`` index 642): a hardcoded ``carry``/``x`` lambda arg then
+        # shadows a same-named carry var, and a hardcoded ``final_carry``/``ys``
+        # output clobbers a same-named outer var. ``skolem`` names contain an
+        # ``_<count>`` suffix that no base-26 name has, so they are collision-free.
+        carry_name = state.skolem('carry')
+        x_name = state.skolem('x')
+
         modified_signature = ast.arguments(
-            args=[ast.arg(arg='carry'), ast.arg(arg='x')],
+            args=[ast.arg(arg=carry_name), ast.arg(arg=x_name)],
             vararg=None,
             kwonlyargs=[],
             kw_defaults=[],
@@ -1143,8 +1158,8 @@ def _astify_scan(state, eqn):
             targets=[ast.Tuple(elts=[ast.Name(a.arg) for a in fn_ast.args.args],
                                ctx=ast.Store())],
             value=ast.Tuple(
-                elts=[maybe_untuple_vars(ast.Name(id='carry', ctx=ast.Load()), num_carry != 1),
-                      maybe_untuple_vars(ast.Name(id='x', ctx=ast.Load()), len(xs) != 1)]
+                elts=[maybe_untuple_vars(ast.Name(id=carry_name, ctx=ast.Load()), num_carry != 1),
+                      maybe_untuple_vars(ast.Name(id=x_name, ctx=ast.Load()), len(xs) != 1)]
             )
         )
 
@@ -1179,12 +1194,17 @@ def _astify_scan(state, eqn):
 
         stmts.append(fn_ast)
 
+        # Collision-free temporaries for the scan's (final_carry, ys) result
+        # (see the note above on ``carry``/``x``).
+        final_carry_name = state.skolem('final_carry')
+        ys_name = state.skolem('ys')
+
         scan_call = ast.Assign(
             # targets=_astify_outvars(eqn.outvars),
             targets=[
                 ast.Tuple(
-                    elts=[ast.Name(id='final_carry', ctx=ast.Store()),
-                          ast.Name(id='ys', ctx=ast.Store())],
+                    elts=[ast.Name(id=final_carry_name, ctx=ast.Store()),
+                          ast.Name(id=ys_name, ctx=ast.Store())],
                     ctx=ast.Store()
                 )
             ],
@@ -1203,7 +1223,7 @@ def _astify_scan(state, eqn):
         if num_carry > 0:
             assign_carry = ast.Assign(
                 targets=_astify_outvars(state, eqn.outvars[:num_carry]),
-                value=ast.Name(id='final_carry', ctx=ast.Load())
+                value=ast.Name(id=final_carry_name, ctx=ast.Load())
             )
 
             stmts.append(assign_carry)
@@ -1211,7 +1231,7 @@ def _astify_scan(state, eqn):
         if num_carry < len(eqn.outvars):
             assign_ys = ast.Assign(
                 targets=_astify_outvars(state, eqn.outvars[num_carry:]),
-                value=ast.Name(id='ys', ctx=ast.Load())
+                value=ast.Name(id=ys_name, ctx=ast.Load())
             )
 
             stmts.append(assign_ys)

--- a/brainstate/transform/_ir_tocode_test.py
+++ b/brainstate/transform/_ir_tocode_test.py
@@ -1623,5 +1623,42 @@ class TestAuditRegressions(unittest.TestCase):
         self.assertEqual(len(results), 8)
 
 
+class TestThreadLocalImportsSetApi(unittest.TestCase):
+    """The ``prefix_imports`` accumulator (`_ThreadLocalImports`) exposes a
+    set-like API. ``add``/``clear``/``__iter__``/``__len__`` are driven by code
+    generation, but ``discard`` and ``__contains__`` are part of the same public
+    surface and are exercised directly here."""
+
+    def setUp(self):
+        _ir_tocode.prefix_imports.clear()
+
+    def tearDown(self):
+        _ir_tocode.prefix_imports.clear()
+
+    def test_contains_reflects_membership(self):
+        """``in`` reports membership (``__contains__``)."""
+        pi = _ir_tocode.prefix_imports
+        pi.add('import foo')
+        self.assertIn('import foo', pi)
+        self.assertNotIn('import bar', pi)
+
+    def test_discard_removes_present_and_ignores_absent(self):
+        """``discard`` removes a present element and is a no-op for an absent one."""
+        pi = _ir_tocode.prefix_imports
+        pi.add('import foo')
+        pi.add('import bar')
+
+        pi.discard('import foo')
+        self.assertNotIn('import foo', pi)
+        self.assertIn('import bar', pi)
+        self.assertEqual(len(pi), 1)
+
+        # Discarding something not present must not raise and must not change
+        # the contents (set.discard semantics, unlike set.remove).
+        pi.discard('import missing')
+        self.assertEqual(len(pi), 1)
+        self.assertIn('import bar', pi)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/transform/_ir_tocode_test.py
+++ b/brainstate/transform/_ir_tocode_test.py
@@ -616,6 +616,28 @@ class TestControlFlowHandlers(unittest.TestCase):
         _roundtrip_check(self, f, jnp.float32(0.0), jnp.float32(1.0),
                          jnp.float32([1., 2., 3.]))
 
+    def test_scan_name_collision_with_namer(self):
+        """The scan wrapper's carry/x/final_carry/ys names must not collide
+        with variable-namer output.
+
+        The base-26 namer can emit ``x`` (index 23) and ``ys`` (index 642).
+        With enough preceding variables a carry var is named ``x`` and, with a
+        hardcoded ``x`` lambda arg, the inner unpacking ``..., x, ... = (carry, x)``
+        silently rebinds the carry from the xs slice. This drives the namer past
+        ``x`` and uses an asymmetric body so any such collision changes results.
+        """
+        def f(init, xs):
+            a = init
+            for _ in range(20):  # advance the namer toward index 23 ('x')
+                a = a + 1.0
+            def body(carry, x):
+                c0, c1 = carry
+                # asymmetric: c1 must survive untouched by the xs slice ``x``
+                return (c0 + x, c1 * 2.0), c1
+            (f0, f1), ys = jax.lax.scan(body, (a, jnp.float32(1.0)), xs)
+            return f0, f1, ys
+        _roundtrip_check(self, f, jnp.float32(0.0), jnp.float32([1., 2., 3., 4.]))
+
     def test_scan_zero_carry(self):
         """scan with zero carry (map-like) exercises the num_carry==0 branch."""
         def f(xs):
@@ -1138,7 +1160,23 @@ class TestHelperContainers(unittest.TestCase):
         self.assertEqual(len(m), 1)
         self.assertIn('IdentityMap', repr(m))
         self.assertIn('IdentityMap', str(m))
-        self.assertIn('y', list(m))
+        # __iter__ must yield KEYS (the Mapping contract), not values: the
+        # remaining key ``b`` is iterated, and its value is reachable via [].
+        self.assertEqual(list(m), [b])
+        self.assertEqual(m[b], 'y')
+
+    def test_identity_map_mapping_contract(self):
+        """keys()/values()/items()/dict() honor the Mapping contract."""
+        m = _ir_tocode.IdentityMap()
+        a, b = [1], [2]
+        m[a] = 'x'
+        m[b] = 'y'
+        # keys() yields the actual key objects (by identity)
+        self.assertEqual(list(m.keys()), [a, b])
+        # values() yields the stored values, items() the (key, value) pairs.
+        # These previously raised KeyError because __iter__ yielded values.
+        self.assertEqual(list(m.values()), ['x', 'y'])
+        self.assertEqual(list(m.items()), [(a, 'x'), (b, 'y')])
 
     def test_identity_map_init_mapping(self):
         """The constructor accepts an initial mapping (exercises update)."""

--- a/brainstate/transform/_ir_tocode_test.py
+++ b/brainstate/transform/_ir_tocode_test.py
@@ -969,9 +969,27 @@ class TestAstifyValueBranches(unittest.TestCase):
             _ir_tocode.prefix_imports.clear()
 
     def test_enum_value(self):
-        """An enum value emits ``ClassName.MEMBER`` attribute access."""
-        node = _ir_tocode._astify_value(_Color.GREEN)
-        self.assertEqual(_unparse(node), '_Color.GREEN')
+        """An enum value emits a fully-qualified, importable reference.
+
+        Regression for H18: the old code emitted a bare ``ClassName.MEMBER``
+        with no import, which raises ``NameError`` in the generated namespace.
+        The fix emits ``<module>.<qualname>.MEMBER`` and records ``import
+        <module>`` in ``prefix_imports``.
+        """
+        _ir_tocode.prefix_imports.clear()
+        try:
+            node = _ir_tocode._astify_value(_Color.GREEN)
+            src = _unparse(node)
+            module = _Color.__module__
+            self.assertEqual(src, f'{module}._Color.GREEN')
+            self.assertIn(f'import {module}', list(_ir_tocode.prefix_imports))
+            # The emitted reference must actually resolve to the enum member.
+            self.assertIs(eval(src, {module.split('.')[0]: __import__(module)
+                                     if '.' not in module
+                                     else __import__(module.split('.')[0])}),
+                          _Color.GREEN)
+        finally:
+            _ir_tocode.prefix_imports.clear()
 
     def test_nested_tuple_value(self):
         """Nested tuples/lists/None/str recurse to a tuple literal."""
@@ -997,10 +1015,22 @@ class TestAstifyValueBranches(unittest.TestCase):
         self.assertEqual(eval(_unparse(node)), 2.5)
 
     def test_astify_array_scalar_nonstandard_dtype(self):
-        """A 0-d uint8 array wraps the constant in its dtype call."""
-        node = _ir_tocode._astify_array(np.uint8(5))
-        src = _unparse(node)
-        self.assertIn("dtype('uint8')", src)
+        """A 0-d unlisted-dtype scalar emits ``jax.numpy.array(v, dtype=...)``.
+
+        Regression for H17: the old code emitted ``dtype('uint8')(5)``, calling a
+        non-callable DType instance (``TypeError`` at runtime). The fix wraps the
+        value in ``jax.numpy.array(..., dtype=...)``, which evaluates correctly
+        and preserves ndim==0 and the exact dtype for every unlisted dtype.
+        """
+        for dt in ('uint8', 'uint16', 'uint32', 'int8', 'int16', 'complex64'):
+            node = _ir_tocode._astify_array(np.asarray(5, dtype=np.dtype(dt)))
+            src = _unparse(node)
+            self.assertIn('jax.numpy.array', src)
+            self.assertIn(f"dtype('{dt}')", src)
+            out = eval(src, {'jax': jax, 'jnp': jnp, 'np': np})
+            self.assertEqual(np.asarray(out).ndim, 0)
+            self.assertEqual(np.asarray(out).dtype, np.dtype(dt))
+            self.assertEqual(int(np.asarray(out).real), 5)
 
     def test_astify_array_multidim(self):
         """A multi-dimensional array emits ``jax.numpy.array([...], dtype=...)``."""
@@ -1330,6 +1360,229 @@ class TestBoxedScalarLiteralRegression(unittest.TestCase):
         self.assertIsInstance(node, ast.Constant)
         self.assertEqual(node.value, 5)
         self.assertIs(type(node.value), int)
+
+
+class TestAuditRegressions(unittest.TestCase):
+    """Regression tests for the audit fixes H15-H18, M35, M36."""
+
+    def test_h15_keyword_variable_names_compile(self):
+        """>=214 SSA names no longer collide with Python keywords (H15).
+
+        The base-26 naming scheme produces 'if'/'in'/'is'/'or'/'def'/... at
+        specific counter values; without disambiguation the generated source
+        contains ``if = ie + 1.0`` (SyntaxError).
+        """
+        def f(x):
+            for _ in range(230):
+                x = x + 1.0
+            return x
+
+        # Both public entry points exercise the same naming path.
+        for src in (
+            jaxpr_to_python_code(jax.make_jaxpr(f)(jnp.float32(0.0)).jaxpr),
+            fn_to_python_code(f, jnp.float32(0.0)),
+        ):
+            # Must compile (pre-fix this raised SyntaxError) ...
+            compile(src, '<generated>', 'exec')
+            # ... and the function must actually run to the right answer.
+            gen = _exec_generated(src, 'f')
+            got = gen(jnp.float32(0.0))
+            self.assertTrue(np.allclose(np.asarray(got), np.asarray(f(jnp.float32(0.0)))))
+
+    def test_h15_no_bare_keyword_assignment_target(self):
+        """No generated assignment target is a bare Python keyword (H15)."""
+        def f(x):
+            for _ in range(400):
+                x = x + 1.0
+            return x
+
+        src = fn_to_python_code(f, jnp.float32(0.0))
+        kws = set(__import__('keyword').kwlist)
+        for line in src.splitlines():
+            stripped = line.strip()
+            if ' = ' in stripped:
+                target = stripped.split(' = ', 1)[0].strip()
+                self.assertNotIn(target, kws,
+                                 f"bare keyword used as assignment target: {line!r}")
+
+    def test_h15_keyword_names_unique(self):
+        """Disambiguated keyword names stay unique (no '_'-suffix collision)."""
+        st = _ir_tocode.SourcerorState()
+
+        class V:
+            pass
+        vs = [V() for _ in range(500)]
+        names = [st.str_name(v) for v in vs]
+        self.assertEqual(len(set(names)), len(names))
+        # At least one keyword was disambiguated with a trailing underscore.
+        self.assertTrue(any(n.endswith('_') for n in names))
+
+    def test_h16_round_half_to_even(self):
+        """jnp.round/around preserve banker's rounding through codegen (H16)."""
+        def fround(x):
+            return jnp.round(x)
+
+        def faround(x):
+            return jnp.around(x)
+
+        for fn in (fround, faround):
+            for inp in (jnp.float32([0.5, 1.5, 2.5, 3.5]),
+                        jnp.float32([-0.5, -1.5, -2.5])):
+                _roundtrip_check(self, fn, inp)
+                # The generated source must forward the rounding method.
+                src = fn_to_python_code(fn, inp)
+                self.assertIn('RoundingMethod', src)
+
+    def test_h17_zero_d_unlisted_dtype_roundtrips(self):
+        """0-d literals of unlisted dtypes execute and keep their dtype (H17)."""
+        for dt in (jnp.uint8, jnp.uint16, jnp.uint32, jnp.int8, jnp.int16,
+                   jnp.complex64):
+            def f(x, _dt=dt):
+                return x + jnp.asarray(3, dtype=_dt)
+
+            inp = jnp.ones((3,), dtype=dt)
+            # Pre-fix this generated ``dtype('uint16')(3)`` -> TypeError on exec.
+            _roundtrip_check(self, f, inp)
+            src = fn_to_python_code(f, inp)
+            self.assertIn('jax.numpy.array', src)
+
+    def test_h18_precision_enum_param_roundtrips(self):
+        """A lax.Precision enum param round-trips and imports cleanly (H18)."""
+        def f(a, b):
+            return jax.lax.dot_general(
+                a, b, (((1,), (0,)), ((), ())),
+                precision=jax.lax.Precision.HIGHEST,
+            )
+
+        a = jnp.ones((2, 3), dtype=jnp.float32)
+        b = jnp.ones((3, 4), dtype=jnp.float32)
+        # Pre-fix the generated code referenced a bare ``Precision`` -> NameError.
+        _roundtrip_check(self, f, a, b)
+        src = fn_to_python_code(f, a, b)
+        # An import line for the enum's module must be prepended.
+        self.assertTrue(any(line.startswith('import ')
+                            for line in src.splitlines()),
+                        f"no import emitted for enum param:\n{src}")
+        # No bare ``Precision.HIGHEST`` (unqualified) survives in the body.
+        self.assertNotIn(' Precision.HIGHEST', src)
+
+    def test_h18_nested_enum_reference_importable(self):
+        """A nested enum (dotted __qualname__) emits an importable reference (H18)."""
+        class Outer:
+            class Mode(enum.Enum):
+                A = 1
+                B = 2
+
+        _ir_tocode.prefix_imports.clear()
+        try:
+            node = _ir_tocode._astify_value(Outer.Mode.B)
+            src = _unparse(node)
+            module = Outer.Mode.__module__
+            # The reference is module + dotted qualname + member (no broken
+            # ``from m import Outer.Mode``).
+            self.assertEqual(src, f'{module}.{Outer.Mode.__qualname__}.B')
+            self.assertIn(f'import {module}', list(_ir_tocode.prefix_imports))
+        finally:
+            _ir_tocode.prefix_imports.clear()
+
+    def test_m35_lambda_with_pytree_arg_compiles(self):
+        """A lambda taking a pytree arg yields a valid ``def`` name (M35)."""
+        g = lambda d: d['a'] + d['b']
+        arg = {'a': jnp.float32(1.0), 'b': jnp.float32(2.0)}
+        src = fn_to_python_code(g, arg)
+        # Pre-fix the wrapper def was ``def <lambda>(...)`` -> SyntaxError.
+        compile(src, '<generated>', 'exec')
+        self.assertIn('def generated_function', src)
+        self.assertNotIn('def <lambda>', src)
+        ns = {'jax': jax, 'jnp': jnp, 'np': np}
+        exec(src, ns)
+        self.assertTrue(np.allclose(np.asarray(ns['generated_function'](arg)), 3.0))
+
+    def test_m35_partial_with_pytree_arg_compiles(self):
+        """A functools.partial (no __name__) + pytree arg compiles (M35)."""
+        import functools
+        p = functools.partial(lambda d: d['a'] * d['b'])
+        arg = {'a': jnp.float32(3.0), 'b': jnp.float32(4.0)}
+        src = fn_to_python_code(p, arg)
+        compile(src, '<generated>', 'exec')
+        self.assertIn('def generated_function', src)
+        ns = {'jax': jax, 'jnp': jnp, 'np': np}
+        exec(src, ns)
+        self.assertTrue(np.allclose(np.asarray(ns['generated_function'](arg)), 12.0))
+
+    def test_m36_prefix_imports_thread_local(self):
+        """prefix_imports is isolated per thread (M36)."""
+        import threading
+
+        errors = []
+        barrier = threading.Barrier(6)
+
+        def worker(tag):
+            try:
+                _ir_tocode.prefix_imports.clear()
+                _ir_tocode.prefix_imports.add(f'import pkg_{tag}')
+                # Rendezvous so every thread has populated its set before any
+                # thread reads back -- a shared global would be corrupted here.
+                barrier.wait(timeout=5)
+                self.assertEqual(set(_ir_tocode.prefix_imports),
+                                 {f'import pkg_{tag}'})
+            except Exception as exc:  # pragma: no cover - surfaced via errors
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+
+    def test_m36_concurrent_codegen_preserves_imports(self):
+        """Concurrent generation of import-bearing code keeps the import (M36).
+
+        The enum path (H18) deterministically adds ``import <module>`` to
+        ``prefix_imports`` during generation. With a shared module-global set,
+        one thread clearing the set on entry would drop another thread's
+        in-flight import, emitting source that references the enum module
+        without importing it (``NameError``). Each thread must keep its own
+        import.
+        """
+        import threading
+
+        # dot_general with an explicit Precision enum forces an import to be
+        # accumulated mid-generation on every call.
+        def f(a, b):
+            return jax.lax.dot_general(
+                a, b, (((1,), (0,)), ((), ())),
+                precision=jax.lax.Precision.HIGHEST,
+            )
+
+        a = jnp.ones((2, 3), dtype=jnp.float32)
+        b = jnp.ones((3, 4), dtype=jnp.float32)
+        results = []
+        errors = []
+        start = threading.Barrier(8)
+
+        def worker():
+            try:
+                start.wait(timeout=5)
+                src = fn_to_python_code(f, a, b)
+                # The generated module must compile, carry an import line, and
+                # run -- i.e. its import was not clobbered by a sibling thread.
+                self.assertTrue(any(line.startswith('import ')
+                                    for line in src.splitlines()),
+                                f"import dropped under concurrency:\n{src}")
+                _exec_generated(src, 'f')(a, b)
+                results.append(src)
+            except Exception as exc:  # pragma: no cover - surfaced via errors
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 8)
 
 
 if __name__ == '__main__':

--- a/brainstate/transform/_ir_visualize.py
+++ b/brainstate/transform/_ir_visualize.py
@@ -451,10 +451,14 @@ if pydot_is_installed:
                     branch_label = (
                         eqn.params["name"] if "name" in eqn.params else eqn.primitive.name
                     )
-                    no_literal_inputs = any(
-                        [isinstance(a, Literal) for a in branch.jaxpr.invars]
-                    )
-                    collapse_branch = no_literal_inputs or collapse_primitives
+                    # A single-equation branch is collapsed exactly when
+                    # ``collapse_primitives`` asks for it. (A previous
+                    # ``no_literal_inputs = any(isinstance(a, Literal) for a in
+                    # branch.jaxpr.invars)`` term was both misnamed -- it computed
+                    # "has a literal input" -- and inert: ``jaxpr.invars`` are
+                    # binder ``Var``s, never ``Literal``, so it was always False
+                    # and never actually forced a collapse.)
+                    collapse_branch = collapse_primitives
                     if collapse_branch:
                         branch_label = f"branch {i}: {branch_label}"
                     else:
@@ -803,7 +807,17 @@ if pydot_is_installed:
             **GRAPH_STYLING,
         )
 
-        argument_nodes, argument_edges = get_arguments(
+        # ``expand_pjit_primitive`` renders ``jaxpr`` as a self-contained graph
+        # with no enclosing equation, so there are no real parent operands to map
+        # the formal parameters/results onto. We therefore pass the jaxpr's own
+        # ``invars``/``outvars`` as the "parent" vars purely to build the inner
+        # argument/output nodes, then DISCARD the parent-linking edges/nodes
+        # ``get_arguments``/``get_outputs`` return: those point at
+        # ``{parent_id}_{var}`` source/sink nodes that do not exist (the parent
+        # has its own variable names), producing phantom default nodes. The live
+        # ``expand_non_primitive`` path avoids this by passing the enclosing
+        # ``eqn.invars``/``eqn.outvars`` instead.
+        argument_nodes, _phantom_arg_edges = get_arguments(
             graph_id,
             parent_id,
             jaxpr.constvars,
@@ -828,7 +842,7 @@ if pydot_is_installed:
             for edge in out_edges:
                 graph.add_edge(edge)
 
-        output_nodes, out_edges, out_nodes, id_edges = get_outputs(
+        output_nodes, _phantom_out_edges, _phantom_out_nodes, id_edges = get_outputs(
             graph_id,
             parent_id,
             jaxpr.invars,
@@ -841,7 +855,9 @@ if pydot_is_installed:
         for edge in id_edges:
             graph.add_edge(edge)
 
-        return graph, argument_edges, out_nodes, out_edges, n
+        # No real parent: return empty parent-linking edge/node lists rather than
+        # the phantom ones keyed off this jaxpr's own vars.
+        return graph, [], [], [], n
 
 
     def get_scan(

--- a/brainstate/transform/_ir_visualize.py
+++ b/brainstate/transform/_ir_visualize.py
@@ -261,6 +261,25 @@ if pydot_is_installed:
                     seen.add(node_id)
             return g
 
+        # Declare the top-level function's input arguments as green IN_ARG nodes.
+        # On this (non-empty) path the equations only ever *consume* the top-level
+        # invars -- they are referenced as edge sources ``f"_{var}"`` but never
+        # produced -- so without this loop graphviz would fabricate bare,
+        # default-styled phantom nodes for them. pydot strips the ``:aval`` port,
+        # so the node name ``_{var}`` matches what those edges reference. Created
+        # *before* the eqn loop so that a verbatim-returned input (which has no
+        # producing eqn) exists as a node and can be recoloured to OUT styling
+        # below, matching the empty-jaxpr path's dedup-to-green precedence.
+        seen = set()
+        for var in list(fn.invars):
+            if _is_dropped_var(var):
+                continue
+            node_id = f"_{var}"
+            if node_id not in seen:
+                g.add_node(get_arg_node(node_id, var, show_avals,
+                                        isinstance(var, Literal)))
+                seen.add(node_id)
+
         # Expand *every* top-level equation, not just the first one. The
         # original implementation indexed ``fn.eqns[0]`` and silently dropped
         # the rest whenever the top-level jaxpr held more than one equation.
@@ -279,6 +298,22 @@ if pydot_is_installed:
                 g.add_node(node)
             for edge in out_edges:
                 g.add_edge(edge)
+
+        # Style the top-level outputs as outputs (red), consistent with the
+        # empty-jaxpr path. The producing equation already added a blue VAR node
+        # named ``_{var}`` (port-stripped) for each non-literal/non-dropped
+        # outvar, so rather than declaring a *duplicate* red node with the same
+        # name (which graphviz would merge ambiguously) we recolour the existing
+        # node in place. An input returned verbatim has no producing eqn; its
+        # green node was created above and is likewise recoloured here.
+        out_names = set(
+            f"_{var}".split(":")[0]
+            for var in fn.outvars
+            if not isinstance(var, (Literal, DropVar))
+        )
+        for name in out_names:
+            for nd in g.get_node(name):
+                nd.set_color(OUT_ARG_STYLING["color"])
 
         return g
 
@@ -357,7 +392,13 @@ if pydot_is_installed:
             cond_arguments.add_node(
                 get_arg_node(arg_id, arg, show_avals, is_literal)
             )
-            in_edges.append(pydot.Edge(f"{parent_id}_{arg}", arg_id))
+            # Only wire a parent edge for non-literal operands. A literal operand
+            # is rendered as the standalone destination node created above; adding
+            # an edge from ``{parent_id}_{Literal(...)}`` would reference a node
+            # that is never declared, producing a phantom default node. Mirrors
+            # the ``if not is_literal`` guard in ``get_arguments``.
+            if not is_literal:
+                in_edges.append(pydot.Edge(f"{parent_id}_{arg}", arg_id))
 
         cond_graph.add_subgraph(cond_arguments)
 
@@ -832,7 +873,15 @@ if pydot_is_installed:
         )
         graph.add_subgraph(argument_nodes)
 
-        out_var_keys = set(f"{graph_id}_{v}" for v in eqn.params["jaxpr"].jaxpr.outvars)
+        # ``str(Var)`` includes the aval (e.g. ``Var(id=N):float32[]``), but pydot
+        # treats ':' as a port separator and stores ``node.get_name()`` without it.
+        # Strip the aval here so the dedup keys compare equal to the port-stripped
+        # node names below; otherwise the guard never matches and scan body
+        # outputs that ``get_scan_outputs`` recreates get added twice.
+        out_var_keys = set(
+            (f"{graph_id}_{v}").split(":")[0]
+            for v in eqn.params["jaxpr"].jaxpr.outvars
+        )
         eqns = eqn.params["jaxpr"].jaxpr.eqns
 
         body_graph_id = f"cluster_{graph_id}_body"
@@ -881,7 +930,10 @@ if pydot_is_installed:
                 for edge in in_edges:
                     graph.add_edge(edge)
                 for node in out_nodes:
-                    if not node.get_name() in out_var_keys:
+                    # ``node.get_name()`` is already port-stripped by pydot;
+                    # ``.split(":")[0]`` is harmless/defensive and keeps both
+                    # sides of the comparison in the same (port-stripped) form.
+                    if node.get_name().split(":")[0] not in out_var_keys:
                         body_graph.add_node(node)
                 for edge in out_edges:
                     graph.add_edge(edge)
@@ -1359,9 +1411,30 @@ if pydot_is_installed:
             if _is_dropped_var(var):
                 continue
             arg_id = f"{graph_id}_{var}"
-            is_literal = isinstance(var, Literal)
-            argument_nodes.add_node(get_arg_node(arg_id, var, show_avals, is_literal))
-            if not is_literal:
+            # ``var`` is the callee's *formal* parameter (graph_invars); these are
+            # plain ``Var`` binders, never ``Literal``. The argument that can
+            # actually be a literal is ``p_var`` (the parent/caller invar). Keep
+            # ``var_is_literal`` purely for node styling, and key the parent edge
+            # off ``p_var``'s literal-ness so we never reference an undeclared
+            # ``{parent_id}_{Literal(...)}`` source node. Mirrors
+            # ``get_scan_arguments``.
+            var_is_literal = isinstance(var, Literal)
+            parent_is_literal = isinstance(p_var, Literal)
+            argument_nodes.add_node(get_arg_node(arg_id, var, show_avals, var_is_literal))
+            if parent_is_literal:
+                # Create the literal source node locally inside the argument
+                # cluster (keyed by the inner var, so unique per parameter) and
+                # wire it to the formal-parameter node, instead of pointing at a
+                # phantom ``{parent_id}_{Literal(...)}`` node that never exists.
+                # The ``_lit`` suffix must come *before* any ``:aval`` port:
+                # ``str(var)`` embeds the aval (e.g. ``Var(id=N):float32[]``) and
+                # pydot drops everything after ':', so ``f"{arg_id}_lit"`` would
+                # strip back to the formal-parameter node's name and collide with
+                # it. Strip the aval first so the literal node is distinct.
+                literal_id = f"{arg_id.split(':')[0]}_lit"
+                argument_nodes.add_node(get_arg_node(literal_id, p_var, show_avals, True))
+                argument_nodes.add_edge(pydot.Edge(literal_id, arg_id))
+            else:
                 argument_edges.append(pydot.Edge(f"{parent_id}_{p_var}", arg_id))
 
         return argument_nodes, argument_edges
@@ -1407,11 +1480,20 @@ if pydot_is_installed:
         argument_nodes = pydot.Subgraph(
             f"cluster_{graph_id}_args", rank="min", **ARG_SUBGRAPH_STYLING
         )
+        # JAX scan invars are ordered [consts..., carry..., xs...] (see the
+        # ``i < n_const`` / ``i < n_carry + n_const`` dispatch below), so the
+        # subgraph collecting the first ``n_const`` invars holds the loop
+        # constants and the next ``n_carry`` invars hold the carry. Label each
+        # group by its actual contents (previously the two labels were swapped,
+        # so consts rendered as "init" and the carry as "consts"). The carry
+        # group keeps its ``_init`` subgraph id: the ``_carry`` id is already
+        # used by the scan *output* carry subgraph (see ``get_scan_outputs``), so
+        # reusing it here would collide.
         const_nodes = pydot.Subgraph(
-            f"cluster_{graph_id}_const", rank="same", label="init", style="dotted"
+            f"cluster_{graph_id}_const", rank="same", label="consts", style="dotted"
         )
         carry_nodes = pydot.Subgraph(
-            f"cluster_{graph_id}_init", rank="same", label="consts", style="dotted"
+            f"cluster_{graph_id}_init", rank="same", label="carry", style="dotted"
         )
         iterate_nodes = pydot.Subgraph(
             f"cluster_{graph_id}_iter", rank="same", label="iterate", style="dotted"
@@ -1429,7 +1511,10 @@ if pydot_is_installed:
             is_literal = var_is_literal or parent_is_literal
 
             if parent_is_literal:
-                literal_id = f"{arg_id}_lit"
+                # Strip the ``:aval`` port before appending ``_lit`` so the
+                # literal node does not collide with the formal-parameter node
+                # (pydot drops everything after ':' in a node name).
+                literal_id = f"{arg_id.split(':')[0]}_lit"
                 argument_nodes.add_node(get_arg_node(literal_id, p_var, show_avals, True))
                 argument_nodes.add_edge(pydot.Edge(literal_id, arg_id))
 
@@ -1510,8 +1595,15 @@ if pydot_is_installed:
 
         for var, p_var in zip(graph_outvars, parent_outvars):
             if str(var) in in_var_set:
-                arg_id = f"{graph_id}_{var}_out"
-                id_edges.append(pydot.Edge(f"{graph_id}_{var}", arg_id))
+                # An output that is also an input (a function returning one of its
+                # arguments) gets a distinct ``_out`` node. ``str(var)`` embeds the
+                # ``:aval`` port and pydot drops everything after ':', so append
+                # ``_out`` to the *port-stripped* base -- otherwise it is stripped,
+                # the ``_out`` node collides with the input/var node of the same
+                # name, and the id-edge degenerates into a self-loop.
+                base = f"{graph_id}_{var}".split(":")[0]
+                arg_id = f"{base}_out"
+                id_edges.append(pydot.Edge(base, arg_id))
             else:
                 arg_id = f"{graph_id}_{var}"
             out_graph.add_node(get_out_node(arg_id, var, show_avals))
@@ -1590,8 +1682,16 @@ if pydot_is_installed:
 
         for i, (var, p_var) in enumerate(zip(graph_outvars, parent_outvars)):
             if str(var) in in_var_set:
-                arg_id = f"{graph_id}_{var}_out"
-                id_edges.append(pydot.Edge(f"{graph_id}_{var}", arg_id))
+                # A scan output that is also an input (e.g. a carry returned
+                # verbatim) gets a distinct ``_out`` node so it does not collide
+                # with the argument node of the same var. ``str(var)`` embeds the
+                # ``:aval`` port and pydot drops everything after ':', so the
+                # ``_out`` suffix must be appended to the *port-stripped* base;
+                # otherwise it is stripped away, the output node collides with the
+                # input node, and the id-edge degenerates into a self-loop.
+                base = f"{graph_id}_{var}".split(":")[0]
+                arg_id = f"{base}_out"
+                id_edges.append(pydot.Edge(base, arg_id))
             else:
                 arg_id = f"{graph_id}_{var}"
             if i < n_carry:

--- a/brainstate/transform/_ir_visualize_test.py
+++ b/brainstate/transform/_ir_visualize_test.py
@@ -943,5 +943,134 @@ class TestCondLiteralOperand(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(PYDOT, "pydot not installed")
+class TestDrawDotGraphDroppedAndDuplicateInvars(unittest.TestCase):
+    """draw_dot_graph's non-empty top-level invar loop must skip dropped vars
+    and dedup a repeated invar.
+
+    On the non-empty (>=1 eqn) path ``draw_dot_graph`` walks ``fn.invars`` to
+    declare green IN_ARG nodes. JAX's normal tracing never puts a ``DropVar`` or
+    a repeated invar at the top level, so the ``_is_dropped_var`` skip and the
+    ``node_id in seen`` dedup are reached by handing the public
+    ``draw_dot_graph`` entry a surgically-built ClosedJaxpr of that shape -- a
+    legitimate input that the loop must tolerate without fabricating spurious
+    nodes.
+    """
+
+    def _build_closed_jaxpr(self):
+        import jax.core as jc
+        from brainstate._compatible_import import ClosedJaxpr, DropVar
+
+        # Real ``x + 1.0`` jaxpr (one eqn -> non-empty path), then prepend a
+        # duplicate of the sole invar and append a dropped invar.
+        base = jax.make_jaxpr(lambda x: x + 1.0)(jnp.float32(1.0))
+        x = base.jaxpr.invars[0]
+        dropped = DropVar(jc.ShapedArray((), jnp.dtype('float32')))
+        new_jaxpr = base.jaxpr.replace(invars=[x, x, dropped])
+        return ClosedJaxpr(new_jaxpr, base.consts), x, dropped
+
+    def test_dropped_invar_skipped_and_duplicate_deduped(self):
+        from brainstate.transform import draw_dot_graph
+
+        cj, x, dropped = self._build_closed_jaxpr()
+        g = draw_dot_graph(cj, True, True)
+        self.assertIsNotNone(g)
+
+        # pydot strips the ``:aval`` port from node names, so compare on the
+        # port-stripped base (matching how draw_dot_graph keys ``f"_{var}"``).
+        names = [_base(nd.get_name()) for nd in _all_nodes(g)]
+
+        # The dropped invar (stringifies as ``_``) must NOT produce an input
+        # node: ``_is_dropped_var`` short-circuits the loop body (the ``continue``).
+        dropped_node_id = _base(f"_{dropped}")  # == "__"
+        self.assertNotIn(
+            dropped_node_id, names,
+            f"dropped invar should be skipped, but a node {dropped_node_id!r} "
+            f"was declared among {names}",
+        )
+
+        # The invar appears twice in ``fn.invars`` but the ``seen`` dedup means
+        # exactly one green input node is declared for it (the second pass hits
+        # the ``node_id in seen`` branch and adds nothing). The input node keeps
+        # the bare ``_{var}`` name; the eqn's *output* node (the ``x + 1.0``
+        # result) is a distinct var, so it does not inflate this count.
+        from collections import Counter
+        x_node_id = _base(f"_{x}")
+        counts = Counter(names)
+        self.assertEqual(
+            counts.get(x_node_id, 0), 1,
+            f"duplicate invar must be declared exactly once, got "
+            f"{counts.get(x_node_id, 0)} for {x_node_id!r} among {names}",
+        )
+
+        # No edge may reference an undeclared (phantom) source.
+        self.assertEqual(_undeclared_edge_sources(g), [])
+
+    def test_duplicate_invar_node_is_green_input(self):
+        from brainstate.transform import draw_dot_graph, _ir_visualize as viz
+
+        cj, x, _dropped = self._build_closed_jaxpr()
+        g = draw_dot_graph(cj, True, True)
+
+        # pydot strips the ``:aval`` port, so match on the port-stripped base.
+        x_node_id = _base(f"_{x}")
+        node = [nd for nd in _all_nodes(g) if _base(nd.get_name()) == x_node_id]
+        self.assertEqual(len(node), 1)
+        # The declared input carries IN_ARG (green) styling from get_arg_node.
+        self.assertEqual(node[0].get_color(), viz.IN_ARG_STYLING["color"])
+
+
+@unittest.skipUnless(PYDOT, "pydot not installed")
+class TestScanLiteralCarryInit(unittest.TestCase):
+    """A scan whose carry init is a Python literal exercises the
+    ``parent_is_literal`` branch in get_scan_arguments.
+
+    ``jax.lax.scan(body, 0.0, xs)`` lowers to a scan equation whose first invar
+    (the carry init) is a ``Literal``. When the scan body is expanded
+    (collapse_primitives=False), get_scan_arguments must materialise a dedicated
+    ``..._lit`` node for that literal (port-stripped so it does not collide with
+    the formal-parameter node) and wire it into the parameter node.
+    """
+
+    def _scan_fn(self):
+        def f(xs):
+            def body(c, e):
+                return c + e, c
+            final, ys = jax.lax.scan(body, 0.0, xs)  # 0.0 -> Literal carry init
+            return final
+        return f
+
+    def test_literal_carry_init_declares_lit_node(self):
+        from brainstate.transform import draw
+
+        g = draw(self._scan_fn(), collapse_primitives=False)(
+            jnp.float32([1., 2., 3.])
+        )
+        self.assertIsNotNone(g)
+
+        names = [nd.get_name() for nd in _all_nodes(g)]
+        lit_nodes = [n for n in names if n.endswith("_lit")]
+        self.assertTrue(
+            lit_nodes,
+            f"expected a scan literal carry-init node ending in '_lit', "
+            f"got node names {names}",
+        )
+        # The literal node feeds the formal carry parameter via a local edge:
+        # the ``_lit`` source must be a declared node (no phantom edge source).
+        self.assertEqual(_undeclared_edge_sources(g), [])
+
+    def test_literal_carry_init_lit_node_is_orange_literal(self):
+        from brainstate.transform import draw, _ir_visualize as viz
+
+        g = draw(self._scan_fn(), collapse_primitives=False)(
+            jnp.float32([1., 2., 3.])
+        )
+        lit_nodes = [nd for nd in _all_nodes(g)
+                     if nd.get_name().endswith("_lit")]
+        self.assertTrue(lit_nodes)
+        # get_arg_node was called with is_literal=True -> orange LITERAL styling.
+        self.assertEqual(lit_nodes[0].get_color(), viz.LITERAL_STYLING["color"])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/transform/_ir_visualize_test.py
+++ b/brainstate/transform/_ir_visualize_test.py
@@ -376,6 +376,25 @@ class TestExpandPjitPrimitive(unittest.TestCase):
         graph, *_ = viz.expand_pjit_primitive(jpr.jaxpr, "", 0, False, True, "g")
         self.assertIsNotNone(graph)
 
+    def test_expand_pjit_primitive_no_phantom_parent_edges(self):
+        """The standalone pjit expansion must not return parent-linking edges or
+        nodes keyed off its own vars: it has no enclosing equation, so such edges
+        point at non-existent ``{parent_id}_{var}`` nodes (audit item 4)."""
+        import brainstate.transform._ir_visualize as viz
+
+        def f(x):
+            return jnp.sin(x) * 2.0
+
+        jpr = jax.make_jaxpr(f)(jnp.float32(1.0))
+        graph, arg_edges, out_nodes, out_edges, n = viz.expand_pjit_primitive(
+            jpr.jaxpr, "parent", 0, False, True, "g"
+        )
+        self.assertIsNotNone(graph)
+        # No phantom parent linkage.
+        self.assertEqual(list(arg_edges), [])
+        self.assertEqual(list(out_nodes), [])
+        self.assertEqual(list(out_edges), [])
+
 
 @unittest.skipUnless(PYDOT, "pydot not installed")
 class TestExpandNonPrimitiveErrors(unittest.TestCase):

--- a/brainstate/transform/_ir_visualize_test.py
+++ b/brainstate/transform/_ir_visualize_test.py
@@ -92,6 +92,54 @@ def _count_nodes(graph):
     return total
 
 
+def _all_nodes(graph):
+    """Recursively collect every pydot.Node in a graph/subgraph."""
+    nodes = list(graph.get_nodes())
+    for sub in graph.get_subgraphs():
+        nodes += _all_nodes(sub)
+    return nodes
+
+
+def _all_edges(graph):
+    """Recursively collect every pydot.Edge in a graph/subgraph."""
+    edges = list(graph.get_edges())
+    for sub in graph.get_subgraphs():
+        edges += _all_edges(sub)
+    return edges
+
+
+def _all_subgraphs(graph):
+    """Recursively collect every pydot.Subgraph below ``graph``."""
+    out = []
+    for sub in graph.get_subgraphs():
+        out.append(sub)
+        out += _all_subgraphs(sub)
+    return out
+
+
+def _base(name):
+    """Port-stripped node name (pydot treats ':' as a port separator)."""
+    return str(name).split(":")[0]
+
+
+def _declared_node_bases(graph):
+    """Set of port-stripped names of all declared nodes."""
+    return {_base(nd.get_name()) for nd in _all_nodes(graph)}
+
+
+def _undeclared_edge_sources(graph):
+    """Edge-source base ids that are not declared as nodes anywhere.
+
+    A non-empty result means an edge references a phantom node that graphviz
+    would fabricate with default styling -- the signature of the literal /
+    boundary-node bugs.
+    """
+    declared = _declared_node_bases(graph)
+    return sorted(
+        {_base(e.get_source()) for e in _all_edges(graph)} - declared
+    )
+
+
 @unittest.skipUnless(PYDOT, "pydot not installed")
 class TestVisualizeTopLevel(unittest.TestCase):
     def test_empty_jaxpr_does_not_crash(self):
@@ -624,6 +672,256 @@ class TestDrawDotGraphEmpty(unittest.TestCase):
         jpr = jax.make_jaxpr(lambda x: x)(jnp.float32(1.0))
         g = draw_dot_graph(jpr, True, True)
         self.assertIsNotNone(g)
+
+
+@unittest.skipUnless(PYDOT, "pydot not installed")
+class TestLiteralCallArgument(unittest.TestCase):
+    """Regression for M37: a literal passed into an inlinable call.
+
+    ``get_arguments`` used to test ``isinstance(var, Literal)`` on the callee's
+    *formal* parameter (never a literal) and unconditionally draw an edge from
+    ``{parent}_{Literal(...)}`` -- a node that is never created -- dropping the
+    literal value and leaving a dangling edge to a phantom node.
+    """
+
+    def test_literal_call_argument_node_and_no_dangling_edge(self):
+        from brainstate.transform import draw
+
+        @jax.jit
+        def inner(a, b):
+            return a + b
+
+        def f(x):
+            return inner(x, 3.0)  # 3.0 is a Literal passed positionally
+
+        g = draw(f, collapse_primitives=False)(jnp.float32(1.0))
+
+        # The literal value must be rendered as a declared node (orange literal
+        # box), not lost. Pre-fix no node anywhere carried the literal.
+        literal_nodes = [
+            nd for nd in _all_nodes(g)
+            if nd.get_label() and "Literal(3.0)" in str(nd.get_label())
+        ]
+        self.assertEqual(
+            len(literal_nodes), 1,
+            f"expected exactly one declared Literal(3.0) node, got "
+            f"{[nd.get_name() for nd in literal_nodes]}",
+        )
+
+        # No edge may reference an undeclared source. Pre-fix the edge
+        # ``_Literal(3.0) -> inner_0_<var>`` had a phantom source.
+        self.assertEqual(_undeclared_edge_sources(g), [])
+
+        # The literal node feeds the formal-parameter node via a *local* edge
+        # (inside the argument cluster); its declared name keeps the ``_lit``
+        # marker (pre-fix the ``:aval`` port stripped it, colliding with the
+        # parameter node).
+        lit_name = literal_nodes[0].get_name()
+        self.assertTrue(
+            lit_name.endswith("_lit"),
+            f"literal node name should end with '_lit', got {lit_name!r}",
+        )
+
+
+@unittest.skipUnless(PYDOT, "pydot not installed")
+class TestTopLevelBoundaryNodes(unittest.TestCase):
+    """Regression for L19: top-level input/output boundary nodes.
+
+    On the non-empty-jaxpr path ``draw_dot_graph`` used to create no node for
+    the function's input arguments (they were only referenced as edge sources)
+    and rendered the final outputs with blue VAR styling rather than red OUT
+    styling.
+    """
+
+    def test_input_node_declared_and_styled(self):
+        from brainstate.transform import draw, _ir_visualize as viz
+
+        def f(x):
+            return x + 1.0  # one top-level eqn -> non-empty path
+
+        g = draw(f)(jnp.float32(1.0))
+
+        # Every edge source must be a declared node. Pre-fix the top-level
+        # input ``_Var(x)`` was referenced by the add's in-edge but never
+        # declared, so graphviz fabricated a phantom node.
+        self.assertEqual(_undeclared_edge_sources(g), [])
+
+        # The input argument is declared with green IN_ARG styling.
+        green = viz.IN_ARG_STYLING["color"]
+        red = viz.OUT_ARG_STYLING["color"]
+        colors = {nd.get_color() for nd in _all_nodes(g)}
+        self.assertIn(green, colors, "expected a green top-level input node")
+        # The final output is styled as an output (red), not a plain VAR.
+        self.assertIn(red, colors, "expected a red top-level output node")
+
+    def test_multi_equation_no_undeclared_sources(self):
+        from brainstate.transform import draw
+
+        def f(x):
+            a = x + 1.0
+            b = x * 2.0
+            return a + b
+
+        g = draw(f)(jnp.float32(1.0))
+        self.assertEqual(_undeclared_edge_sources(g), [])
+
+    def test_input_returned_verbatim_recoloured(self):
+        """An input that is also an output is recoloured red (no duplicate)."""
+        from brainstate.transform import draw, _ir_visualize as viz
+
+        def f(x, y):
+            # x + 1.0 is an eqn (non-empty path); y is returned verbatim and is
+            # therefore both an input and an output with no producing eqn.
+            return x + 1.0, y
+
+        g = draw(f)(jnp.float32(1.0), jnp.float32(2.0))
+
+        # No phantom sources and no duplicate declaration for the verbatim var.
+        self.assertEqual(_undeclared_edge_sources(g), [])
+        from collections import Counter
+        name_counts = Counter(nd.get_name() for nd in _all_nodes(g))
+        dups = {k: c for k, c in name_counts.items() if c > 1}
+        self.assertEqual(dups, {}, f"unexpected duplicate nodes: {dups}")
+        # The verbatim-returned input ends up red (OUT styling).
+        red = viz.OUT_ARG_STYLING["color"]
+        self.assertIn(red, {nd.get_color() for nd in _all_nodes(g)})
+
+
+@unittest.skipUnless(PYDOT, "pydot not installed")
+class TestScanBodyOutputDedup(unittest.TestCase):
+    """Regression for L20: scan body output-dedup + duplicate scan nodes.
+
+    The dedup filter compared an unstripped key set (``...:float32[]``) against
+    pydot's port-stripped node names, so it never matched and scan output nodes
+    were declared twice.
+    """
+
+    def test_no_duplicate_scan_nodes(self):
+        from brainstate.transform import draw
+        from collections import Counter
+
+        def f(x):
+            def body(c, _):
+                return c + 1.0, c  # carry returned verbatim -> exercises _out path
+            final, ys = jax.lax.scan(body, x, None, length=3)
+            return final
+
+        g = draw(f, collapse_primitives=False)(jnp.float32(0.0))
+
+        scan_names = [
+            nd.get_name() for nd in _all_nodes(g)
+            if nd.get_name().startswith("scan_")
+        ]
+        dups = {k: c for k, c in Counter(scan_names).items() if c > 1}
+        self.assertEqual(
+            dups, {},
+            f"scan_* node names must be unique, got duplicates: {dups}",
+        )
+
+    def test_no_self_loop_edges(self):
+        """The ``_out`` id-edge must connect distinct endpoints, not self-loop."""
+        from brainstate.transform import draw
+
+        def f(x):
+            def body(c, _):
+                return c + 1.0, c
+            final, ys = jax.lax.scan(body, x, None, length=3)
+            return final
+
+        g = draw(f, collapse_primitives=False)(jnp.float32(0.0))
+        self_loops = [
+            (e.get_source(), e.get_destination())
+            for e in _all_edges(g)
+            if _base(e.get_source()) == _base(e.get_destination())
+        ]
+        self.assertEqual(self_loops, [], f"unexpected self-loop edges: {self_loops}")
+
+
+@unittest.skipUnless(PYDOT, "pydot not installed")
+class TestScanArgumentClusterLabels(unittest.TestCase):
+    """Regression for L21: scan argument subgraphs mislabel consts/carry.
+
+    The const-holding cluster was labeled 'init' and the carry-holding cluster
+    'consts' -- swapped relative to JAX's [consts, carry, xs] invar order.
+    """
+
+    def test_const_and_carry_clusters_labelled_correctly(self):
+        from brainstate.transform import draw
+
+        def f(x, w):
+            def body(c, inp):
+                return c + w * inp, c  # w is a scan const, c is the carry
+            final, ys = jax.lax.scan(body, x, jnp.float32([1., 2., 3.]))
+            return final, ys
+
+        g = draw(f, collapse_primitives=False)(jnp.float32(0.0), jnp.float32(2.0))
+
+        # The argument-side const cluster id ends in '_const'; the carry cluster
+        # keeps the historical '_init' id (the '_carry' id is taken by the scan
+        # output cluster). Distinguish them by id, then assert their labels.
+        const_label = None
+        carry_label = None
+        for s in _all_subgraphs(g):
+            name = s.get_name() or ""
+            if name == "cluster_scan_0_const":
+                const_label = s.get_label()
+            elif name == "cluster_scan_0_init":
+                carry_label = s.get_label()
+
+        self.assertEqual(
+            const_label, "consts",
+            "the cluster holding the scan consts must be labeled 'consts'",
+        )
+        self.assertEqual(
+            carry_label, "carry",
+            "the cluster holding the scan carry must be labeled 'carry'",
+        )
+
+
+@unittest.skipUnless(PYDOT, "pydot not installed")
+class TestCondLiteralOperand(unittest.TestCase):
+    """Regression for L22: literal non-predicate operand to ``cond``.
+
+    ``get_conditional`` unconditionally drew a parent edge for every operand,
+    so a literal operand produced an edge from ``{parent}_{Literal(...)}`` -- a
+    node that is never declared -- fabricating a phantom node.
+    """
+
+    def _cond_fn(self):
+        def f(pred, x):
+            return jax.lax.cond(
+                pred, lambda a, b: a + b, lambda a, b: a - b, x, 5.0
+            )
+        return f
+
+    def test_no_phantom_literal_source_collapsed(self):
+        from brainstate.transform import draw
+        g = draw(self._cond_fn(), collapse_primitives=True)(True, jnp.float32(1.0))
+        self._check(g)
+
+    def test_no_phantom_literal_source_expanded(self):
+        from brainstate.transform import draw
+        g = draw(self._cond_fn(), collapse_primitives=False)(True, jnp.float32(1.0))
+        self._check(g)
+
+    def _check(self, g):
+        # No undeclared literal edge source (the phantom). Pre-fix there was an
+        # edge ``_Literal(5.0) -> _cond_..._Literal(5.0)`` with no source node.
+        undeclared = _undeclared_edge_sources(g)
+        literal_phantoms = [s for s in undeclared if "Literal" in s]
+        self.assertEqual(
+            literal_phantoms, [],
+            f"literal operand left a phantom edge source: {literal_phantoms}",
+        )
+        # The literal destination node IS declared (orange literal box).
+        declared_literal = [
+            nd for nd in _all_nodes(g)
+            if "Literal(5.0)" in nd.get_name()
+        ]
+        self.assertTrue(
+            declared_literal,
+            "expected a declared cond literal destination node",
+        )
 
 
 if __name__ == '__main__':

--- a/brainstate/transform/_loop_collect_return.py
+++ b/brainstate/transform/_loop_collect_return.py
@@ -443,6 +443,8 @@ def checkpointed_scan(
         return (new_write_states, new_carray), new_collect, i + 1
 
     # while_loop
+    if isinstance(base, bool) or not isinstance(base, int) or base < 2:
+        raise ValueError(f"base must be an integer >= 2, got {base!r}.")
     rounded_max_steps = base ** int(math.ceil(math.log(length, base)))
     (write_state_vals, carry), data2collection, _ = (
         _bounded_while_loop(

--- a/brainstate/transform/_loop_collect_return.py
+++ b/brainstate/transform/_loop_collect_return.py
@@ -221,7 +221,12 @@ def scan(
         else:
             raise TypeError("pbar argument should be a ProgressBar instance or an integer.")
         f = _wrap_fun_with_pbar(f, pbar_runner)
-        init = (0, init) if pbar else init
+        # Use the unambiguous ``has_pbar`` flag (always True in this branch)
+        # rather than the truthiness of ``pbar`` itself: a ``ProgressBar``
+        # instance or non-zero int is the only thing that reaches here, but
+        # keying the carry shape off ``pbar`` truthiness is a latent trap if a
+        # future falsy-but-not-None pbar type is added.
+        init = (0, init) if has_pbar else init
 
     # not jit
     if jax.config.jax_disable_jit:
@@ -400,7 +405,16 @@ def checkpointed_scan(
 
     # initialize the collected values/dataa
     out_info = stateful_fun.get_out_shapes_by_cache(cache_key)[0]
-    assert len(out_info) == 2, "function in checkpointed_scan should return two data: carray and out."
+    # ``f`` is user-supplied; validate its (carry, out) two-tuple contract with a
+    # real exception. An ``assert len(out_info) == 2`` was both stripped under
+    # ``python -O`` and, for a non-tuple return (e.g. ``return c + x``), raised an
+    # opaque ``TypeError: len() of unsized object`` because ``out_info`` is then a
+    # bare ``ShapeDtypeStruct``. Check the structure explicitly.
+    if not isinstance(out_info, (tuple, list)) or len(out_info) != 2:
+        raise ValueError(
+            "f in checkpointed_scan must return a two-tuple (carry, out), but its "
+            f"return has structure {jax.tree.structure(out_info)}."
+        )
     data2collection = jax.tree.map(lambda x: jnp.zeros((length,) + x.shape, x.dtype), out_info[1])
     del out_info
 

--- a/brainstate/transform/_loop_collect_return_test.py
+++ b/brainstate/transform/_loop_collect_return_test.py
@@ -474,3 +474,49 @@ class TestCheckpointedScanLengthValidation(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, 'length'):
             brainstate.transform.checkpointed_scan(step, 0.0, jnp.zeros((0,)), length=0)
+
+
+class TestCheckpointedScanBaseValidation(unittest.TestCase):
+    """checkpointed_scan must validate ``base`` up front with a clear ValueError
+    instead of crashing inside ``math.log(length, base)`` (audit M38).
+
+    base=1 previously raised ``ZeroDivisionError`` (log base 1 divides by
+    ``math.log(1) == 0``) and base<=0 raised ``ValueError: math domain error``;
+    base=True (bool subclasses int and collapses to the broken base==1 path)
+    must also be rejected.
+    """
+
+    def test_base_one_raises_value_error(self):
+        def step(carry, x):
+            return carry + x, carry
+
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.checkpointed_scan(step, 0.0, jnp.arange(5.0), base=1)
+
+    def test_base_zero_raises_value_error(self):
+        def step(carry, x):
+            return carry + x, carry
+
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.checkpointed_scan(step, 0.0, jnp.arange(5.0), base=0)
+
+    def test_base_negative_raises_value_error(self):
+        def step(carry, x):
+            return carry + x, carry
+
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.checkpointed_scan(step, 0.0, jnp.arange(5.0), base=-2)
+
+    def test_base_true_raises_value_error(self):
+        def step(carry, x):
+            return carry + x, carry
+
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.checkpointed_scan(step, 0.0, jnp.arange(5.0), base=True)
+
+    def test_valid_base_still_runs(self):
+        def step(carry, x):
+            return carry + x, carry
+
+        carry, ys = brainstate.transform.checkpointed_scan(step, 0.0, jnp.arange(5.0), base=2)
+        self.assertEqual(float(carry), float(jnp.arange(5.0).sum()))

--- a/brainstate/transform/_loop_collect_return_test.py
+++ b/brainstate/transform/_loop_collect_return_test.py
@@ -322,6 +322,22 @@ class TestCheckpointedScanValidation(unittest.TestCase):
         )
         self.assertTrue(jnp.allclose(carry, jnp.sum(xs), atol=1e-5))
 
+    def test_checkpointed_scan_single_value_return_raises(self):
+        """Item 6: f returning a single value (not a (carry, out) tuple) must
+        raise a clear ValueError, not a stripped assert / opaque
+        ``TypeError: len() of unsized object``."""
+        with self.assertRaises(ValueError):
+            brainstate.transform.checkpointed_scan(
+                lambda c, x: c + x, 0.0, jnp.arange(4.0)
+            )
+
+    def test_checkpointed_scan_three_tuple_return_raises(self):
+        """Item 6: f returning a three-tuple must raise a clear ValueError."""
+        with self.assertRaises(ValueError):
+            brainstate.transform.checkpointed_scan(
+                lambda c, x: (c + x, x, x), 0.0, jnp.arange(4.0)
+            )
+
 
 class TestCheckpointedScanBasic(unittest.TestCase):
     """Tests for basic correctness of checkpointed_scan()."""

--- a/brainstate/transform/_loop_no_collection.py
+++ b/brainstate/transform/_loop_no_collection.py
@@ -137,7 +137,7 @@ def while_loop(
             while cond_fun(val):
                 val = body_fun(val)
             return val
-        except jax.core.ConcretizationTypeError:
+        except jax.errors.ConcretizationTypeError:
             # Can't run this while_loop in Python (e.g. because there's a vmap
             # transformation on it), so we fall back to the primitive version.
             pass
@@ -253,6 +253,8 @@ def bounded_while_loop(
     # checking
     if not isinstance(max_steps, int) or max_steps < 0:
         raise ValueError("max_steps must be a non-negative integer")
+    if isinstance(base, bool) or not isinstance(base, int) or base < 2:
+        raise ValueError(f"base must be an integer >= 2, got {base!r}.")
     init_val = jax.tree.map(jax.numpy.asarray, init_val)
     if max_steps == 0:
         return init_val

--- a/brainstate/transform/_loop_no_collection_test.py
+++ b/brainstate/transform/_loop_no_collection_test.py
@@ -245,3 +245,64 @@ class TestBoundedWhileLoopSemantics(TestCase):
 
         self.assertEqual(float(f(1.0)), 8.0)
         self.assertEqual(float(jax.grad(f)(1.0)), 8.0)
+
+
+class TestWhileLoopDisableJitVmap(TestCase):
+    """Under ``jax.disable_jit()`` the Python fast path cannot concretize a
+    vmapped predicate; the except clause must fall through to the primitive
+    ``lax.while_loop`` instead of crashing (audit M39).
+
+    The except previously referenced ``jax.core.ConcretizationTypeError``,
+    which does not exist (``jax.core`` has no such attribute), so evaluating
+    the handler raised ``AttributeError`` and masked the intended fallback.
+    """
+
+    def test_vmap_under_disable_jit_returns_correct_result(self):
+        cond = lambda v: jnp.all(v < 3)
+        body = lambda v: v + 1
+        run = lambda init: brainstate.transform.while_loop(cond, body, init)
+        with jax.disable_jit():
+            out = jax.vmap(run)(jnp.array([0, 1, 2]))
+        self.assertTrue(bool(jnp.array_equal(out, jnp.array([3, 3, 3]))))
+
+
+class TestBoundedWhileLoopBaseValidation(TestCase):
+    """bounded_while_loop must validate ``base`` up front with a clear
+    ValueError instead of crashing inside ``math.log(max_steps, base)``
+    (audit M40).
+
+    base=1 previously raised ``ZeroDivisionError`` (log base 1 divides by
+    ``math.log(1) == 0``) and base<=0 raised ``ValueError: math domain
+    error``; base=True must also be rejected (bool subclasses int and
+    collapses to the broken base==1 path).
+    """
+
+    def test_base_one_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.bounded_while_loop(
+                lambda v: v < 3, lambda v: v + 1, jnp.asarray(0), max_steps=10, base=1
+            )
+
+    def test_base_zero_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.bounded_while_loop(
+                lambda v: v < 3, lambda v: v + 1, jnp.asarray(0), max_steps=10, base=0
+            )
+
+    def test_base_negative_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.bounded_while_loop(
+                lambda v: v < 3, lambda v: v + 1, jnp.asarray(0), max_steps=10, base=-2
+            )
+
+    def test_base_true_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, 'base'):
+            brainstate.transform.bounded_while_loop(
+                lambda v: v < 3, lambda v: v + 1, jnp.asarray(0), max_steps=10, base=True
+            )
+
+    def test_valid_base_still_runs(self):
+        out = brainstate.transform.bounded_while_loop(
+            lambda v: v < 3, lambda v: v + 1, jnp.asarray(0), max_steps=10, base=2
+        )
+        self.assertEqual(int(out), 3)

--- a/brainstate/transform/_make_jaxpr.py
+++ b/brainstate/transform/_make_jaxpr.py
@@ -157,7 +157,11 @@ def get_arg_cache_key(
             static_args.append(arg)
         else:
             dyn_args.append(arg)
-    jax.tree.map(fn_to_check, dyn_args, is_leaf=lambda x: isinstance(x, State))
+    # Mirror the kwargs branch below: skip the State check when ``fn_to_check``
+    # is None. Without this guard ``jax.tree.map(None, ...)`` raises a confusing
+    # ``TypeError: 'NoneType' object is not callable`` on the positional args.
+    if fn_to_check is not None:
+        jax.tree.map(fn_to_check, dyn_args, is_leaf=lambda x: isinstance(x, State))
     dyn_args = jax.tree.map(shaped_abstractify, dyn_args)
 
     # kwargs -- the State check must run BEFORE abstractification, which
@@ -469,7 +473,13 @@ class StatefulFunction(PrettyObject):
             if current_def != compiled_def or len(current_leaves) != len(compiled_leaves):
                 return True
             for cur, ref in zip(current_leaves, compiled_leaves):
-                if shaped_abstractify(cur) != ref:
+                # Compare shape and dtype only, per the documented contract. Full
+                # aval equality also distinguishes ``weak_type`` (e.g. a Python
+                # float -> ``weak_type=True`` vs an array -> ``weak_type=False``),
+                # which would flag an otherwise-identical state as stale and force
+                # a spurious recompile.
+                cur_aval = shaped_abstractify(cur)
+                if cur_aval.shape != ref.shape or cur_aval.dtype != ref.dtype:
                     return True
         return False
 
@@ -902,8 +912,11 @@ class StatefulFunction(PrettyObject):
         # static args
         cache_key = self.get_arg_cache_key(*args, **kwargs)
 
-        # Validate static_argnums bounds
-        if self.static_argnums and args:
+        # Validate static_argnums bounds. The check must run even when ``args``
+        # is empty: calling with only keyword arguments while ``static_argnums``
+        # names a positional index (e.g. ``static_argnums=(0,)``) is still
+        # out of range -- gating on ``and args`` silently skipped that case.
+        if self.static_argnums:
             max_idx = max(self.static_argnums)
             if max_idx >= len(args):
                 raise ValueError(
@@ -1038,6 +1051,17 @@ class StatefulFunction(PrettyObject):
             states: Sequence[State] = tuple(compilation.state_trace.states)
             if len(state_vals) != len(states):
                 raise ValueError(f'State length mismatch: expected {len(states)} states, got {len(state_vals)}')
+            # A correct-length ``state_vals`` whose entries are ``None`` would
+            # otherwise flatten away (``None`` is an empty pytree) and reach
+            # ``eval_jaxpr`` with too few operands, failing with an opaque
+            # ``foreach()``/argument-count error. Each entry is one tracked
+            # state's value and must be present; report the offending indices.
+            none_indices = [i for i, v in enumerate(state_vals) if v is None]
+            if none_indices:
+                raise ValueError(
+                    f'state_vals contains None at index(es) {none_indices}; '
+                    f'every tracked state must be given a concrete value.'
+                )
 
             # parameters
             kwargs = {k: v for k, v in kwargs.items() if k not in self.static_argnames}  # remove static kwargs
@@ -1164,7 +1188,21 @@ class StatefulFunction(PrettyObject):
 
         for i, (state, compiled_aval) in enumerate(zip(state_trace.states, compiled_avals)):
             current_aval = jax.tree.map(shaped_abstractify, state.value)
-            if current_aval != compiled_aval:
+            # Compare structurally rather than with ``!=`` on the whole aval.
+            # A direct ``current_aval != compiled_aval`` dispatches to the leaf
+            # type's ``__ne__``; for a unit-aware ``Quantity`` with mismatched
+            # units that raises ``UnitMismatchError`` instead of the documented
+            # ``ValueError``. Flattening folds any unit change into the treedef
+            # and leaves plain ``ShapedArray`` leaves to compare by shape/dtype.
+            cur_leaves, cur_def = jax.tree.flatten(current_aval)
+            ref_leaves, ref_def = jax.tree.flatten(compiled_aval)
+            mismatch = (
+                cur_def != ref_def
+                or len(cur_leaves) != len(ref_leaves)
+                or any(c.shape != r.shape or c.dtype != r.dtype
+                       for c, r in zip(cur_leaves, ref_leaves))
+            )
+            if mismatch:
                 raise ValueError(
                     f'State shape/dtype mismatch for state {i} '
                     f'(type: {type(state).__name__}): '

--- a/brainstate/transform/_make_jaxpr.py
+++ b/brainstate/transform/_make_jaxpr.py
@@ -922,10 +922,12 @@ class StatefulFunction(PrettyObject):
             compilation = self._compilation_cache.get(cache_key)
             if compilation is not None and not self._compilation_is_stale(compilation):
                 return self
-            # Drop the stale entry (if any) up front: even if recompilation
-            # fails below, a known-stale jaxpr must not be reused.
-            self._compilation_cache.pop(cache_key)
-
+            # NJ2: do NOT drop the stale entry up front. Leaving it in place during
+            # the (slow) re-trace means a concurrent reader using a get_*_by_cache()
+            # method observes the old-but-valid entry instead of a transient hole
+            # (which previously raised a spurious ValueError). On success we
+            # atomically replace it below; on failure we drop it in the except
+            # branch so a known-stale jaxpr is never reused.
             try:
                 # kwargs separation
                 static_kwargs, dyn_kwargs = {}, {}
@@ -982,12 +984,19 @@ class StatefulFunction(PrettyObject):
                     state_trace=state_trace,
                     state_avals=state_avals,
                 )
-                self._compilation_cache.set(cache_key, compilation)
+                # Atomically swap the (possibly stale) entry under the cache's own
+                # lock so a concurrent reader sees either the old or the new value,
+                # never a hole. Fall back to set() for the first compilation.
+                if cache_key in self._compilation_cache:
+                    self._compilation_cache.replace(cache_key, compilation)
+                else:
+                    self._compilation_cache.set(cache_key, compilation)
 
             except Exception:
-                # No partial cache entries to clean up since we only write
-                # to the cache on success (state_trace is in _result_holder,
-                # not in the cache).
+                # The re-trace failed: drop any stale entry now so a known-stale
+                # jaxpr is never reused (it was deliberately left in place during
+                # tracing to avoid a transient miss for concurrent readers). NJ2.
+                self._compilation_cache.pop(cache_key)
                 raise
 
         return self

--- a/brainstate/transform/_make_jaxpr_test.py
+++ b/brainstate/transform/_make_jaxpr_test.py
@@ -2013,3 +2013,129 @@ class TestUnhashableStaticArgs(unittest.TestCase):
         sf = brainstate.transform.StatefulFunction(f, static_argnums=(1,))
         with self.assertRaisesRegex(TypeError, '[Ss]tatic argument'):
             sf.make_jaxpr(jnp.zeros(3), jnp.zeros(3))
+
+
+class TestStaleCacheRecompileNJ2(unittest.TestCase):
+    """A stale compilation entry must be recompiled in place (atomic replace),
+    never exposed to concurrent readers as a transient hole, and dropped only
+    when the re-trace itself fails (audit NJ2)."""
+
+    def _make_sf_with_closure_state(self):
+        # The output depends on the argument ``x`` (which drives the cache key),
+        # while *staleness* is driven by a closure state whose aval we mutate
+        # without ever touching the arguments -> same key, stale entry.
+        state = brainstate.State(jnp.zeros(3))
+
+        def f(x):
+            state.value = state.value * 2.0  # tracked-state aval => staleness source
+            return x.sum()                   # arg-derived cache key
+
+        return brainstate.transform.StatefulFunction(f), state
+
+    def test_stale_entry_recompiled_in_place(self):
+        sf, state = self._make_sf_with_closure_state()
+        x = jnp.ones(3)
+        sf.make_jaxpr(x)
+        key = sf.get_arg_cache_key(x)
+        self.assertIn(key, sf._compilation_cache)
+        self.assertEqual(len(sf._compilation_cache), 1)
+
+        # Mutate the closure state's aval: the cached entry is now stale, but
+        # the arg-derived cache key is unchanged.
+        state.value = jnp.zeros(5)
+
+        # Recompiling with the same args hits the same key; NJ2 replaces the
+        # stale entry in place -- key stays present, size stays 1 (no duplicate).
+        sf.make_jaxpr(x)
+        self.assertIn(key, sf._compilation_cache)
+        self.assertEqual(len(sf._compilation_cache), 1)
+        # The replacement is fresh: it must no longer read as stale.
+        self.assertFalse(sf._compilation_is_stale(sf._compilation_cache.get(key)))
+
+    def test_stale_recompile_failure_drops_entry(self):
+        state = brainstate.State(jnp.zeros(3))
+        fail = {'on': False}
+
+        def f(x):
+            if fail['on']:
+                # Data-dependent Python control flow => a tracing error on the
+                # re-trace of an already-cached key.
+                if x[0] > 0:
+                    return x.sum()
+                return x.prod()
+            state.value = state.value * 2.0
+            return x.sum()
+
+        sf = brainstate.transform.StatefulFunction(f)
+        x = jnp.ones(3)
+        sf.make_jaxpr(x)
+        key = sf.get_arg_cache_key(x)
+        self.assertIn(key, sf._compilation_cache)
+
+        # Force staleness AND make the re-trace fail.
+        state.value = jnp.zeros(5)
+        fail['on'] = True
+        with self.assertRaises(Exception):
+            sf.make_jaxpr(x)
+        # NJ2: the known-stale entry is dropped, never silently reused.
+        self.assertNotIn(key, sf._compilation_cache)
+
+    def test_no_transient_hole_for_concurrent_reader(self):
+        # Pre-fix the stale entry was popped up front (inside the compile lock)
+        # before the slow re-trace, so a concurrent reader observed a hole and
+        # raised a spurious ValueError. Post-fix the old entry stays until the
+        # atomic replace, so the reader always sees a valid compilation.
+        import threading
+
+        state = brainstate.State(jnp.zeros(3))
+        arm = threading.Event()          # set right before triggering the recompile
+        mid_trace = threading.Event()    # set once the recompile is parked mid-trace
+        reader_done = threading.Event()  # set once the reader has finished
+
+        def f(x):
+            if arm.is_set():
+                mid_trace.set()
+                reader_done.wait(timeout=10)
+            state.value = state.value * 2.0
+            return x.sum()
+
+        sf = brainstate.transform.StatefulFunction(f)
+        x = jnp.ones(3)
+        sf.make_jaxpr(x)
+        key = sf.get_arg_cache_key(x)
+
+        # Make the entry stale so the next make_jaxpr re-traces under the lock.
+        state.value = jnp.zeros(5)
+
+        errors = []
+
+        def recompile():
+            try:
+                sf.make_jaxpr(x)
+            except Exception as e:  # pragma: no cover - surfaced via the list
+                errors.append(e)
+
+        arm.set()
+        t = threading.Thread(target=recompile)
+        t.start()
+        reader_error = None
+        try:
+            self.assertTrue(mid_trace.wait(timeout=10), 'recompile never reached trace')
+            try:
+                # Must observe the OLD-but-valid entry, not a transient hole.
+                self.assertIsNotNone(sf.get_jaxpr_by_cache(key))
+            except Exception as e:
+                reader_error = e
+        finally:
+            reader_done.set()
+            t.join(timeout=15)
+
+        self.assertEqual(errors, [])
+        self.assertIsNone(
+            reader_error,
+            f'concurrent reader saw a transient cache hole: {reader_error!r}',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainstate/transform/_make_jaxpr_test.py
+++ b/brainstate/transform/_make_jaxpr_test.py
@@ -2228,6 +2228,29 @@ class TestAuditFixes(unittest.TestCase):
         with pytest.raises(ValueError, match="shape/dtype mismatch"):
             sf._validate_state_shapes(cache_key)
 
+    def test_validate_state_shapes_unchanged_returns_none(self):
+        """``_validate_state_shapes`` returns without raising when every tracked
+        state still matches the shape/dtype it was compiled with (the
+        no-mismatch branch).
+
+        The companion test above covers the mismatch->ValueError branch; here
+        the state value is left untouched between compilation and validation, so
+        the per-state comparison finds no mismatch for any state and the method
+        completes normally (returning ``None``)."""
+        sv = brainstate.State(jnp.array([1.0, 2.0, 3.0]))
+
+        def g(x):
+            sv.value = sv.value + x
+            return sv.value.sum()
+
+        sf = brainstate.transform.StatefulFunction(g)
+        x = jnp.array([1.0, 2.0, 3.0])
+        sf.make_jaxpr(x)
+        cache_key = sf.get_arg_cache_key(x)
+
+        # Shapes/dtypes are unchanged -> no mismatch -> no exception.
+        self.assertIsNone(sf._validate_state_shapes(cache_key))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/transform/_make_jaxpr_test.py
+++ b/brainstate/transform/_make_jaxpr_test.py
@@ -2137,5 +2137,97 @@ class TestStaleCacheRecompileNJ2(unittest.TestCase):
         )
 
 
+class TestAuditFixes(unittest.TestCase):
+    """Regression tests for the make_jaxpr audit items 7-11."""
+
+    def test_get_arg_cache_key_fn_to_check_none_on_args(self):
+        """Item 7: ``fn_to_check=None`` must skip the positional-arg State check
+        (mirroring the kwargs branch) instead of calling ``None``."""
+        from brainstate.transform._make_jaxpr import get_arg_cache_key
+        # Must not raise ``TypeError: 'NoneType' object is not callable``.
+        key = get_arg_cache_key((), (), (jnp.array([1.0, 2.0]),), {}, fn_to_check=None)
+        self.assertIsNotNone(key)
+
+    def test_weak_type_change_is_not_stale(self):
+        """Item 8: a weak_type-only change (same shape/dtype) must not be treated
+        as a stale compilation and force a recompile."""
+        st = brainstate.State(jnp.float32(1.0))  # strong-typed scalar
+
+        def f(x):
+            st.value = st.value + x
+            return st.value
+
+        sf = brainstate.transform.StatefulFunction(f)
+        sf.make_jaxpr(jnp.float32(2.0))
+        cache_key = sf.get_arg_cache_key(jnp.float32(2.0))
+        compilation = sf._get_compilation(cache_key)
+        # Replace the state with a weak-typed python scalar (same shape/dtype).
+        st.value = 5.0
+        self.assertFalse(sf._compilation_is_stale(compilation))
+
+    def test_shape_change_is_stale(self):
+        """Item 8 guard: a genuine shape change must still be detected."""
+        st = brainstate.State(jnp.zeros(3))
+
+        def f(x):
+            st.value = st.value + x
+            return st.value
+
+        sf = brainstate.transform.StatefulFunction(f)
+        sf.make_jaxpr(jnp.zeros(3))
+        cache_key = sf.get_arg_cache_key(jnp.zeros(3))
+        compilation = sf._get_compilation(cache_key)
+        st.value = jnp.zeros(5)  # different shape
+        self.assertTrue(sf._compilation_is_stale(compilation))
+
+    def test_static_argnums_out_of_range_kwargs_only(self):
+        """Item 9: an out-of-range ``static_argnums`` must raise even when the
+        function is invoked with keyword arguments only (empty ``args``)."""
+        def f(x, n=2):
+            return x ** n
+
+        sf = brainstate.transform.StatefulFunction(f, static_argnums=(0,))
+        with pytest.raises(ValueError, match="static_argnums contains index 0"):
+            sf.make_jaxpr(x=jnp.array([1.0, 2.0]), n=3)
+
+    def test_jaxpr_call_none_state_value(self):
+        """Item 10: a correct-length ``state_vals`` with a ``None`` entry must
+        raise a clear ValueError, not a cryptic eval_jaxpr/foreach error."""
+        st = brainstate.State(jnp.array([1.0, 2.0]))
+
+        def f(x):
+            st.value = st.value + x
+            return st.value.sum()
+
+        sf = brainstate.transform.StatefulFunction(f)
+        x = jnp.array([1.0, 2.0])
+        sf.make_jaxpr(x)
+        with pytest.raises(ValueError, match="None at index"):
+            sf.jaxpr_call([None], x)
+
+    def test_validate_state_shapes_unit_mismatch_raises_value_error(self):
+        """Item 11: ``_validate_state_shapes`` must raise ValueError (not
+        UnitMismatchError) when a Quantity state's units change."""
+        try:
+            import brainunit as u
+        except ImportError:
+            self.skipTest("brainunit not available")
+
+        sv = brainstate.State(u.Quantity(jnp.array([1.0, 2.0]), unit=u.mV))
+
+        def g(x):
+            sv.value = sv.value + x
+            return sv.value
+
+        sf = brainstate.transform.StatefulFunction(g)
+        xq = u.Quantity(jnp.array([1.0, 2.0]), unit=u.mV)
+        sf.make_jaxpr(xq)
+        cache_key = sf.get_arg_cache_key(xq)
+        # Change to an incompatible unit (mV -> mA).
+        sv.value = u.Quantity(jnp.array([1.0, 2.0]), unit=u.mA)
+        with pytest.raises(ValueError, match="shape/dtype mismatch"):
+            sf._validate_state_shapes(cache_key)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/brainstate/transform/_mapping2.py
+++ b/brainstate/transform/_mapping2.py
@@ -109,7 +109,9 @@ class StatefulMapping:
         ``'warn'`` scatters them with a warning, and ``'ignore'`` scatters them
         silently.
     static_argnums : int or iterable of int, default ()
-        Positional arguments treated as compile-time constants for caching.
+        Not supported by the state-mapping engine: a non-empty value raises
+        ``NotImplementedError``. Use ``static_argnames`` for keyword arguments,
+        or set ``in_axes=None`` for the positional slot you want broadcast.
     static_argnames : str or iterable of str, default ()
         Keyword arguments treated as compile-time constants for caching.
     axis_env : sequence, optional
@@ -844,14 +846,34 @@ def _map_new_states(
 
     try:
         with catch_new_states(state_tag):
-            mapped = primitive(
-                init_fn,
-                in_axes=(0 if len(rng_states) else None,),
-                out_axes=tuple(axes_order),
-                axis_size=axis_size,
-                axis_name=axis_name,
-            )
-            tuple_vals = mapped(rng_keys)
+            if behavior == 'pmap' and len(rng_states) == 0:
+                # H19: jax.pmap (unlike jax.vmap) has no axis_size-only
+                # broadcast and raises ``ValueError: pmap requires at least one
+                # argument with a mapped axis`` when every in_axes entry is
+                # None. When init draws no randomness ``rng_keys == []`` and the
+                # natural ``in_axes=(None,)`` triggers that error. Feed a
+                # throwaway mapped argument (in_axes=0) and discard it; keep
+                # ``init_fn``'s signature/closure over rng_keys unchanged. The
+                # ``out_axes`` is left untouched so NonBatchState replication
+                # (out axis None) is preserved.
+                init_fn2 = lambda rng_keys, _dummy: init_fn(rng_keys)
+                mapped = primitive(
+                    init_fn2,
+                    in_axes=(None, 0),
+                    out_axes=tuple(axes_order),
+                    axis_size=axis_size,
+                    axis_name=axis_name,
+                )
+                tuple_vals = mapped(rng_keys, jax.numpy.arange(axis_size))
+            else:
+                mapped = primitive(
+                    init_fn,
+                    in_axes=(0 if len(rng_states) else None,),
+                    out_axes=tuple(axes_order),
+                    axis_size=axis_size,
+                    axis_name=axis_name,
+                )
+                tuple_vals = mapped(rng_keys)
     finally:
         # restore the global RNG once -- also on failure, so a crashed mapped
         # pass cannot leave key tracers in the random states

--- a/brainstate/transform/_mapping2_test.py
+++ b/brainstate/transform/_mapping2_test.py
@@ -401,9 +401,11 @@ class TestStatefulMappingInit(unittest.TestCase):
     """Tests for StatefulMapping construction with non-default static args."""
 
     def test_static_argnums_int(self):
-        """StatefulMapping accepts an int for static_argnums and wraps it in a tuple."""
-        sm = StatefulMapping(lambda x: x, static_argnums=2)
-        self.assertEqual(sm.static_argnums, (2,))
+        """M41: StatefulMapping rejects a non-empty static_argnums (the engine
+        never excludes static positional slots from the axis mapping, so it
+        would crash/mismap). The int form is normalized before the check."""
+        with self.assertRaises(NotImplementedError):
+            StatefulMapping(lambda x: x, static_argnums=2)
 
     def test_static_argnames_list(self):
         """StatefulMapping accepts a list for static_argnames and converts to tuple."""
@@ -900,6 +902,43 @@ class TestPmap2NewStates(unittest.TestCase):
         result = pmap2_new_states(m, {})
         self.assertIsInstance(result, dict)
         self.assertEqual(m.w.value.shape[0], jax.local_device_count())
+
+    @unittest.skipIf(jax.local_device_count() < 2, "Requires at least 2 devices")
+    def test_pmap2_new_states_deterministic_param(self):
+        """H19: pmap2_new_states must not crash when init draws no randomness.
+
+        ``jax.pmap`` (unlike ``jax.vmap``) requires at least one mapped
+        argument; with deterministic state init there are no RNG keys to map,
+        so the no-rng pmap branch must supply a throwaway mapped argument.
+        Pre-fix this raised ``ValueError: pmap requires at least one argument
+        with a mapped axis``.
+        """
+
+        class M(brainstate.nn.Module):
+            def init_all_states(self, **kw):
+                self.w = brainstate.ParamState(jnp.ones(3))
+
+        m = M()
+        n = jax.local_device_count()
+        result = pmap2_new_states(m, {}, axis_size=n)
+        self.assertIsInstance(result, dict)
+        # batched at axis 0 with size == number of devices
+        self.assertEqual(m.w.value.shape, (n, 3))
+        # each device receives the same deterministic init
+        self.assertTrue(jnp.allclose(m.w.value, jnp.ones((n, 3))))
+
+    @unittest.skipIf(jax.local_device_count() < 2, "Requires at least 2 devices")
+    def test_pmap2_new_states_deterministic_default_axis_size(self):
+        """H19: deterministic init with default axis_size (local_device_count)."""
+
+        class M(brainstate.nn.Module):
+            def init_all_states(self, **kw):
+                self.count = brainstate.ShortTermState(jnp.zeros(()))
+
+        m = M()
+        result = pmap2_new_states(m, {})
+        self.assertIsInstance(result, dict)
+        self.assertEqual(m.count.value.shape, (jax.local_device_count(),))
 
 
 class TestVmap2PytreeInAxes(unittest.TestCase):

--- a/brainstate/transform/_mapping_core.py
+++ b/brainstate/transform/_mapping_core.py
@@ -1163,9 +1163,14 @@ def state_map_transform(
     unexpected_out_state_mapping : {'auto', 'raise', 'warn', 'ignore'}
         Policy for states written with a batched value but not declared in
         ``state_out_axes``.
-    static_argnums, static_argnames : int/str or iterable
-        Positional/keyword arguments treated as compile-time constants when
-        building the per-signature cache key.
+    static_argnums : int or iterable
+        Not supported: a non-empty value raises ``NotImplementedError``. The
+        engine never excludes static positional slots from the axis mapping, so
+        accepting them would crash or silently mismap. Use ``static_argnames``
+        for keyword args, or ``in_axes=None`` for the positional slot.
+    static_argnames : str or iterable
+        Keyword arguments treated as compile-time constants when building the
+        per-signature cache key.
     name : str, optional
         Diagnostic name.
 
@@ -1174,6 +1179,30 @@ def state_map_transform(
     callable
         A wrapped function with the same calling convention as ``f``.
     """
+    # M41: ``static_argnums`` is threaded only into ``get_arg_cache_key`` for the
+    # plan cache key; it is never excluded from the per-argument axis mapping
+    # (``in_axes``/``_strip_args``/``_get_batch_size``). Static positional args
+    # are therefore treated like dynamic ones -- the default ``in_axes=0`` is
+    # applied and ``_remove_axis`` calls ``.ndim`` on them, which crashes on
+    # scalars (``AttributeError: 'float' object has no attribute 'ndim'``) or
+    # silently mismaps array statics over axis 0. The state-mapping engine has no
+    # split-positional support (and ``static_argnums`` is not exposed via
+    # vmap2/pmap2), so reject it explicitly rather than crashing deep in
+    # ``_remove_axis``. ``static_argnames`` is fully supported via
+    # ``_split_kwargs`` and remains available for keyword args.
+    if isinstance(static_argnums, int):
+        static_argnums = (static_argnums,)
+    elif static_argnums is None:
+        static_argnums = ()
+    else:
+        static_argnums = tuple(static_argnums)
+    if len(static_argnums) > 0:
+        raise NotImplementedError(
+            "static_argnums is not supported by the state-mapping engine; use "
+            "static_argnames for keyword arguments, or set in_axes=None for that "
+            "positional slot."
+        )
+
     in_predicates = normalize_state_axes(state_in_axes)
     out_predicates = normalize_state_axes(state_out_axes)
     mapping_kwargs = dict() if mapping_kwargs is None else mapping_kwargs

--- a/brainstate/transform/_mapping_core.py
+++ b/brainstate/transform/_mapping_core.py
@@ -183,11 +183,20 @@ def _flatten_in_out_states(
 def _remove_axis(x, axis: int):
     if not isinstance(axis, int):
         raise TypeError(f"Expected the mapped axis to be an integer, but got {type(axis)}.")
+    # A non-array (scalar) leaf has no ``ndim``/``shape``; touching them yields an
+    # opaque ``AttributeError``. Report which leaf cannot carry a mapped axis.
+    ndim = getattr(x, 'ndim', None)
+    if ndim is None:
+        raise ValueError(
+            f"Cannot map axis {axis} over a non-array leaf of type "
+            f"{type(x).__name__}: it has no array dimensions. Mapped inputs and "
+            f"states must be arrays; use a None axis to broadcast scalars."
+        )
     if axis < 0:
-        axis += x.ndim
-    if axis < 0 or axis >= x.ndim:
+        axis += ndim
+    if axis < 0 or axis >= ndim:
         raise ValueError(f"Mapped axis {axis} is out of bounds for array of shape {x.shape}.")
-    return x[tuple(slice(None, None, None) if i != axis else 0 for i in range(x.ndim))]
+    return x[tuple(slice(None, None, None) if i != axis else 0 for i in range(ndim))]
 
 
 def _deaxed_like(x, axis: int):
@@ -212,10 +221,22 @@ def _deaxed_like(x, axis: int):
 
 def _compile_stateful_function(
     stateful_fn: StatefulFunction,
-    in_axes: int | Tuple[int, ...],
-    args: Tuple
+    in_axes: Tuple[Any, int | None | Tuple],
+    args: Tuple[Any, Tuple],
 ):
     """Strip mapped axes and build a per-signature cache key for a stateful fn.
+
+    Parameters
+    ----------
+    stateful_fn : StatefulFunction
+        The stateful function being mapped.
+    in_axes : tuple
+        A 2-tuple ``(state_in_axes, arg_in_axes)`` -- *not* a bare int. The first
+        element holds the per-state mapped axes and the second the per-argument
+        ``in_axes`` (an int, ``None``, or a tuple); both are unpacked below.
+    args : tuple
+        A 2-tuple ``(state_vals, args)`` of the current state values and the
+        positional arguments.
 
     .. note::
 
@@ -303,6 +324,15 @@ def _get_batch_size(
     # Ensure all batch sizes are consistent.
     if len(set(batch_sizes)) > 1:
         raise ValueError(f"Inconsistent batch sizes found: {set(batch_sizes)}")
+    # Cross-check an explicit ``axis_size`` against the inferred size instead of
+    # silently ignoring it. Previously ``axis_size`` was consulted only when no
+    # size could be inferred, so a wrong ``axis_size`` paired with batched inputs
+    # passed unnoticed (jax.vmap would later error, but far less clearly).
+    if axis_size is not None and axis_size != batch_sizes[0]:
+        raise ValueError(
+            f"Explicit axis_size={axis_size} does not match the mapped axis size "
+            f"{batch_sizes[0]} inferred from the batched inputs/states."
+        )
     return batch_sizes[0]
 
 
@@ -929,7 +959,12 @@ def _build_plan(
         det = detected.get(id(st))
 
         if in_axis is not None:
-            # batched input -> also a batched output at the same axis
+            # A batched input is scattered back as a batched output only when it
+            # is actually written by ``f`` or explicitly declared in
+            # ``state_out_axes``. A purely read-only batched input must NOT be
+            # added to the output groups: it is unchanged by the call, so
+            # collecting and re-stacking it is wasted work (and forces it to be a
+            # vmap output it never needed to be).
             matched, out_axis = _match_out_axis(st)
             if matched and out_axis is not None and out_axis != in_axis:
                 st.raise_error_with_source_info(
@@ -938,7 +973,8 @@ def _build_plan(
                         f"state_out_axes maps it to axis {out_axis}."
                     )
                 )
-            out_axis_groups[in_axis].append(st)
+            if is_write or matched:
+                out_axis_groups[in_axis].append(st)
             continue
 
         matched, out_axis = _match_out_axis(st)
@@ -1109,12 +1145,24 @@ def _execute_plan(plan: LiveStateMapPlan, f, args, kwargs, in_axes, out_axes,
         raise
 
     # scatter batched output state values
+    out_group_ids = {id(st) for _, states in out_groups for st in states}
     for (axis, states), vals in zip(out_groups, out_group_vals):
         for st, v in zip(states, vals):
             st.restore_value(v)
     # restore broadcast output state values
     for st, v in zip(oth_out_states, oth_vals):
         st.restore_value(v)
+    # Restore read-only batched inputs from their pre-call snapshot. They are fed
+    # per-lane into ``fn_to_map`` (which leaves each state holding a single lane),
+    # but a read-only input is unchanged by the call and is deliberately NOT a
+    # vmap output, so without this its leaked per-lane value would replace the
+    # original batched value. (Written/declared inputs are in ``out_groups`` and
+    # were already scattered above; only the input-group states need this.)
+    snapshot_by_id = {id(st): val for st, val in snapshots}
+    for _, states in in_groups:
+        for st in states:
+            if id(st) not in out_group_ids and id(st) in snapshot_by_id:
+                st.restore_value(snapshot_by_id[id(st)])
     # restore the global RNG once (randomness consumed exactly once per call)
     for rng, key in zip(rng_states, rng_backups):
         rng.restore_value(key)

--- a/brainstate/transform/_mapping_core_test.py
+++ b/brainstate/transform/_mapping_core_test.py
@@ -1443,5 +1443,53 @@ class TestStalePlanWriteSetDivergence(unittest.TestCase):
         self.assertLess(second, first)
 
 
+class TestStaticArgnumsRejected(unittest.TestCase):
+    """M41: static_argnums is never excluded from the axis mapping, so a static
+    positional arg gets the default in_axes=0 and is axis-stripped by
+    _remove_axis -- crashing on scalars (AttributeError: 'float' object has no
+    attribute 'ndim') or silently mismapping arrays. The engine has no
+    split-positional support, so a non-empty static_argnums must be rejected
+    loudly instead of crashing deep in _remove_axis."""
+
+    def test_static_argnums_tuple_raises(self):
+        # Pre-fix this raised AttributeError from _remove_axis on the scalar.
+        with self.assertRaises(NotImplementedError):
+            state_map_transform(
+                lambda x, scale: x * scale, in_axes=0, static_argnums=(1,)
+            )
+
+    def test_static_argnums_int_raises(self):
+        # int form is normalized to a tuple before the check.
+        with self.assertRaises(NotImplementedError):
+            state_map_transform(
+                lambda x, scale: x * scale, in_axes=0, static_argnums=1
+            )
+
+    def test_static_argnums_empty_is_allowed(self):
+        # The default () (and None) must NOT trip the guard.
+        f = state_map_transform(lambda x: x * 2.0, in_axes=0, static_argnums=())
+        out = f(jnp.arange(3.))
+        self.assertTrue(jnp.allclose(out, jnp.arange(3.) * 2.0))
+        g = state_map_transform(lambda x: x * 2.0, in_axes=0, static_argnums=None)
+        self.assertTrue(jnp.allclose(g(jnp.arange(3.)), jnp.arange(3.) * 2.0))
+
+    def test_statefulmapping_static_argnums_raises(self):
+        # StatefulMapping builds the engine wrapper at construction time, so the
+        # rejection surfaces immediately when static_argnums is non-empty.
+        with self.assertRaises(NotImplementedError):
+            brainstate.transform.StatefulMapping(
+                lambda x, scale: x * scale, in_axes=0, static_argnums=(1,)
+            )
+
+    def test_static_argnames_still_supported(self):
+        # The exactly-parallel keyword path must keep working (and produce the
+        # correct broadcast result), proving the fix targets only argnums.
+        f = state_map_transform(
+            lambda x, scale: x * scale, in_axes=0, static_argnames=('scale',)
+        )
+        out = f(jnp.arange(3.), scale=10.0)
+        self.assertTrue(jnp.allclose(out, jnp.asarray([0., 10., 20.])))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/transform/_mapping_core_test.py
+++ b/brainstate/transform/_mapping_core_test.py
@@ -1491,5 +1491,69 @@ class TestStaticArgnumsRejected(unittest.TestCase):
         self.assertTrue(jnp.allclose(out, jnp.asarray([0., 10., 20.])))
 
 
+class TestRemoveAxisScalar(unittest.TestCase):
+    """Item 12: _remove_axis must reject non-array (scalar) leaves with a clear
+    error instead of an opaque AttributeError on ``.ndim``."""
+
+    def test_python_scalar_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _remove_axis(5.0, 0)
+
+    def test_int_scalar_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _remove_axis(3, 0)
+
+    def test_array_still_works(self):
+        out = _remove_axis(jnp.arange(6.).reshape(2, 3), 0)
+        self.assertEqual(out.shape, (3,))
+
+
+class TestAxisSizeCrossCheck(unittest.TestCase):
+    """Item 14: an explicit axis_size must be cross-checked against the inferred
+    mapped-axis size, not silently ignored when a size is inferable."""
+
+    def test_conflicting_axis_size_raises(self):
+        with self.assertRaises(ValueError):
+            _get_batch_size((jnp.ones((4, 2)),), in_axes=0, in_states={}, axis_size=7)
+
+    def test_matching_axis_size_ok(self):
+        batch = _get_batch_size((jnp.ones((4, 2)),), in_axes=0, in_states={}, axis_size=4)
+        self.assertEqual(batch, 4)
+
+    def test_axis_size_fallback_unchanged(self):
+        # No inferable size -> axis_size is still used as the fallback.
+        self.assertEqual(_get_batch_size((), 0, {}, axis_size=5), 5)
+
+
+class TestReadOnlyBatchedInputNotScattered(unittest.TestCase):
+    """Item 15: a read-only batched-input state must stay at its original
+    (batched) value across calls -- it is fed per-lane but not scattered back as
+    an output, and must be restored from its pre-call snapshot."""
+
+    def test_readonly_declared_input_is_stable(self):
+        B, N = 3, 4
+        a = brainstate.HiddenState(jnp.ones((B, N)))      # read-only batched input
+        b = brainstate.ShortTermState(jnp.zeros((B, N)))  # RMW, auto-promoted
+
+        def f(x):
+            b.value = b.value + a.value + x
+            return b.value
+
+        mapped = state_map_transform(f, in_axes=0, out_axes=0, state_in_axes={0: a})
+        xs = jnp.ones((B, N))
+        o1 = mapped(xs)
+        self.assertEqual(a.value.shape, (B, N))            # unchanged shape
+        self.assertTrue(jnp.allclose(a.value, 1.0))        # unchanged value
+        self.assertEqual(b.value.shape, (B, N))
+        self.assertTrue(jnp.allclose(b.value, 2.0))        # 0 + a(1) + x(1)
+        o2 = mapped(xs)
+        # Read-only input still stable; the RMW state keeps accumulating.
+        self.assertEqual(a.value.shape, (B, N))
+        self.assertTrue(jnp.allclose(a.value, 1.0))
+        self.assertTrue(jnp.allclose(b.value, 4.0))
+        self.assertEqual(o1.shape, (B, N))
+        self.assertEqual(o2.shape, (B, N))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/transform/_named_call.py
+++ b/brainstate/transform/_named_call.py
@@ -73,7 +73,7 @@ def named_call(fun: Optional[Callable] = None, *, name: Optional[str] = None) ->
         ...     return jnp.sin(x) * 2.0
         >>>
         >>> block(jnp.array([1.0, 2.0]))
-        Array([1.6829419, 1.8185949], dtype=float32)
+        Array([1.6829419, 1.8185948], dtype=float32)
     """
     def _wrap(f: Callable) -> Callable:
         scope_name = name if name is not None else getattr(f, '__name__', 'named_call')

--- a/brainstate/transform/_named_scope.py
+++ b/brainstate/transform/_named_scope.py
@@ -133,7 +133,13 @@ def named_scope(
     ``static_argnums``/``static_argnames`` may also be callables that compute the
     static configuration from the actual call arguments.
 
-    The decorated function supports being used as a class bound method.
+    The decorated function supports being used as a class bound method. When
+    used on a method, the instance is passed as the first positional argument
+    (index 0). Under ``ir_compilation=True`` that argument is JIT-traced, so the
+    instance (index 0) must be included in ``static_argnums`` to be treated as a
+    static/closed-over value (mirroring the convention used elsewhere in
+    brainstate, e.g. ``RandomState``); otherwise JIT tries to abstractify the
+    instance and fails.
 
     Parameters
     ----------
@@ -170,13 +176,14 @@ def named_scope(
     ... def scaled_power(x, n, scale):
     ...     return (x ** n) * scale  # n and scale are static
 
-    As a class method:
+    As a class method (the instance at index 0 must be marked static so it is
+    not JIT-abstractified under ``ir_compilation=True``):
 
     >>> class MyModule:
     ...     def __init__(self, scale):
     ...         self.scale = scale
     ...
-    ...     @named_scope(name='compute')
+    ...     @named_scope(name='compute', static_argnums=0)
     ...     def compute(self, x):
     ...         return x * self.scale
     """

--- a/brainstate/transform/_named_scope_test.py
+++ b/brainstate/transform/_named_scope_test.py
@@ -609,6 +609,41 @@ class TestIrCompilationPath(unittest.TestCase):
         self.assertTrue(jnp.allclose(out, jnp.array([12.0, 27.0])))
 
 
+class TestBoundMethodUnderIrCompilation(unittest.TestCase):
+    """A ``named_scope``-decorated bound method works under
+    ``ir_compilation=True`` when the instance (index 0) is marked static, and
+    fails loudly otherwise -- pinning the documented method convention
+    (audit L23)."""
+
+    def test_method_with_static_self_under_ir_compilation(self):
+        class MyModule:
+            def __init__(self, scale):
+                self.scale = scale
+
+            @named_scope(name='compute', static_argnums=0)
+            def compute(self, x):
+                return x * self.scale
+
+        with bst.environ.context(ir_compilation=True):
+            out = MyModule(3.0).compute(jnp.array(2.0))
+        self.assertTrue(jnp.allclose(out, jnp.array(6.0)))
+
+    def test_method_without_static_self_raises(self):
+        # Omitting index 0 makes ``self`` a dynamic JIT arg, which cannot be
+        # abstractified -- this must raise, pinning the convention.
+        class MyModule:
+            def __init__(self, scale):
+                self.scale = scale
+
+            @named_scope(name='compute')
+            def compute(self, x):
+                return x * self.scale
+
+        with bst.environ.context(ir_compilation=True):
+            with self.assertRaises(Exception):
+                MyModule(3.0).compute(jnp.array(2.0))
+
+
 class TestNamedScopeJitCache(unittest.TestCase):
     """``fn_to_call`` must reuse the jit-compiled function across calls with
     the same static configuration instead of rebuilding a fresh ``jit()``

--- a/brainstate/transform/_progress_bar.py
+++ b/brainstate/transform/_progress_bar.py
@@ -391,14 +391,33 @@ class ProgressBar(object):
             kwargs.pop(kwarg, None)
         self.kwargs = kwargs
 
-        # description
+        # description -- ``desc`` is user-supplied, so validate with real
+        # exceptions: ``assert`` is stripped under ``python -O``, which would let
+        # a malformed ``desc`` reach the formatting callbacks and fail cryptically.
         if desc is not None:
             if isinstance(desc, str):
                 pass
             else:
-                assert isinstance(desc, (tuple, list)), 'Description should be a tuple or list.'
-                assert isinstance(desc[0], str), 'Description should be a string.'
-                assert callable(desc[1]), 'Description should be a callable.'
+                if not isinstance(desc, (tuple, list)):
+                    raise TypeError(
+                        f'desc must be a string or a (format_string, callable) '
+                        f'tuple/list, but got {type(desc).__name__}.'
+                    )
+                if len(desc) != 2:
+                    raise ValueError(
+                        f'desc tuple/list must have exactly two elements '
+                        f'(format_string, callable), but got {len(desc)}.'
+                    )
+                if not isinstance(desc[0], str):
+                    raise TypeError(
+                        f'The first element of a desc tuple must be a format '
+                        f'string, but got {type(desc[0]).__name__}.'
+                    )
+                if not callable(desc[1]):
+                    raise TypeError(
+                        f'The second element of a desc tuple must be callable, '
+                        f'but got {type(desc[1]).__name__}.'
+                    )
         self.desc = desc
 
     def init(self, n: int):
@@ -477,7 +496,14 @@ class ProgressBarRunner(object):
 
     def __call__(self, iter_num, **kwargs):
         data = dict() if isinstance(self.message, str) else self.message[1](dict(i=iter_num, **kwargs))
-        assert isinstance(data, dict), 'Description function should return a dictionary.'
+        # The description callback is user-supplied; validate its return with a
+        # real exception (``assert`` is stripped under ``python -O``), which would
+        # otherwise let a non-dict reach ``str.format(**data)`` and fail cryptically.
+        if not isinstance(data, dict):
+            raise TypeError(
+                f'The desc format function must return a dict, but got '
+                f'{type(data).__name__}.'
+            )
 
         _ = jax.lax.cond(
             iter_num == 0,
@@ -485,8 +511,14 @@ class ProgressBarRunner(object):
             lambda x: None,
             data
         )
+        # Guard the update on ``iter_num < self.n``. ``checkpointed_scan`` runs
+        # through ``_bounded_while_loop``, whose skip path advances the counter
+        # PAST ``self.n - 1`` (by whole sub-blocks) after the loop is done and
+        # still invokes this runner. Without the guard those post-completion
+        # calls can satisfy ``iter_num % print_freq == print_freq - 1`` and fire
+        # ``update()`` after ``close()`` already ran, pushing the bar past 100%.
         _ = jax.lax.cond(
-            iter_num % self.print_freq == (self.print_freq - 1),
+            (iter_num < self.n) & (iter_num % self.print_freq == (self.print_freq - 1)),
             lambda x: jax.debug.callback(self._update_tqdm, x, ordered=True),
             lambda x: None,
             data

--- a/brainstate/transform/_progress_bar.py
+++ b/brainstate/transform/_progress_bar.py
@@ -406,9 +406,15 @@ class ProgressBar(object):
         freq = self.print_freq
         count = self.print_count
         if count is not None:
-            freq, remainder = divmod(n, count)
+            freq = n // count
             if freq == 0:
                 raise ValueError(f"Count {count} is too large for n {n}.")
+            # The leftover added by ``_close_tqdm`` must be ``n % freq`` (the
+            # iterations not covered by the floor(n/freq) regular ``update(freq)``
+            # ticks), NOT ``n % count``. Using ``n % count`` overshoots the bar
+            # past 100% whenever ``count`` does not evenly divide ``n``. Match the
+            # other two branches, which correctly use ``n % freq``.
+            remainder = n % freq
         elif freq is None:
             if n > 20:
                 freq = int(n / 20)

--- a/brainstate/transform/_progress_bar_test.py
+++ b/brainstate/transform/_progress_bar_test.py
@@ -32,7 +32,7 @@ import jax.numpy as jnp
 import brainstate
 from brainstate.transform import ProgressBar
 from brainstate.transform import _progress_bar as _pbmod
-from brainstate.transform._progress_bar import _FallbackProgressBar
+from brainstate.transform._progress_bar import _FallbackProgressBar, ProgressBarRunner
 
 
 class _TTYStringIO(io.StringIO):
@@ -406,6 +406,67 @@ class TestProgressBarFreqValidation(unittest.TestCase):
     def test_positive_freq_accepted(self):
         pbar = ProgressBar(freq=2)
         self.assertEqual(pbar.print_freq, 2)
+
+
+class _CountingBar:
+    """A minimal fake bar that just accumulates ``update`` deltas, used to
+    measure the final bar position the runner drives it to."""
+
+    def __init__(self, *args, **kwargs):
+        self.n = 0
+
+    def update(self, delta):
+        self.n += delta
+
+    def set_description(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+class TestProgressBarCountNoOvershoot(unittest.TestCase):
+    """``ProgressBar(count=K)`` over a loop of length ``n`` must finish at
+    exactly ``n`` (100%) and never overshoot, even when ``K`` does not divide
+    ``n`` (audit L24: the close remainder was ``n % count`` instead of
+    ``n % freq``)."""
+
+    def _final_position(self, n, count):
+        """Replicate the runner's __call__ dispatch with a counting bar and
+        return the final accumulated position."""
+        runner = ProgressBar(count=count).init(n)
+        bar = _CountingBar()
+        runner.tqdm_bars[0] = bar
+        freq = runner.print_freq
+        for iter_num in range(n):
+            if iter_num % freq == (freq - 1):
+                runner._update_tqdm({})
+            if iter_num == n - 1:
+                runner._close_tqdm({})
+        return bar.n
+
+    def test_count_not_dividing_n_reaches_exactly_n(self):
+        # Audit example: count=20, n=50 used to push the bar to 60/50.
+        self.assertEqual(self._final_position(50, 20), 50)
+        # Audit example: count=99, n=100 used to give 101/100.
+        self.assertEqual(self._final_position(100, 99), 100)
+
+    def test_sweep_no_overshoot_no_undershoot(self):
+        # Exhaustive-ish sweep: for every valid (n, count) the bar must end at
+        # exactly n -- never over, never under.
+        for n in range(2, 60):
+            for count in range(1, n + 1):
+                pos = self._final_position(n, count)
+                self.assertEqual(
+                    pos, n,
+                    msg=f"count={count}, n={n}: bar ended at {pos}, expected {n}",
+                )
+
+    def test_remainder_consistent_with_freq(self):
+        # The init-time remainder must be n % freq (matching the other branches).
+        runner = ProgressBar(count=20).init(50)
+        self.assertEqual(runner.print_freq, 2)
+        self.assertEqual(runner.remainder, 50 % runner.print_freq)
 
 
 if __name__ == "__main__":

--- a/brainstate/transform/_progress_bar_test.py
+++ b/brainstate/transform/_progress_bar_test.py
@@ -105,9 +105,28 @@ class TestProgressBarConstruction(unittest.TestCase):
         self.assertEqual(pbar.desc[0], "step {i}")
 
     def test_desc_tuple_requires_callable(self):
-        """A ``desc`` tuple whose second element is not callable raises."""
-        with self.assertRaises(AssertionError):
+        """A ``desc`` tuple whose second element is not callable raises.
+
+        Uses a real ``TypeError`` (not ``AssertionError``) so the validation
+        survives ``python -O`` (audit Tier C).
+        """
+        with self.assertRaises(TypeError):
             ProgressBar(desc=("step {i}", "not-callable"))
+
+    def test_desc_tuple_first_must_be_string(self):
+        """A ``desc`` tuple whose first element is not a string raises TypeError."""
+        with self.assertRaises(TypeError):
+            ProgressBar(desc=(123, lambda d: d))
+
+    def test_desc_must_be_str_or_sequence(self):
+        """A ``desc`` that is neither a string nor a tuple/list raises TypeError."""
+        with self.assertRaises(TypeError):
+            ProgressBar(desc=123)
+
+    def test_desc_tuple_wrong_length_raises(self):
+        """A ``desc`` tuple without exactly two elements raises ValueError."""
+        with self.assertRaises(ValueError):
+            ProgressBar(desc=("only-one",))
 
 
 class TestProgressBarInitFrequency(unittest.TestCase):
@@ -467,6 +486,66 @@ class TestProgressBarCountNoOvershoot(unittest.TestCase):
         runner = ProgressBar(count=20).init(50)
         self.assertEqual(runner.print_freq, 2)
         self.assertEqual(runner.remainder, 50 % runner.print_freq)
+
+
+class TestCheckpointedScanNoPostCloseUpdate(unittest.TestCase):
+    """``checkpointed_scan`` drives its bar through ``_bounded_while_loop``,
+    whose skip path advances the counter PAST ``n - 1`` after the loop is done.
+    ``ProgressBarRunner.__call__`` must guard the update on ``iter_num < n`` so
+    those post-completion calls never fire ``update()`` after ``close()`` and
+    push the bar past 100% (audit item 18)."""
+
+    def _run_and_collect(self, n, base, freq):
+        created = []
+
+        class _RecordingBar:
+            def __init__(self, *args, **kwargs):
+                self.n = 0
+                self.closed = False
+                self.updates_after_close = 0
+                created.append(self)
+
+            def update(self, delta):
+                if self.closed:
+                    self.updates_after_close += 1
+                self.n += delta
+
+            def set_description(self, *args, **kwargs):
+                pass
+
+            def close(self):
+                self.closed = True
+
+        with mock.patch.object(_pbmod, "tqdm_installed", False):
+            with mock.patch.object(_pbmod, "_FallbackProgressBar", _RecordingBar):
+                def step(c, x):
+                    return c + x, c + x
+
+                _, ys = brainstate.transform.checkpointed_scan(
+                    step, 0.0, jnp.arange(float(n)), base=base,
+                    pbar=ProgressBar(freq=freq),
+                )
+                ys.block_until_ready()
+        return created
+
+    def test_no_post_close_update_and_exact_position(self):
+        # base=2 forces several skip-call counter bumps past n-1.
+        n = 5
+        created = self._run_and_collect(n, base=2, freq=1)
+        self.assertTrue(created, "expected the runner to create a progress bar")
+        bar = created[0]
+        # No update() may land after close()...
+        self.assertEqual(bar.updates_after_close, 0)
+        # ...and the bar must end at exactly n (never past 100%).
+        self.assertEqual(bar.n, n)
+
+    def test_no_overshoot_various_lengths(self):
+        for n in (3, 4, 7, 8, 16):
+            created = self._run_and_collect(n, base=2, freq=1)
+            self.assertTrue(created)
+            bar = created[0]
+            self.assertEqual(bar.updates_after_close, 0, msg=f"n={n}")
+            self.assertEqual(bar.n, n, msg=f"n={n}")
 
 
 if __name__ == "__main__":

--- a/brainstate/transform/_progress_bar_test.py
+++ b/brainstate/transform/_progress_bar_test.py
@@ -548,5 +548,39 @@ class TestCheckpointedScanNoPostCloseUpdate(unittest.TestCase):
             self.assertEqual(bar.n, n, msg=f"n={n}")
 
 
+class TestProgressBarRunnerDescReturnValidation(unittest.TestCase):
+    """``ProgressBarRunner.__call__`` validates the user desc callback's return.
+
+    A ``(fmt, fn)`` desc whose ``fn`` returns a non-dict would otherwise reach
+    ``str.format(**data)`` and fail cryptically. The runner raises a clear
+    ``TypeError`` (a real exception, not an ``assert`` stripped under ``python
+    -O``) before dispatching the ``jax.lax.cond``."""
+
+    def test_non_dict_desc_return_raises_type_error(self):
+        """A desc callback returning a non-dict raises TypeError naming the type."""
+        def bad_fmt(data):
+            return "not-a-dict"  # callable (passes construction) but wrong return
+
+        runner = ProgressBar(freq=2, desc=("iter {i}", bad_fmt)).init(10)
+        with self.assertRaises(TypeError) as ctx:
+            runner(0)
+        msg = str(ctx.exception)
+        self.assertIn("must return a dict", msg)
+        # The error reports the offending return type.
+        self.assertIn("str", msg)
+
+    def test_dict_desc_return_does_not_raise_type_error(self):
+        """A desc callback returning a dict passes the validation guard.
+
+        ``__call__`` proceeds into ``jax.lax.cond``; we only assert that the
+        non-dict guard does not trip for a well-behaved callback."""
+        def good_fmt(data):
+            return {"i": data["i"]}
+
+        runner = ProgressBar(freq=2, desc=("iter {i}", good_fmt)).init(10)
+        # Must not raise TypeError from the desc-return guard.
+        runner(0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/transform/_unvmap.py
+++ b/brainstate/transform/_unvmap.py
@@ -39,8 +39,10 @@ def unvmap(x: ArrayLike, op: str = 'any') -> Any:
 
     Parameters
     ----------
-    x : Any
-        Value produced inside a :func:`jax.vmap`-transformed function.
+    x : ArrayLike
+        A single array value produced inside a :func:`jax.vmap`-transformed
+        function. The reductions bind a JAX primitive and accept only one array;
+        pytrees are not supported.
     op : {'all', 'any', 'none', 'max'}, default='any'
         Reduction to apply across the vmapped axis. ``'none'`` returns ``x`` without
         reduction, while ``'max'`` computes the maximum element.
@@ -88,8 +90,10 @@ def unvmap_all(x):
 
     Parameters
     ----------
-    x : Any
-        Input array or pytree produced under :func:`jax.vmap`.
+    x : ArrayLike
+        A single input array produced under :func:`jax.vmap`. This is bound to a
+        JAX primitive (``Primitive.bind``), which accepts only one array value;
+        pytrees are not supported.
 
     Returns
     -------
@@ -141,8 +145,10 @@ def unvmap_any(x):
 
     Parameters
     ----------
-    x : Any
-        Input array or pytree produced under :func:`jax.vmap`.
+    x : ArrayLike
+        A single input array produced under :func:`jax.vmap`. This is bound to a
+        JAX primitive (``Primitive.bind``), which accepts only one array value;
+        pytrees are not supported.
 
     Returns
     -------
@@ -194,8 +200,10 @@ def unvmap_max(x):
 
     Parameters
     ----------
-    x : Any
-        Input array or pytree produced under :func:`jax.vmap`.
+    x : ArrayLike
+        A single input array produced under :func:`jax.vmap`. This is bound to a
+        JAX primitive (``Primitive.bind``), which accepts only one array value;
+        pytrees are not supported.
 
     Returns
     -------

--- a/brainstate/transform/_util.py
+++ b/brainstate/transform/_util.py
@@ -321,7 +321,12 @@ def warp_grad_fn(
             new_args[argnums] = dyn_args
             return fn(*new_args, **kwargs)
 
-        assert argnums < len(args), f"argnum {argnums} is out of range {len(args)}"
+        # ``argnums`` is user-supplied (it comes from the public grad transforms),
+        # so validate its bound with a real exception. An ``assert`` is stripped
+        # under ``python -O``, degrading this into a bare ``IndexError`` from
+        # ``args[argnums]`` with no context.
+        if argnums >= len(args):
+            raise IndexError(f"argnum {argnums} is out of range {len(args)}")
         return new_fn, args[argnums]
 
     else:
@@ -337,7 +342,9 @@ def warp_grad_fn(
         argnums = (argnums,) if isinstance(argnums, int) else tuple(argnums)
         params = []
         for i in argnums:
-            assert i < len(args), f"argnum {i} is out of range {len(args)}"
+            # See above: user-supplied index, validate with a real exception.
+            if i >= len(args):
+                raise IndexError(f"argnum {i} is out of range {len(args)}")
             params.append(args[i])
         return new_fn, params
 

--- a/brainstate/transform/_util_test.py
+++ b/brainstate/transform/_util_test.py
@@ -90,8 +90,9 @@ class TestWarpGradFn(unittest.TestCase):
         self.assertTrue(bool(jnp.allclose(new_fn(jnp.array([3.0, 4.0])), jnp.array([13.0, 24.0]))))
 
     def test_int_argnum_out_of_range_raises(self):
-        """An int argnum out of range raises ``AssertionError``."""
-        with self.assertRaises(AssertionError):
+        """An int argnum out of range raises ``IndexError`` (not
+        ``AssertionError``, which is stripped under ``python -O``)."""
+        with self.assertRaises(IndexError):
             warp_grad_fn(lambda a: a, 5, (jnp.ones((2,)),), {})
 
     def test_sequence_argnums_rebinds_multiple_args(self):
@@ -107,8 +108,9 @@ class TestWarpGradFn(unittest.TestCase):
         self.assertTrue(bool(jnp.allclose(out, jnp.array([42.0]))))
 
     def test_sequence_argnums_out_of_range_raises(self):
-        """A sequence argnum out of range raises ``AssertionError``."""
-        with self.assertRaises(AssertionError):
+        """A sequence argnum out of range raises ``IndexError`` (not
+        ``AssertionError``, which is stripped under ``python -O``)."""
+        with self.assertRaises(IndexError):
             warp_grad_fn(lambda a, b: a + b, (0, 9), (jnp.ones((2,)), jnp.ones((2,))), {})
 
 

--- a/brainstate/transform/_vjp_jvp.py
+++ b/brainstate/transform/_vjp_jvp.py
@@ -259,6 +259,21 @@ def vjp(
                     f"argnums {i} is out of range for a function called with "
                     f"{n_primals} positional argument(s)."
                 )
+        # Normalize negative indices so ``diff_primals`` (built below) and the
+        # ``_pure`` reconstruction loop operate in a single, unambiguous index
+        # space. Then reject aliasing duplicates: when the same positional
+        # argument appears twice (literal ``(0, 0)`` or a positive/negative
+        # alias like ``(0, -2)``), the reconstruction loop ``full[i] = ...``
+        # writes both traced inputs into the same slot, so the last write wins
+        # and ``jax.vjp`` silently returns a zero cotangent for the discarded
+        # input. Fail loudly instead, mirroring ``grad``'s contract.
+        argnums_t = tuple(i % n_primals for i in argnums_t)
+        if len(set(argnums_t)) != len(argnums_t):
+            raise ValueError(
+                "argnums contains duplicate (or aliasing positive/negative) "
+                "indices: each positional argument may be differentiated at "
+                "most once."
+            )
         diff_args = True
 
     if not diff_args and not has_states:

--- a/brainstate/transform/_vjp_jvp_test.py
+++ b/brainstate/transform/_vjp_jvp_test.py
@@ -313,6 +313,48 @@ class TestVjpArgnumsSemantics(unittest.TestCase):
         g = vjp_fn(1.0)
         self.assertTrue(jnp.allclose(g, 2.0 * x * y))   # d/dy sum(x*y**2)
 
+    def test_duplicate_argnums_raises(self):
+        """Aliasing/duplicate argnums must fail loudly (mirroring ``grad``),
+        not silently return a zeroed cotangent for the discarded input
+        (audit M42)."""
+        def f(x, y):
+            return jnp.sum(x * 10 + y * 100)
+
+        x = jnp.array([1.0, 1.0])
+        y = jnp.array([1.0, 1.0])
+
+        # literal duplicate
+        with self.assertRaises(ValueError):
+            brainstate.transform.vjp(f, x, y, argnums=(0, 0))
+        # positive/negative alias of the same argument (index 0 == -2)
+        with self.assertRaises(ValueError):
+            brainstate.transform.vjp(f, x, y, argnums=(0, -2))
+        # positive/negative alias of the same argument (index 1 == -1)
+        with self.assertRaises(ValueError):
+            brainstate.transform.vjp(f, x, y, argnums=(1, -1))
+        # duplicate embedded among distinct indices
+        with self.assertRaises(ValueError):
+            brainstate.transform.vjp(f, x, y, argnums=(0, 1, 0))
+
+    def test_distinct_argnums_still_correct(self):
+        """The duplicate guard must not disturb genuinely distinct argnums:
+        cotangents stay correct (no spurious zeroing)."""
+        def f(x, y):
+            return jnp.sum(x * 10 + y * 100)
+
+        x = jnp.array([1.0, 1.0])
+        y = jnp.array([1.0, 1.0])
+        out, vjp_fn = brainstate.transform.vjp(f, x, y, argnums=(0, 1))
+        gx, gy = vjp_fn(1.0)
+        self.assertTrue(jnp.allclose(gx, jnp.array([10.0, 10.0])))   # d/dx
+        self.assertTrue(jnp.allclose(gy, jnp.array([100.0, 100.0]))) # d/dy
+
+        # negative index normalizes to a distinct slot and stays correct.
+        out2, vjp_fn2 = brainstate.transform.vjp(f, x, y, argnums=(0, -1))
+        gx2, gy2 = vjp_fn2(1.0)
+        self.assertTrue(jnp.allclose(gx2, jnp.array([10.0, 10.0])))
+        self.assertTrue(jnp.allclose(gy2, jnp.array([100.0, 100.0])))
+
 
 class TestVjpComprehensive(unittest.TestCase):
     """Cover the documented use cases end to end."""

--- a/brainstate/typing.py
+++ b/brainstate/typing.py
@@ -217,7 +217,9 @@ Components
 type
     Filter by type, e.g., `float`, `jax.Array`.
 str
-    Filter by string matching in path keys.
+    Filter by tag: matches objects whose ``tag`` attribute equals the string
+    (converted to a :class:`~brainstate.util.filter.WithTag` filter), not by
+    path-key matching.
 Predicate
     Custom function for complex filtering logic.
 bool
@@ -234,7 +236,7 @@ Examples
     >>> # Filter by type
     >>> float_filter: FilterLiteral = float
     >>>
-    >>> # Filter by string pattern
+    >>> # Filter by tag (matches objects whose ``tag`` attribute == "weight")
     >>> weight_filter: FilterLiteral = "weight"
     >>>
     >>> # Custom predicate filter
@@ -439,57 +441,105 @@ class _MetaPyTree(type):
     # isn't allowed.
     # Likewise we can't do types.new_class("PyTree", (Generic[_T],), {}) because that
     # has __module__ "types", e.g. we get types.PyTree[int].
-    @functools.lru_cache(maxsize=None)
     def __getitem__(cls, item: Any) -> Any:
+        # Validate/normalise *before* hitting the cache. The cached builder is
+        # keyed on a hashable, whitespace-normalised key so that (a) an
+        # unhashable leaf type produces a clear error instead of a cryptic
+        # ``TypeError: unhashable type`` raised from inside ``lru_cache``, and
+        # (b) whitespace-variant structures (``"S T"`` vs ``"S  T"``) collapse to
+        # the same class rather than distinct, non-equal ones.
         if isinstance(item, tuple):
-            if len(item) == 2:
-
-                # PyTree is a runtime-built metaclass instance used purely for
-                # annotation magic; it cannot be expressed as a static base class.
-                class X(PyTree):  # type: ignore[valid-type, misc]
-                    leaftype = item[0]
-                    structure = item[1].strip()
-
-                if not isinstance(X.structure, str):
-                    raise ValueError(
-                        "The structure annotation `struct` in "
-                        "`brainstate.typing.PyTree[leaftype, struct]` must be be a string, "
-                        f"e.g. `brainstate.typing.PyTree[leaftype, 'T']`. Got '{X.structure}'."
-                    )
-                pieces = X.structure.split()
-                if len(pieces) == 0:
-                    raise ValueError(
-                        "The string `struct` in `brainstate.typing.PyTree[leaftype, struct]` "
-                        "cannot be the empty string."
-                    )
-                for piece_index, piece in enumerate(pieces):
-                    if (piece_index == 0) or (piece_index == len(pieces) - 1):
-                        if piece == "...":
-                            continue
-                    if not piece.isidentifier():
-                        raise ValueError(
-                            "The string `struct` in "
-                            "`brainstate.typing.PyTree[leaftype, struct]` must be be a "
-                            "whitespace-separated sequence of identifiers, e.g. "
-                            "`brainstate.typing.PyTree[leaftype, 'T']` or "
-                            "`brainstate.typing.PyTree[leaftype, 'foo bar']`.\n"
-                            "(Here, 'identifier' is used in the same sense as in "
-                            "regular Python, i.e. a valid variable name.)\n"
-                            f"Got piece '{piece}' in overall structure '{X.structure}'."
-                        )
-                name = str(_FakePyTree[item[0]])[:-1] + ', "' + item[1].strip() + '"]'
-            else:
+            if len(item) != 2:
                 raise ValueError(
                     "The subscript `foo` in `brainstate.typing.PyTree[foo]` must either be a "
                     "leaf type, e.g. `PyTree[int]`, or a 2-tuple of leaf and "
                     "structure, e.g. `PyTree[int, 'T']`. Received a tuple of length "
                     f"{len(item)}."
                 )
+            leaftype, structure = item
+            if not isinstance(structure, str):
+                raise ValueError(
+                    "The structure annotation `struct` in "
+                    "`brainstate.typing.PyTree[leaftype, struct]` must be be a string, "
+                    f"e.g. `brainstate.typing.PyTree[leaftype, 'T']`. Got '{structure}'."
+                )
+            pieces = structure.split()
+            if len(pieces) == 0:
+                raise ValueError(
+                    "The string `struct` in `brainstate.typing.PyTree[leaftype, struct]` "
+                    "cannot be the empty string."
+                )
+            # An ellipsis is permitted only as a single leading OR single
+            # trailing marker, and at least one named identifier must remain.
+            # Reject "..."/"... ..." (no identifiers) and "... T ..." (ellipsis
+            # at both ends) and any ellipsis in the interior.
+            non_ellipsis = [p for p in pieces if p != "..."]
+            if len(non_ellipsis) == 0:
+                raise ValueError(
+                    "The string `struct` in `brainstate.typing.PyTree[leaftype, struct]` "
+                    "must contain at least one structure name; an ellipsis-only "
+                    f"structure such as '{structure}' is not allowed."
+                )
+            # At most one ellipsis, and only as a single leading or trailing
+            # marker. This rejects "... T ..." (both ends), "S ... T" (interior)
+            # and any structure with more than one ellipsis.
+            if pieces.count("...") > 1 or any(
+                p == "..." and i not in (0, len(pieces) - 1)
+                for i, p in enumerate(pieces)
+            ):
+                raise ValueError(
+                    "An ellipsis '...' in "
+                    "`brainstate.typing.PyTree[leaftype, struct]` may appear only "
+                    "as a single leading or single trailing marker (e.g. '... T' "
+                    "or 'T ...'), not in the interior nor at both ends.\n"
+                    f"Got structure '{structure}'."
+                )
+            for piece_index, piece in enumerate(pieces):
+                if piece == "...":
+                    continue
+                if not piece.isidentifier():
+                    raise ValueError(
+                        "The string `struct` in "
+                        "`brainstate.typing.PyTree[leaftype, struct]` must be be a "
+                        "whitespace-separated sequence of identifiers, e.g. "
+                        "`brainstate.typing.PyTree[leaftype, 'T']` or "
+                        "`brainstate.typing.PyTree[leaftype, 'foo bar']`.\n"
+                        "(Here, 'identifier' is used in the same sense as in "
+                        "regular Python, i.e. a valid variable name.)\n"
+                        f"Got piece '{piece}' in overall structure '{structure}'."
+                    )
+            # Normalise whitespace so equivalent structures share one class.
+            normalized = " ".join(pieces)
+            key = (leaftype, normalized)
         else:
-            name = str(_FakePyTree[item])
+            leaftype = item
+            key = item
+
+        if not isinstance(leaftype, Hashable):
+            raise TypeError(
+                "The leaf type in `brainstate.typing.PyTree[leaftype]` must be hashable; "
+                f"got an unhashable {type(leaftype).__name__}."
+            )
+        return cls._build(key)
+
+    @functools.lru_cache(maxsize=None)
+    def _build(cls, key: Any) -> Any:
+        if isinstance(key, tuple):
+            leaftype, structure = key
+
+            # PyTree is a runtime-built metaclass instance used purely for
+            # annotation magic; it cannot be expressed as a static base class.
+            class X(PyTree):  # type: ignore[valid-type, misc]
+                pass
+
+            X.leaftype = leaftype
+            X.structure = structure
+            name = str(_FakePyTree[leaftype])[:-1] + ', "' + structure + '"]'
+        else:
+            name = str(_FakePyTree[key])
 
             class X(PyTree):  # type: ignore[no-redef, valid-type, misc]
-                leaftype = item
+                leaftype = key
                 structure = None
 
         X.__name__ = name

--- a/brainstate/typing.py
+++ b/brainstate/typing.py
@@ -534,7 +534,10 @@ class _MetaPyTree(type):
 
             X.leaftype = leaftype
             X.structure = structure
-            name = str(_FakePyTree[leaftype])[:-1] + ', "' + structure + '"]'
+            # NB: subscript with `key[0]`, not the unpacked `leaftype` name —
+            # mypy rejects a bare variable in a type-subscript position
+            # ("Variable not valid as a type"), but accepts an index expression.
+            name = str(_FakePyTree[key[0]])[:-1] + ', "' + structure + '"]'
         else:
             name = str(_FakePyTree[key])
 

--- a/brainstate/typing_test.py
+++ b/brainstate/typing_test.py
@@ -510,6 +510,38 @@ class TestPyTreeTypes(unittest.TestCase):
         with self.assertRaises(ValueError):
             PyTree[float,]  # 1-tuple with trailing comma would be (float,)
 
+    def test_a22_unhashable_leaf_raises_clear_typeerror(self):
+        """Appendix item 22: an unhashable leaf type raises a clear TypeError,
+        not a cryptic 'unhashable type' from inside lru_cache."""
+        with self.assertRaises(TypeError) as ctx:
+            PyTree[[int, str]]  # a list is unhashable
+        self.assertIn("hashable", str(ctx.exception).lower())
+        with self.assertRaises(TypeError):
+            PyTree[{"a": int}]  # a dict is unhashable
+        with self.assertRaises(TypeError):
+            PyTree[[int], "T"]  # unhashable leaf in the 2-tuple form
+
+    def test_a23_whitespace_variants_are_the_same_class(self):
+        """Appendix item 23: whitespace-variant structures collapse to a single
+        class with a normalised structure string."""
+        a = PyTree[int, "S T"]
+        b = PyTree[int, "S  T"]  # double internal space
+        c = PyTree[int, "  S   T  "]  # plus outer padding
+        self.assertIs(a, b)
+        self.assertIs(a, c)
+        self.assertEqual(a.structure, "S T")
+
+    def test_a24_ellipsis_only_and_double_ellipsis_rejected(self):
+        """Appendix item 24: ellipsis-only, double-ellipsis, both-ends and
+        interior-ellipsis structures are rejected."""
+        for bad in ["...", "... ...", "... T ...", "S ... T", "T ... S"]:
+            with self.subTest(structure=bad):
+                with self.assertRaises(ValueError):
+                    PyTree[int, bad]
+        # single leading / trailing ellipsis remain valid
+        PyTree[int, "... T"]
+        PyTree[int, "T ..."]
+
 
 class TestRandomTypes(unittest.TestCase):
     """Test random number generation types."""

--- a/brainstate/typing_test.py
+++ b/brainstate/typing_test.py
@@ -510,6 +510,19 @@ class TestPyTreeTypes(unittest.TestCase):
         with self.assertRaises(ValueError):
             PyTree[float,]  # 1-tuple with trailing comma would be (float,)
 
+    def test_pytree_non_string_structure_raises(self):
+        """In the 2-tuple form, a non-string structure annotation raises ValueError.
+
+        ``PyTree[leaftype, struct]`` requires ``struct`` to be a string (it is later
+        ``.split()`` into structure names). A non-string second element (int, None,
+        a type, ...) must raise a clear ValueError rather than crashing downstream.
+        """
+        for bad_structure in (123, None, float, ["T"], object()):
+            with self.subTest(structure=bad_structure):
+                with self.assertRaises(ValueError) as ctx:
+                    PyTree[int, bad_structure]
+                self.assertIn("must be", str(ctx.exception))
+
     def test_a22_unhashable_leaf_raises_clear_typeerror(self):
         """Appendix item 22: an unhashable leaf type raises a clear TypeError,
         not a cryptic 'unhashable type' from inside lru_cache."""

--- a/brainstate/util/_others.py
+++ b/brainstate/util/_others.py
@@ -93,12 +93,17 @@ def split_total(
     >>> split_total(100, 1.5)  # Raises ValueError
     ValueError: 'fraction' value cannot be greater than 1.
     """
-    if not isinstance(total, int):
+    # ``bool`` is a subclass of ``int``; reject it explicitly so that a boolean
+    # is never silently treated as 0/1 (which would also leak a ``bool`` into the
+    # ``int`` return value).
+    if isinstance(total, bool) or not isinstance(total, int):
         raise TypeError(f"'total' must be an integer, got {type(total).__name__}.")
     if total <= 0:
         raise ValueError(f"'total' must be a positive integer, got {total}.")
 
-    if isinstance(fraction, float):
+    if isinstance(fraction, bool):
+        raise TypeError(f"'fraction' must be an integer or float, got {type(fraction).__name__}.")
+    elif isinstance(fraction, float):
         if fraction < 0:
             raise ValueError(f"'fraction' value cannot be negative, got {fraction}.")
         if fraction > 1:
@@ -600,13 +605,21 @@ def clear_buffer_memory(
     >>> clear_buffer_memory(compilation=True)  # Also clear compilation cache
     """
     if array:
-        try:
-            from brainstate._compatible_import import get_backend
-            backend = get_backend(platform)
-            for buf in backend.live_buffers():
+        from brainstate._compatible_import import get_backend
+        # Acquiring the backend and listing live buffers are setup steps: if they
+        # fail (e.g. an unknown platform, or a JAX version without ``live_buffers``)
+        # surface the error to the caller instead of hiding a real misconfiguration.
+        backend = get_backend(platform)
+        live_buffers = backend.live_buffers()
+        # Individual buffer deletions, on the other hand, are best-effort: a single
+        # buffer that cannot be freed should not abort the whole cleanup loop. Warn
+        # per failure (rather than swallowing every error under one message) so the
+        # cause stays visible.
+        for buf in live_buffers:
+            try:
                 buf.delete()
-        except Exception as e:
-            warnings.warn(f"Failed to clear buffers: {e}", RuntimeWarning)
+            except Exception as e:
+                warnings.warn(f"Failed to delete buffer {buf!r}: {e}", RuntimeWarning)
 
     if compilation:
         jax.clear_caches()
@@ -822,6 +835,40 @@ class DotDict(dict, MutableMapping[str, Any]):
         if key not in self:
             self[key] = default
         return self[key]
+
+    def __or__(self, other: Mapping[str, Any]) -> 'DotDict':
+        """Combine with another mapping using ``|``, preserving the DotDict type.
+
+        Unlike ``dict.__or__`` (which would return a plain ``dict``), this keeps
+        the result a :class:`DotDict` and recursively hooks nested mappings.
+        """
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        new_dict = self.__class__(self)
+        new_dict.update(other)
+        return new_dict
+
+    def __ror__(self, other: Mapping[str, Any]) -> 'DotDict':
+        """Right-hand ``|`` so ``mapping | dotdict`` yields a hooked DotDict.
+
+        Note: ``dict.__or__`` already accepts ``DotDict`` operands, so a plain
+        ``dict`` on the left handles the operation itself and this is only reached
+        for non-``dict`` mappings.
+        """
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        # ``other`` may be any Mapping (not just a dict); normalise via ``dict()``
+        # so DotDict.__init__ takes its dict branch instead of mis-iterating keys.
+        new_dict = self.__class__(dict(other))
+        new_dict.update(self)
+        return new_dict
+
+    def __ior__(self, other: Mapping[str, Any]) -> 'DotDict':
+        """In-place ``|=`` that routes through the hook-aware ``update``."""
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        self.update(other)
+        return self
 
     def __getstate__(self) -> Dict[str, Any]:
         """Get state for pickling."""

--- a/brainstate/util/_others.py
+++ b/brainstate/util/_others.py
@@ -650,10 +650,6 @@ class DotDict(dict, MutableMapping[str, Any]):
         **kwargs
             Keyword arguments become key-value pairs.
         """
-        # Handle parent reference for nested updates
-        object.__setattr__(self, '__parent', kwargs.pop('__parent', None))
-        object.__setattr__(self, '__key', kwargs.pop('__key', None))
-
         # Process positional arguments
         for arg in args:
             if not arg:
@@ -685,25 +681,19 @@ class DotDict(dict, MutableMapping[str, Any]):
         self[name] = value
 
     def __setitem__(self, name: str, value: Any) -> None:
-        """Set item and update parent if nested."""
-        value = self._hook(value)
-        super().__setitem__(name, value)
-        try:
-            parent = object.__getattribute__(self, '__parent')
-            key = object.__getattribute__(self, '__key')
-            if parent is not None:
-                parent[key] = self
-                object.__delattr__(self, '__parent')
-                object.__delattr__(self, '__key')
-        except AttributeError:
-            pass
+        """Set item, converting nested mappings/sequences to DotDict."""
+        super().__setitem__(name, self._hook(value))
 
     @classmethod
     def _hook(cls, item: Any) -> Any:
         """Convert nested dicts to DotDict."""
         if isinstance(item, dict) and not isinstance(item, cls):
             return cls(item)
-        elif isinstance(item, (list, tuple)):
+        elif isinstance(item, tuple):
+            hooked = tuple(cls._hook(elem) for elem in item)
+            # namedtuples take positional fields, not a single iterable
+            return type(item)(*hooked) if hasattr(item, '_fields') else type(item)(hooked)
+        elif isinstance(item, list):
             return type(item)(cls._hook(elem) for elem in item)
         return item
 
@@ -759,10 +749,15 @@ class DotDict(dict, MutableMapping[str, Any]):
             if isinstance(value, DotDict):
                 result[key] = value.to_dict()
             elif isinstance(value, (list, tuple)):
-                result[key] = type(value)(
-                    item.to_dict() if isinstance(item, DotDict) else item
-                    for item in value
-                )
+                converted = [it.to_dict() if isinstance(it, DotDict) else it for it in value]
+                if isinstance(value, tuple):
+                    # namedtuples take positional fields, not a single iterable
+                    if hasattr(value, '_fields'):
+                        result[key] = type(value)(*converted)
+                    else:
+                        result[key] = type(value)(tuple(converted))
+                else:
+                    result[key] = type(value)(converted)
             else:
                 result[key] = value
         return result
@@ -802,8 +797,13 @@ class DotDict(dict, MutableMapping[str, Any]):
         else:
             other = {}
 
-        if hasattr(other, 'items'):
-            other = dict(other.items())
+        try:
+            # accept mappings and iterables of (key, value) pairs, like builtin dict.update
+            other = dict(other)
+        except (TypeError, ValueError) as e:
+            raise TypeError(
+                f"update expected a mapping or iterable of key/value pairs, got {type(other).__name__}"
+            ) from e
         other.update(kwargs)
 
         for k, v in other.items():
@@ -916,14 +916,31 @@ def flatten_dict(
     """
     if not isinstance(d, dict):
         raise TypeError(f"d must be a dict, got {type(d).__name__}.")
-    items = []
+    items = {}
     for k, v in d.items():
+        if parent_key and not isinstance(k, str):
+            # nested keys must be joinable with the string separator; coercing
+            # non-str keys silently breaks round-tripping via unflatten_dict
+            raise TypeError(
+                f"flatten_dict requires string keys for nested levels, got {type(k).__name__} key {k!r}."
+            )
         new_key = f"{parent_key}{sep}{k}" if parent_key else k
         if isinstance(v, dict):
-            items.extend(flatten_dict(v, new_key, sep=sep).items())
+            if v:
+                for nk, nv in flatten_dict(v, new_key, sep=sep).items():
+                    if nk in items:
+                        raise ValueError(f"flatten_dict produced duplicate key {nk!r}.")
+                    items[nk] = nv
+            else:
+                # emit a key for an empty mapping so flatten/unflatten round-trips
+                if new_key in items:
+                    raise ValueError(f"flatten_dict produced duplicate key {new_key!r}.")
+                items[new_key] = {}
         else:
-            items.append((new_key, v))
-    return dict(items)
+            if new_key in items:
+                raise ValueError(f"flatten_dict produced duplicate key {new_key!r}.")
+            items[new_key] = v
+    return items
 
 
 @set_module_as('brainstate.util')
@@ -971,7 +988,8 @@ def unflatten_dict(
 
         if parts[-1] in current and isinstance(current[parts[-1]], dict):
             raise ValueError(f"Cannot overwrite mapping at key {key!r} with a scalar value.")
-        current[parts[-1]] = value
+        # copy dict leaf values to avoid shared-mutable aliasing with the input
+        current[parts[-1]] = dict(value) if isinstance(value, dict) else value
 
     return result
 

--- a/brainstate/util/_others_test.py
+++ b/brainstate/util/_others_test.py
@@ -904,6 +904,33 @@ class TestDotDict(unittest.TestCase):
         self.assertEqual(result.a, 1)
         self.assertEqual(result.b.c, 2)
 
+    def test_ror_operator_with_non_mapping_returns_notimplemented(self):
+        """``__ror__`` returns ``NotImplemented`` for a non-Mapping left operand.
+
+        This lets Python fall through to the other operand / raise ``TypeError``
+        rather than mis-handling a non-mapping. Exercises the guard at the top of
+        ``DotDict.__ror__``.
+        """
+        dd = DotDict({'a': 1})
+        self.assertIs(dd.__ror__(5), NotImplemented)
+        self.assertIs(dd.__ror__("not a mapping"), NotImplemented)
+        # As a consequence, ``non_mapping | dotdict`` raises TypeError.
+        with self.assertRaises(TypeError):
+            _ = 5 | dd
+
+    def test_ior_operator_with_non_mapping_returns_notimplemented(self):
+        """``__ior__`` returns ``NotImplemented`` for a non-Mapping right operand.
+
+        Exercises the guard at the top of ``DotDict.__ior__``; the original
+        DotDict must be left untouched.
+        """
+        dd = DotDict({'a': 1})
+        self.assertIs(dd.__ior__(5), NotImplemented)
+        self.assertEqual(dict(dd), {'a': 1})  # unchanged
+        # ``dotdict |= non_mapping`` therefore raises TypeError.
+        with self.assertRaises(TypeError):
+            dd |= 5
+
     def test_pickling(self):
         """Test pickling/unpickling."""
         dd1 = DotDict({'a': 1, 'b': {'c': 2}})
@@ -1098,6 +1125,18 @@ class TestUtilityFunctions(unittest.TestCase):
             flatten_dict({'a.b': 1, 'a': {'b': 2}})
         with self.assertRaises(ValueError):
             flatten_dict({'a': {'b': 2}, 'a.b': 1})
+
+    def test_flatten_dict_rejects_empty_subdict_key_collision(self):
+        """An *empty* sub-dict whose emitted key collides with an already-present
+        key must also raise, not silently overwrite.
+
+        Empty sub-dicts take a dedicated branch (they emit a ``{}`` placeholder so
+        flatten/unflatten round-trips). That branch must still honour the
+        duplicate-key guard: here a non-empty sibling ``'a'`` first emits ``'a.b'``,
+        then the empty sibling ``'a.b': {}`` would re-emit the same joined key.
+        """
+        with self.assertRaisesRegex(ValueError, "duplicate key 'a.b'"):
+            flatten_dict({'a': {'b': 1}, 'a.b': {}})
 
     def test_flatten_dict_rejects_non_string_nested_keys(self):
         """Regression (L25): non-string nested keys must raise, not coerce."""

--- a/brainstate/util/_others_test.py
+++ b/brainstate/util/_others_test.py
@@ -110,6 +110,30 @@ class TestSplitTotal(unittest.TestCase):
             split_total(100, 150)
         self.assertIn("cannot be greater than total", str(ctx.exception))
 
+    def test_bool_rejected(self):
+        """Reject bool arguments so they are never treated as 0/1 or leak into the int return.
+
+        ``bool`` is a subclass of ``int``; without an explicit guard
+        ``split_total(100, True)`` would return ``True`` and ``split_total(True, 0.5)``
+        would silently treat the total as ``1``.
+        """
+        # bool fraction must raise (would otherwise be int 0/1 and return a bool)
+        for frac in (True, False):
+            with self.assertRaises(TypeError) as ctx:
+                split_total(100, frac)
+            self.assertIn("must be an integer or float", str(ctx.exception))
+
+        # bool total must raise (would otherwise pass the int check as 0/1)
+        for tot in (True, False):
+            with self.assertRaises(TypeError) as ctx:
+                split_total(tot, 0.5)
+            self.assertIn("must be an integer", str(ctx.exception))
+
+    def test_return_type_is_strict_int(self):
+        """Return a strict ``int`` (never a ``bool``) for all valid inputs."""
+        for r in (split_total(100, 0.5), split_total(100, 25), split_total(100, 100), split_total(100, 0)):
+            self.assertIs(type(r), int)
+
 
 class TestNameContext(unittest.TestCase):
     """Test cases for NameContext and get_unique_name."""
@@ -833,6 +857,53 @@ class TestDotDict(unittest.TestCase):
         self.assertIsInstance(result, DotDict)
         self.assertEqual(result.value, 3)
 
+    def test_or_operator_preserves_type_and_hooks(self):
+        """``DotDict | dict`` returns a DotDict and recursively hooks nested dicts.
+
+        Without explicit ``__or__`` this delegates to ``dict.__or__`` and returns a
+        plain ``dict`` (losing both the type and the nested-conversion hook).
+        """
+        dd = DotDict({'a': 1})
+        result = dd | {'b': {'c': 2}}
+        self.assertIsInstance(result, DotDict)
+        self.assertIsInstance(result['b'], DotDict)
+        self.assertEqual(result.b.c, 2)
+        # original is unchanged
+        self.assertNotIn('b', dd)
+        # non-mapping right operand is not handled
+        self.assertEqual(dd.__or__(123), NotImplemented)
+
+    def test_ior_operator_preserves_type_and_hooks(self):
+        """``DotDict |= dict`` updates in place via the hook-aware ``update``."""
+        dd = DotDict({'a': 1})
+        dd |= {'b': {'c': 2}}
+        self.assertIsInstance(dd, DotDict)
+        self.assertIsInstance(dd['b'], DotDict)
+        self.assertEqual(dd.b.c, 2)
+
+    def test_ror_operator_with_generic_mapping(self):
+        """``mapping | DotDict`` (non-dict left operand) yields a hooked DotDict."""
+        import collections.abc as abc
+
+        class ReadOnlyMapping(abc.Mapping):
+            def __init__(self, data):
+                self._data = dict(data)
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def __iter__(self):
+                return iter(self._data)
+
+            def __len__(self):
+                return len(self._data)
+
+        result = ReadOnlyMapping({'b': {'c': 2}}) | DotDict({'a': 1})
+        self.assertIsInstance(result, DotDict)
+        self.assertIsInstance(result['b'], DotDict)
+        self.assertEqual(result.a, 1)
+        self.assertEqual(result.b.c, 2)
+
     def test_pickling(self):
         """Test pickling/unpickling."""
         dd1 = DotDict({'a': 1, 'b': {'c': 2}})
@@ -1127,6 +1198,69 @@ class TestJaxIntegration(unittest.TestCase):
             doubled['dict_manager']['a'],
             jnp.array([2, 4])
         ))
+
+
+class TestClearBufferMemory(unittest.TestCase):
+    """Test cases for clear_buffer_memory error handling (item 3)."""
+
+    def test_runs_without_error_when_buffers_delete_cleanly(self):
+        """Complete normally when every live buffer deletes cleanly (happy path).
+
+        Mocks the backend instead of clearing the real one: a real
+        ``clear_buffer_memory()`` deletes JAX's process-global device buffers,
+        including the ordered-effect runtime token that ``jit_error_if`` relies
+        on. Tearing that down corrupts unrelated tests later in the same process
+        (``BlockHostUntilReady() called on deleted or donated buffer``). The real
+        deletion loop and its error handling are covered by the mocked tests below.
+        """
+        buf1, buf2 = MagicMock(), MagicMock()
+        backend = MagicMock()
+        backend.live_buffers.return_value = [buf1, buf2]
+        with patch("brainstate._compatible_import.get_backend", return_value=backend):
+            clear_buffer_memory()  # should not raise
+        buf1.delete.assert_called_once()
+        buf2.delete.assert_called_once()
+
+    def test_per_buffer_delete_failure_warns_and_continues(self):
+        """Warn per failing buffer deletion but still delete the others.
+
+        Previously every error was swallowed under a single warning; now each
+        ``delete()`` failure is isolated so one bad buffer cannot abort the loop.
+        """
+        good = MagicMock()
+        bad = MagicMock()
+        bad.delete.side_effect = RuntimeError("cannot free")
+        another = MagicMock()
+        backend = MagicMock()
+        backend.live_buffers.return_value = [good, bad, another]
+
+        with patch("brainstate._compatible_import.get_backend", return_value=backend):
+            with self.assertWarns(RuntimeWarning):
+                clear_buffer_memory()
+
+        # the failing buffer did not prevent the others from being deleted
+        good.delete.assert_called_once()
+        another.delete.assert_called_once()
+
+    def test_backend_acquisition_error_is_not_swallowed(self):
+        """Surface setup errors (e.g. unknown platform) instead of hiding them.
+
+        The old implementation caught *all* exceptions, masking a genuine
+        misconfiguration; backend acquisition failures should now propagate.
+        """
+        with patch(
+            "brainstate._compatible_import.get_backend",
+            side_effect=RuntimeError("unknown platform"),
+        ):
+            with self.assertRaises(RuntimeError):
+                clear_buffer_memory(platform="definitely_not_a_platform")
+
+    def test_array_false_skips_buffer_clearing(self):
+        """Skip buffer clearing entirely when ``array=False``."""
+        backend = MagicMock()
+        with patch("brainstate._compatible_import.get_backend", return_value=backend) as gb:
+            clear_buffer_memory(array=False)
+        gb.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/brainstate/util/_others_test.py
+++ b/brainstate/util/_others_test.py
@@ -713,6 +713,80 @@ class TestDotDict(unittest.TestCase):
         self.assertIsInstance(dd2.b, DotDict)
         self.assertEqual(dd2.b.d.e, 3)
 
+    def test_namedtuple_values(self):
+        """Regression (H20): namedtuples must survive _hook and to_dict."""
+        from collections import namedtuple
+        Point = namedtuple('Point', ['x', 'y'])
+
+        # Construction must not raise on a namedtuple value.
+        dd = DotDict({'p': Point(1, 2)})
+        self.assertIsInstance(dd.p, Point)
+        self.assertEqual(dd.p, Point(1, 2))
+
+        # Direct item assignment goes through __setitem__ -> _hook.
+        dd['q'] = Point(3, 4)
+        self.assertIsInstance(dd.q, Point)
+        self.assertEqual(dd.q, Point(3, 4))
+
+        # Nested dicts inside a namedtuple are converted to DotDict.
+        dd2 = DotDict({'p': Point({'a': 1}, 2)})
+        self.assertIsInstance(dd2.p, Point)
+        self.assertIsInstance(dd2.p.x, DotDict)
+        self.assertEqual(dd2.p.x.a, 1)
+
+        # to_dict must mirror the same reconstruction (no TypeError, fields kept).
+        d = dd2.to_dict()
+        self.assertIsInstance(d['p'], Point)
+        self.assertNotIsInstance(d['p'].x, DotDict)
+        self.assertEqual(d['p'].x, {'a': 1})
+        self.assertEqual(d['p'].y, 2)
+
+        # Plain tuples and lists still round-trip.
+        dd3 = DotDict({'t': ({'a': 1},), 'l': [{'b': 2}]})
+        self.assertIsInstance(dd3.t, tuple)
+        self.assertNotIsInstance(dd3.t, Point)
+        self.assertIsInstance(dd3.t[0], DotDict)
+        self.assertIsInstance(dd3.l, list)
+        self.assertIsInstance(dd3.l[0], DotDict)
+        d3 = dd3.to_dict()
+        self.assertEqual(d3['t'], ({'a': 1},))
+        self.assertEqual(d3['l'], [{'b': 2}])
+
+    def test_update_accepts_iterable_of_pairs(self):
+        """Regression (M44): update must accept an iterable of (k, v) pairs."""
+        dd = DotDict({'a': 1})
+        dd.update([('b', 2)])
+        self.assertEqual(dict(dd), {'a': 1, 'b': 2})
+
+        # Recursive-merge path still produces nested DotDict from pairs.
+        dd2 = DotDict({'a': {'x': 1}})
+        dd2.update([('a', {'y': 2})])
+        self.assertIsInstance(dd2.a, DotDict)
+        self.assertEqual(dd2.a.x, 1)
+        self.assertEqual(dd2.a.y, 2)
+
+        # Generators (an iterable of pairs) are accepted too.
+        dd3 = DotDict()
+        dd3.update((k, v) for k, v in [('c', 3), ('d', 4)])
+        self.assertEqual(dict(dd3), {'c': 3, 'd': 4})
+
+        # Bad input raises a clear TypeError, not an opaque AttributeError.
+        with self.assertRaises(TypeError):
+            DotDict().update(123)
+
+    def test_parent_kwarg_no_longer_special(self):
+        """Regression (L26): __parent/__key are ordinary keys, not reserved."""
+        # Previously crashed inside __setitem__ with TypeError.
+        dd = DotDict(__parent=5, a=1)
+        self.assertEqual(set(dd.keys()), {'__parent', 'a'})
+        self.assertEqual(dd['__parent'], 5)
+        self.assertEqual(dd['a'], 1)
+
+        # Behaves identically regardless of the supplied value.
+        dd2 = DotDict(__parent='x', value=1)
+        self.assertEqual(set(dd2.keys()), {'__parent', 'value'})
+        self.assertEqual(dd2['__parent'], 'x')
+
     def test_update_method(self):
         """Test update with recursive merge."""
         dd = DotDict({'a': 1, 'b': {'c': 2, 'd': 3}})
@@ -924,6 +998,42 @@ class TestUtilityFunctions(unittest.TestCase):
         flattened = flatten_dict(original)
         unflattened = unflatten_dict(flattened)
         self.assertEqual(unflattened, original)
+
+    def test_flatten_dict_preserves_empty_subdicts(self):
+        """Regression (M43): empty sub-dicts must not be dropped on flatten."""
+        # Top-level empty dict.
+        self.assertEqual(flatten_dict({'a': 1, 'b': {}}), {'a': 1, 'b': {}})
+        # Entirely-empty content.
+        self.assertEqual(flatten_dict({'b': {}}), {'b': {}})
+
+        # Round-trip with empty sub-dicts at top level and nested.
+        for x in (
+            {'a': 1, 'b': {}},
+            {'b': {'c': {}}},
+            {'a': 1, 'b': {'c': {}, 'd': 2}},
+        ):
+            self.assertEqual(unflatten_dict(flatten_dict(x)), x)
+
+    def test_unflatten_dict_copies_dict_leaves(self):
+        """Regression (M43): dict leaf values must not alias the input."""
+        flat = {'b': {}}
+        out = unflatten_dict(flat)
+        out['b']['mutated'] = 1
+        self.assertEqual(flat, {'b': {}})  # input unchanged
+
+    def test_flatten_dict_rejects_key_collision(self):
+        """Regression (L25): colliding joined keys must raise, not silently drop."""
+        with self.assertRaises(ValueError):
+            flatten_dict({'a.b': 1, 'a': {'b': 2}})
+        with self.assertRaises(ValueError):
+            flatten_dict({'a': {'b': 2}, 'a.b': 1})
+
+    def test_flatten_dict_rejects_non_string_nested_keys(self):
+        """Regression (L25): non-string nested keys must raise, not coerce."""
+        with self.assertRaises(TypeError):
+            flatten_dict({1: 'a', 2: {3: 'b'}})
+        # A non-string top-level key (no nesting) is preserved verbatim.
+        self.assertEqual(flatten_dict({1: 'a', 2: 'b'}), {1: 'a', 2: 'b'})
 
     def test_is_instance_eval(self):
         """Test is_instance_eval function."""

--- a/brainstate/util/_pretty_pytree.py
+++ b/brainstate/util/_pretty_pytree.py
@@ -804,7 +804,11 @@ class NestedDict(PrettyDict):
             >>> type(pure)
             <class 'dict'>
         """
-        flat_values = {k: x for k, x in self.to_flat().items()}
+        # ``keep_empty_nodes=True`` so that empty nested mappings (e.g. ``{'a': {}}``)
+        # survive the flatten/nest round-trip; the default would silently drop them,
+        # contradicting this method's "same nested structure" contract. ``nest_mapping``
+        # restores the empty-node sentinel back to an empty ``dict``.
+        flat_values = flat_mapping(self, keep_empty_nodes=True)
         return nest_mapping(flat_values).to_dict()
 
     def replace_by_pure_dict(

--- a/brainstate/util/_pretty_pytree.py
+++ b/brainstate/util/_pretty_pytree.py
@@ -204,7 +204,10 @@ def flat_mapping(
     Empty mappings are ignored by default and will not be restored by
     :func:`nest_mapping` unless ``keep_empty_nodes=True``.
     """
-    assert isinstance(xs, abc.Mapping), f'expected Mapping; got {type(xs).__qualname__}'
+    if not isinstance(xs, abc.Mapping):
+        raise TypeError(f'expected Mapping; got {type(xs).__qualname__}')
+    if is_leaf is None:
+        is_leaf = _default_leaf
 
     if sep is None:
         def _key(path: Tuple[Any, ...]) -> Union[Tuple[Any, ...], str]:
@@ -275,7 +278,8 @@ def nest_mapping(
     --------
     flat_mapping : The inverse operation that flattens a nested mapping.
     """
-    assert isinstance(xs, abc.Mapping), f'expected Mapping; got {type(xs).__qualname__}'
+    if not isinstance(xs, abc.Mapping):
+        raise TypeError(f'expected Mapping; got {type(xs).__qualname__}')
     result: Dict[Any, Any] = {}
     for path, value in xs.items():
         if sep is not None:
@@ -643,14 +647,16 @@ class NestedDict(PrettyDict):
     def __or__(self, other: 'NestedDict') -> 'NestedDict':
         if not other:
             return self
-        assert isinstance(other, NestedDict), f'expected NestedDict; got {type(other).__qualname__}'
+        if not isinstance(other, NestedDict):
+            raise TypeError(f'expected NestedDict; got {type(other).__qualname__}')
         return NestedDict.merge(self, other)
 
     def __sub__(self, other: 'NestedDict') -> 'NestedDict':
         if not other:
             return self
 
-        assert isinstance(other, NestedDict), f'expected NestedDict; got {type(other).__qualname__}'
+        if not isinstance(other, NestedDict):
+            raise TypeError(f'expected NestedDict; got {type(other).__qualname__}')
         self_flat = self.to_flat()
         other_flat = other.to_flat()
         diff = {k: v for k, v in self_flat.items() if k not in other_flat}
@@ -932,13 +938,15 @@ class FlattedDict(PrettyDict):
     def __or__(self, other: 'FlattedDict') -> 'FlattedDict':
         if not other:
             return self
-        assert isinstance(other, FlattedDict), f'expected NestedDict; got {type(other).__qualname__}'
+        if not isinstance(other, FlattedDict):
+            raise TypeError(f'expected FlattedDict; got {type(other).__qualname__}')
         return FlattedDict.merge(self, other)
 
     def __sub__(self, other: 'FlattedDict') -> 'FlattedDict':
         if not other:
             return self
-        assert isinstance(other, FlattedDict), f'expected NestedDict; got {type(other).__qualname__}'
+        if not isinstance(other, FlattedDict):
+            raise TypeError(f'expected FlattedDict; got {type(other).__qualname__}')
         diff = {k: v for k, v in self.items() if k not in other}
         return FlattedDict(diff)
 
@@ -954,21 +962,21 @@ class FlattedDict(PrettyDict):
 
     @classmethod
     def from_nest(
-        cls, nested_dict: abc.Mapping[PathParts, V] | Iterable[tuple[PathParts, V]],
+        cls, nested_dict: abc.Mapping[Any, V] | Iterable[tuple[Any, V]],
     ) -> 'FlattedDict':
         """
-        Create a :class:`NestedDict` from a flat mapping.
+        Create a :class:`FlattedDict` from a nested mapping.
 
         Parameters
         ----------
         nested_dict
-            The flat mapping.
+            The nested mapping.
 
         Returns
         -------
-        The :class:`NestedDict`.
+        The :class:`FlattedDict`.
         """
-        return flat_mapping(nested_dict)
+        return flat_mapping(dict(nested_dict))
 
     def split(  # type: ignore[misc]
         self,

--- a/brainstate/util/_pretty_pytree_test.py
+++ b/brainstate/util/_pretty_pytree_test.py
@@ -1107,3 +1107,60 @@ class TestReprAttributeBranches(unittest.TestCase):
         out = pretty_repr_object(Bare())
         self.assertIn('x', out)
         self.assertIn('items_list', out)
+
+
+class TestAuditRegressions(unittest.TestCase):
+    """Regression tests for audit issues L27, L28, L29."""
+
+    def test_flat_mapping_is_leaf_none(self):
+        # L27: ``is_leaf=None`` must select the default behaviour (the
+        # ``Optional`` hint advertises this) instead of crashing with
+        # ``TypeError: 'NoneType' object is not callable``.
+        nested = {'a': {'b': 1}}
+        result = flat_mapping(nested, is_leaf=None)
+        self.assertEqual(result, flat_mapping(nested))
+        self.assertEqual(dict(result), {('a', 'b'): 1})
+
+    def test_from_nest_accepts_iterable_of_pairs(self):
+        # L28: the type hint advertises an Iterable of (key, value) pairs.
+        # ``from_nest`` must convert it (mirroring ``from_flat``) instead of
+        # silently corrupting under ``python -O`` to ``{(): [('a', 1)]}``.
+        from_iter = FlattedDict.from_nest([('a', 1), ('b', {'c': 2})])
+        from_dict = FlattedDict.from_nest({'a': 1, 'b': {'c': 2}})
+        self.assertEqual(from_iter, from_dict)
+        self.assertEqual(dict(from_iter), {('a',): 1, ('b', 'c'): 2})
+
+    def test_flat_mapping_rejects_non_mapping(self):
+        # L29: validation must raise (not assert) so it survives ``python -O``.
+        with self.assertRaises(TypeError):
+            flat_mapping([('a', 1)])
+
+    def test_nest_mapping_rejects_non_mapping(self):
+        # L29: nest_mapping validation must raise TypeError.
+        with self.assertRaises(TypeError):
+            nest_mapping([('a', 1)])
+
+    def test_flatted_dict_sub_rejects_non_flatted(self):
+        # L29: FlattedDict - <non-FlattedDict> must raise TypeError instead of
+        # silently returning a wrong diff under ``python -O``.
+        fd = FlattedDict({('a',): 1, ('b',): 2})
+        with self.assertRaises(TypeError):
+            _ = fd - {('a',): 1}
+
+    def test_flatted_dict_or_rejects_non_flatted(self):
+        # L29: FlattedDict | <non-FlattedDict> must raise TypeError.
+        fd = FlattedDict({('a',): 1})
+        with self.assertRaises(TypeError):
+            _ = fd | {('b',): 2}
+
+    def test_nested_dict_sub_rejects_non_nested(self):
+        # L29: NestedDict - <non-NestedDict> must raise TypeError.
+        nd = NestedDict({'a': 1, 'b': 2})
+        with self.assertRaises(TypeError):
+            _ = nd - {'a': 1}
+
+    def test_nested_dict_or_rejects_non_nested(self):
+        # L29: NestedDict | <non-NestedDict> must raise TypeError.
+        nd = NestedDict({'a': 1})
+        with self.assertRaises(TypeError):
+            _ = nd | {'b': 2}

--- a/brainstate/util/_pretty_pytree_test.py
+++ b/brainstate/util/_pretty_pytree_test.py
@@ -1164,3 +1164,31 @@ class TestAuditRegressions(unittest.TestCase):
         nd = NestedDict({'a': 1})
         with self.assertRaises(TypeError):
             _ = nd | {'b': 2}
+
+    def test_to_pure_dict_preserves_empty_subdicts(self):
+        # to_pure_dict must keep empty nested mappings (its docstring promises the
+        # "same nested structure"). The default flatten drops empty mappings, so
+        # without keep_empty_nodes=True a key like 'empty' silently disappears.
+        nested = NestedDict({'a': {'b': 1, 'c': 2}, 'empty': {}, 'deep': {'x': {}, 'y': 5}})
+        pure = nested.to_pure_dict()
+
+        expected = {'a': {'b': 1, 'c': 2}, 'empty': {}, 'deep': {'x': {}, 'y': 5}}
+        self.assertEqual(pure, expected)
+        self.assertIn('empty', pure)
+        self.assertEqual(pure['empty'], {})
+        self.assertEqual(pure['deep']['x'], {})
+
+        # the result must be pure ``dict`` all the way down (no NestedDict wrappers)
+        def _all_plain_dict(d):
+            if isinstance(d, dict):
+                self.assertIs(type(d), dict)
+                for v in d.values():
+                    _all_plain_dict(v)
+
+        _all_plain_dict(pure)
+
+    def test_to_pure_dict_root_empty(self):
+        # An entirely empty NestedDict round-trips to an empty plain dict.
+        pure = NestedDict({}).to_pure_dict()
+        self.assertEqual(pure, {})
+        self.assertIs(type(pure), dict)

--- a/brainstate/util/_pretty_repr.py
+++ b/brainstate/util/_pretty_repr.py
@@ -239,17 +239,28 @@ class MappingReprMixin(Mapping[A, B]):
     """
     Mapping mixin for pretty representation.
 
-    This mixin provides a default pretty representation for mapping-like objects.
+    This mixin only supplies a ``__pretty_repr__`` implementation (the hook
+    consumed by :func:`pretty_repr_object`); it does **not** override ``__repr__``
+    or ``__str__``. In particular, mixing it into ``dict`` does not change how the
+    object prints, because ``dict.__repr__`` still wins via the MRO. To obtain the
+    multi-line pretty string you must route through :func:`pretty_repr_object`,
+    which also requires the object to be a :class:`PrettyRepr` instance.
 
     Examples
     --------
     .. code-block:: python
 
-        >>> class MyMapping(dict, MappingReprMixin):
-        ...     pass
+        >>> from brainstate.util._pretty_repr import (
+        ...     MappingReprMixin, PrettyRepr, pretty_repr_object
+        ... )
+        >>>
+        >>> # Combine with ``PrettyRepr`` and expose the pretty output through an
+        >>> # explicit ``__repr__`` (``dict.__repr__`` would otherwise shadow it).
+        >>> class PrettyDict(dict, MappingReprMixin, PrettyRepr):
+        ...     def __repr__(self):
+        ...         return pretty_repr_object(self)
         ...
-        >>> m = MyMapping({'a': 1, 'b': 2})
-        >>> print(m)
+        >>> print(PrettyDict({'a': 1, 'b': 2}))
         {
           'a': 1,
           'b': 2

--- a/brainstate/util/_pretty_repr_test.py
+++ b/brainstate/util/_pretty_repr_test.py
@@ -333,6 +333,32 @@ class TestMappingReprMixin(unittest.TestCase):
         items = list(m.__pretty_repr__())
         self.assertEqual(len(items), 1)  # Only PrettyType, no attributes
 
+    def test_mixin_alone_does_not_change_repr(self):
+        """``dict`` + mixin does NOT pretty-print; ``dict.__repr__`` still wins.
+
+        Regression for the misleading docstring that claimed ``print(m)`` produced
+        a multi-line block. Mixing into ``dict`` leaves ``repr``/``str`` unchanged.
+        """
+        class MyMapping(dict, MappingReprMixin):
+            pass
+
+        m = MyMapping({'a': 1, 'b': 2})
+        self.assertEqual(repr(m), "{'a': 1, 'b': 2}")
+        self.assertNotIn('\n', repr(m))
+
+    def test_documented_pretty_print_pattern(self):
+        """The corrected docstring pattern yields the multi-line pretty output.
+
+        Combining the mixin with :class:`PrettyRepr` and an explicit ``__repr__``
+        that calls :func:`pretty_repr_object` produces the documented block.
+        """
+        class PrettyDict(dict, MappingReprMixin, PrettyRepr):
+            def __repr__(self):
+                return pretty_repr_object(self)
+
+        text = repr(PrettyDict({'a': 1, 'b': 2}))
+        self.assertEqual(text, "{\n  'a': 1,\n  'b': 2\n}")
+
 
 class TestPrettyMapping(unittest.TestCase):
     """Test cases for PrettyMapping class."""

--- a/brainstate/util/_tracers.py
+++ b/brainstate/util/_tracers.py
@@ -63,6 +63,15 @@ class StateJaxTracer(PrettyRepr):
     def __eq__(self, other):
         return isinstance(other, StateJaxTracer) and self._jax_trace == other._jax_trace
 
+    def __hash__(self):
+        # Defining ``__eq__`` resets ``__hash__`` to ``None`` (making instances
+        # unhashable); restore it so tracers can live in sets/dict keys. The
+        # captured JAX trace (``OpaqueTraceState``) supports ``==`` but is itself
+        # unhashable, so we cannot derive the hash from it. Use a constant, type
+        # based hash: this keeps the eq/hash invariant (equal tracers hash equal)
+        # while accepting that distinct traces collide -- correctness over spread.
+        return hash(StateJaxTracer)
+
     def __pretty_repr__(self):
         yield PrettyType(f'{type(self).__name__}')
         yield PrettyAttr('jax_trace', self._jax_trace)

--- a/brainstate/util/_tracers_test.py
+++ b/brainstate/util/_tracers_test.py
@@ -61,6 +61,37 @@ class TestStateJaxTracer(unittest.TestCase):
         """Return True from ``__eq__`` for another tracer with the same trace."""
         self.assertTrue(StateJaxTracer().__eq__(StateJaxTracer()))
 
+    def test_is_hashable(self):
+        """Remain hashable despite defining ``__eq__`` (which would null ``__hash__``).
+
+        The captured ``OpaqueTraceState`` is itself unhashable, so a type-based
+        constant hash is used; this keeps tracers usable as set members / dict keys.
+        """
+        tracer = StateJaxTracer()
+        self.assertIsInstance(hash(tracer), int)
+        # equal tracers must hash equally (eq/hash invariant)
+        self.assertEqual(hash(StateJaxTracer()), hash(StateJaxTracer()))
+        # usable in a set / as a dict key
+        self.assertEqual(len({StateJaxTracer(), StateJaxTracer()}), 1)
+        self.assertEqual({tracer: 'value'}[StateJaxTracer()], 'value')
+
+    def test_hashable_inside_and_across_traces(self):
+        """Tracers captured in different traces are all hashable and dict-usable."""
+        top = StateJaxTracer()
+        captured = []
+
+        @jax.jit
+        def f(x):
+            captured.append(StateJaxTracer())
+            return x
+
+        f(jnp.ones((3,)))
+        # both are hashable even though they are not equal
+        self.assertNotEqual(top, captured[0])
+        mapping = {top: 'top', captured[0]: 'jit'}
+        self.assertIn(top, mapping)
+        self.assertIsInstance(hash(captured[0]), int)
+
     def test_repr_contains_class_name(self):
         """Name the class and the captured attribute in the pretty repr."""
         text = repr(StateJaxTracer())

--- a/brainstate/util/filter.py
+++ b/brainstate/util/filter.py
@@ -303,6 +303,14 @@ class WithTag:
 
     tag: str
 
+    def __post_init__(self):
+        # The type hint and docstring promise a ``str`` tag. Enforce it: a non-str
+        # (e.g. a list) would otherwise be accepted silently and then break the
+        # frozen-dataclass auto-generated ``__hash__`` (``unhashable type``),
+        # making the filter unusable in sets/dict keys or inside ``Any``/``All``.
+        if not isinstance(self.tag, str):
+            raise TypeError(f"WithTag 'tag' must be a str, got {type(self.tag).__name__}.")
+
     def __call__(self, path: PathParts, x: typing.Any) -> bool:
         """
         Check if the object has a matching tag.
@@ -654,9 +662,17 @@ class Any:
         Returns
         -------
         int
-            The hash value of the predicates tuple.
+            The hash value of the predicates tuple, or a type-based fallback when
+            a wrapped predicate is unhashable (so the filter stays hashable and
+            consistent with ``__eq__``).
         """
-        return hash(self.predicates)
+        try:
+            return hash(self.predicates)
+        except TypeError:
+            # A user-supplied predicate may be unhashable; fall back to a stable,
+            # type-based hash. This keeps ``Any`` usable in sets/dict keys and
+            # preserves the eq/hash invariant (equal filters share this fallback).
+            return hash(Any)
 
 
 class All:
@@ -737,9 +753,17 @@ class All:
         Returns
         -------
         int
-            The hash value of the predicates tuple.
+            The hash value of the predicates tuple, or a type-based fallback when
+            a wrapped predicate is unhashable (so the filter stays hashable and
+            consistent with ``__eq__``).
         """
-        return hash(self.predicates)
+        try:
+            return hash(self.predicates)
+        except TypeError:
+            # A user-supplied predicate may be unhashable; fall back to a stable,
+            # type-based hash. This keeps ``All`` usable in sets/dict keys and
+            # preserves the eq/hash invariant (equal filters share this fallback).
+            return hash(All)
 
 
 class Not:
@@ -818,9 +842,17 @@ class Not:
         Returns
         -------
         int
-            The hash value of the predicate.
+            The hash value of the wrapped predicate, or a type-based fallback when
+            that predicate is unhashable (so the filter stays hashable and
+            consistent with ``__eq__``).
         """
-        return hash(self.predicate)
+        try:
+            return hash(self.predicate)
+        except TypeError:
+            # A user-supplied predicate may be unhashable; fall back to a stable,
+            # type-based hash. This keeps ``Not`` usable in sets/dict keys and
+            # preserves the eq/hash invariant (equal filters share this fallback).
+            return hash(Not)
 
 
 class Everything:

--- a/brainstate/util/filter_test.py
+++ b/brainstate/util/filter_test.py
@@ -189,6 +189,24 @@ class TestWithTagFilter(unittest.TestCase):
         self.assertTrue(filter_tag(['some', 'path'], obj))
         self.assertTrue(filter_tag(['another', 'nested', 'path'], obj))
 
+    def test_non_str_tag_rejected(self):
+        """Reject non-str tags so the type hint/docstring hold and hashing works.
+
+        A non-str (e.g. an unhashable list) would otherwise be accepted silently
+        and then break the frozen-dataclass ``__hash__``.
+        """
+        for bad in (['a', 'b'], {'a'}, 5, None, ('a',)):
+            with self.assertRaises(TypeError):
+                WithTag(bad)
+
+    def test_hashable(self):
+        """A str-tagged WithTag is hashable and usable in sets/dict keys."""
+        f1 = WithTag('trainable')
+        f2 = WithTag('trainable')
+        self.assertEqual(hash(f1), hash(f2))
+        self.assertEqual(len({f1, f2}), 1)
+        self.assertEqual({f1: 'v'}[f2], 'v')
+
 
 class TestPathContainsFilter(unittest.TestCase):
     """Test cases for PathContains filter."""
@@ -921,6 +939,54 @@ class TestIntegrationScenarios(unittest.TestCase):
         # Case 4: In excluded path without override - should not match
         regular_obj = MockTaggedObject('regular')
         self.assertFalse(filter_deep(['excluded'], regular_obj))  # Excluded without override
+
+
+class _UnhashablePredicate:
+    """A callable predicate that is deliberately unhashable."""
+    __hash__ = None
+
+    def __call__(self, path, x) -> bool:
+        return True
+
+
+class TestUnhashablePredicateHashing(unittest.TestCase):
+    """Any/All/Not must stay hashable even when wrapping an unhashable predicate.
+
+    These composite filters define both ``__eq__`` and ``__hash__`` (claiming to be
+    hashable). Previously ``hash(...)`` raised ``TypeError`` whenever a wrapped
+    predicate was unhashable, breaking that contract and any set/dict usage.
+    """
+
+    def test_any_hashable_with_unhashable_predicate(self):
+        f = Any(_UnhashablePredicate())
+        self.assertEqual(hash(f), hash(Any))  # stable type-based fallback
+        self.assertEqual(len({f}), 1)  # usable in a set
+
+    def test_all_hashable_with_unhashable_predicate(self):
+        f = All(_UnhashablePredicate())
+        self.assertEqual(hash(f), hash(All))
+        self.assertEqual(len({f}), 1)
+
+    def test_not_hashable_with_unhashable_predicate(self):
+        f = Not(_UnhashablePredicate())
+        self.assertEqual(hash(f), hash(Not))
+        self.assertEqual(len({f}), 1)
+
+    def test_hashable_predicates_still_use_precise_hash(self):
+        """The fallback must not regress the normal (hashable) path."""
+        self.assertEqual(hash(Any('t1', 't2')), hash(Any('t1', 't2')))
+        self.assertEqual(hash(All('t1', 't2')), hash(All('t1', 't2')))
+        self.assertEqual(hash(Not('t1')), hash(Not('t1')))
+        # distinct hashable filters generally differ from the type-fallback value
+        self.assertNotEqual(hash(Any('t1', 't2')), hash(Any))
+
+    def test_eq_hash_invariant_for_equal_filters(self):
+        """Equal composite filters share a hash even with unhashable predicates."""
+        shared = _UnhashablePredicate()
+        a1 = Any(shared)
+        a2 = Any(shared)
+        self.assertEqual(a1, a2)
+        self.assertEqual(hash(a1), hash(a2))
 
 
 if __name__ == '__main__':

--- a/brainstate/util/struct.py
+++ b/brainstate/util/struct.py
@@ -167,8 +167,12 @@ def dataclass(cls: type[T] | None = None, **kwargs) -> type[T] | Any:
     if cls is None:
         return lambda cls_: dataclass(cls_, **kwargs)
 
-    # Check if already converted
-    if is_dataclass(cls):
+    # Check if THIS class was already converted (do not consult inherited marker).
+    # ``_brainstate_dataclass`` is a plain class attribute and is therefore
+    # inherited by subclasses; using ``is_dataclass(cls)`` here would early-return
+    # for any subclass and silently drop its newly declared fields. Inspect this
+    # class's own ``__dict__`` instead (mirroring Flax's ``'_flax_dataclass'`` check).
+    if '_brainstate_dataclass' in cls.__dict__:
         return cls
 
     # Default to frozen for immutability
@@ -182,6 +186,13 @@ def dataclass(cls: type[T] | None = None, **kwargs) -> type[T] | Any:
     meta_fields = []
 
     for field_info in dataclasses.fields(cls):
+        # Skip ``init=False`` fields: jax.tree_util.register_dataclass requires
+        # data_fields + meta_fields to be exactly the ``init=True`` fields, and the
+        # fallback ``unflatten_fn`` reconstructs via ``cls(**kwargs)`` which does not
+        # accept ``init=False`` names. Such fields are restored automatically by
+        # their default or ``__post_init__`` during construction.
+        if not field_info.init:
+            continue
         if field_info.metadata.get('pytree_node', True):
             pytree_fields.append(field_info.name)
         else:
@@ -463,13 +474,12 @@ class FrozenDict(Mapping[K, V], Generic[K, V]):
         """
         Return a view of the items.
 
-        Yields
-        ------
-        tuple
-            Key-value pairs from the dictionary.
+        Returns
+        -------
+        ItemsView
+            A view object of the dictionary's (key, value) pairs.
         """
-        for key in self._data:
-            yield (key, self[key])
+        return ItemsView(self)
 
     def get(self, key: K, default: V | None = None) -> V | None:
         """

--- a/brainstate/util/struct_test.py
+++ b/brainstate/util/struct_test.py
@@ -276,6 +276,59 @@ class TestPyTreeNode:
         grads = grad_fn(mlp)
         assert grads.layer1.weight.shape == mlp.layer1.weight.shape
 
+    def test_pytreenode_subclass_adds_new_field(self):
+        """Subclassing a PyTreeNode must not drop newly declared fields (H21)."""
+        import dataclasses as _dc
+
+        class Base(PyTreeNode):
+            a: jax.Array
+
+        class Derived(Base):
+            b: jax.Array = None
+
+        # The new field must be registered on the subclass.
+        field_names = [f.name for f in _dc.fields(Derived)]
+        assert field_names == ['a', 'b']
+
+        # Construction with the new field must succeed (used to raise TypeError).
+        obj = Derived(a=jnp.ones(3), b=jnp.zeros(2))
+        assert jnp.allclose(obj.a, jnp.ones(3))
+        assert jnp.allclose(obj.b, jnp.zeros(2))
+
+        # It must round-trip as a pytree with all leaves (a + b).
+        leaves, treedef = jax.tree_util.tree_flatten(obj)
+        assert len(leaves) == 2
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert jnp.allclose(rebuilt.a, obj.a)
+        assert jnp.allclose(rebuilt.b, obj.b)
+
+    def test_dataclass_field_init_false(self):
+        """field(init=False) must not crash registration at class-definition time (M46)."""
+
+        # init=False with a default on a meta (non-pytree) field.
+        class WithDefault(PyTreeNode):
+            a: jax.Array
+            b: int = field(pytree_node=False, default=5, init=False)
+
+        obj = WithDefault(a=jnp.ones(3))
+        assert obj.b == 5
+        assert jnp.allclose(obj.a, jnp.ones(3))
+
+        # init=False assigned in __post_init__.
+        class WithPostInit(PyTreeNode):
+            a: jax.Array
+            doubled: jax.Array = field(init=False, default=None)
+
+            def __post_init__(self):
+                object.__setattr__(self, 'doubled', self.a * 2)
+
+        obj2 = WithPostInit(a=jnp.ones(3))
+        assert jnp.allclose(obj2.doubled, jnp.ones(3) * 2)
+
+        # The object still works under jax transformations.
+        leaves = jax.tree_util.tree_leaves(obj2)
+        assert len(leaves) >= 1
+
 
 class TestFrozenDict:
     """Test the FrozenDict class."""
@@ -812,6 +865,34 @@ class TestFrozenDictCoverage(unittest.TestCase):
         # equality against dict and FrozenDict
         self.assertEqual(fd, {'a': 1, 'b': 2})
         self.assertEqual(fd, FrozenDict({'a': 1, 'b': 2}))
+
+    def test_views_are_reusable(self):
+        """items()/keys()/values() must return re-iterable Views, not one-shot generators (M45)."""
+        from collections.abc import ItemsView, KeysView, ValuesView
+
+        fd = FrozenDict({'a': 1, 'b': 2})
+
+        items_view = fd.items()
+        keys_view = fd.keys()
+        values_view = fd.values()
+
+        # They must be Mapping views, not generators.
+        self.assertIsInstance(items_view, ItemsView)
+        self.assertIsInstance(keys_view, KeysView)
+        self.assertIsInstance(values_view, ValuesView)
+
+        # A captured view must be iterable more than once (a generator would be
+        # exhausted on the second pass and yield an empty list).
+        self.assertEqual(set(items_view), {('a', 1), ('b', 2)})
+        self.assertEqual(set(items_view), {('a', 1), ('b', 2)})
+        self.assertEqual(set(keys_view), {'a', 'b'})
+        self.assertEqual(set(keys_view), {'a', 'b'})
+        self.assertEqual(sorted(values_view), [1, 2])
+        self.assertEqual(sorted(values_view), [1, 2])
+
+        # Views support len() and set algebra.
+        self.assertEqual(len(items_view), 2)
+        self.assertEqual(items_view & {('a', 1)}, {('a', 1)})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR resolves **all** issues catalogued in the cross-module audit (`dev/issues.md`), spanning every package under `brainstate/`. Each fix is paired with a regression test that fails before the change and passes after.

### Scope of the audit

| Severity | Items | Status |
|----------|-------|--------|
| Critical | C1 | ✅ fixed |
| High | H1–H21 | ✅ fixed |
| Medium | M1–M46 | ✅ fixed |
| Low | L1–L29 | ✅ fixed |
| Needs-human-judgment | NJ1–NJ4 | ✅ addressed (fix or documented contract) |
| Appendix (unverified findings) | 110 entries | ✅ triaged + fixed where confirmed |

### Commit structure

1. **`fix(audit): resolve 97 confirmed bugs + NJ1–NJ3 across all modules`** — the core C/H/M/L fixes across `core`, `graph`, `interop`, `nn`, `random`, `transform`, `util`.
2. **`fix(audit): resolve appendix findings + NJ items across all modules`** — the 110-entry appendix triage plus the remaining needs-judgment items.
3. **`Merge origin/main (#216 …)`** — reconciles with the independently-merged mapping-engine rewrite (#216). Where the audit overlapped #216 (H19, M41, appendix items 14/15), #216's reviewed rewrite was taken; only the additive, non-overlapping items (a clear `ValueError` for scalar leaves in `_remove_axis`, and a corrected `_compile_stateful_function` type hint) were re-applied on top.
4. **`fix(typing): keep PyTree name construction mypy-clean`** — keeps `brainstate.typing` (a strict-mypy module) type-clean after the appendix refactor.

### Nature of the fixes

- Runtime validation uses `raise TypeError/ValueError` rather than `assert` (asserts are stripped under `python -O`).
- Changes target stable public JAX APIs to preserve compatibility across the supported JAX range (0.7.0 → latest).
- Behavioral contracts that were genuinely ambiguous (the NJ items) are resolved by documenting the existing behavior rather than silently changing it.

## Test plan

- ✅ Full suite: **5235 passed, 23 skipped, 0 failed** (`pytest brainstate/`). The 23 skips are the pre-existing multi-device / `--run-slow` gated tests.
- ✅ Type check: **`mypy brainstate/` — 0 errors, 108 source files**.
- Every fix has a co-located regression test (`_foo_test.py`) exercising the specific edge case.

Net change on top of current `main`: **105 files, +7120 / −839** (50 test files, 55 source files).
