### PR TITLE
perf(graph): classification cache, static-collapse, and shared-State dedup

### DIFF
--- a/brainstate/graph/_classify_test.py
+++ b/brainstate/graph/_classify_test.py
@@ -1,0 +1,68 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (see repo LICENSE).
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+
+import brainstate as bs
+from brainstate import graph
+from brainstate.graph import _walk
+from brainstate.graph._walk import (
+    classify, GRAPH_NODE, PYTREE, STATE, STATE_LEAF, STATIC,
+    _clear_classification_cache, register_graph_node_type,
+)
+
+
+class Box(graph.Node):
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class TestClassify(unittest.TestCase):
+    def setUp(self):
+        _clear_classification_cache()
+
+    def test_kinds(self):
+        s = bs.ParamState(jnp.ones(3))
+        self.assertEqual(classify(Box()), GRAPH_NODE)
+        self.assertEqual(classify([1, 2]), PYTREE)
+        self.assertEqual(classify({'a': 1}), PYTREE)
+        self.assertEqual(classify((1, 2)), PYTREE)
+        self.assertEqual(classify(s), STATE)
+        self.assertEqual(classify(s.to_state_ref()), PYTREE)   # TreefyState is a registered jax pytree; must classify as PYTREE (checked before STATE_LEAF)
+        self.assertEqual(classify(5), STATIC)
+        self.assertEqual(classify(None), PYTREE)               # None is an empty pytree
+        self.assertEqual(classify(np.ones(2)), STATIC)
+        self.assertEqual(classify(jnp.ones(2)), STATIC)
+
+    def test_cache_hit_is_stable(self):
+        self.assertEqual(classify([1]), classify([2, 3]))      # same type -> same kind
+
+    def test_cache_invalidated_on_registration(self):
+        # Classify a plain class FIRST so it gets cached as STATIC, then
+        # register it as a graph node type, and assert that classify now returns
+        # GRAPH_NODE — which only happens if registration cleared the cache.
+        class WillBeRegistered:
+            pass
+
+        # Classified before registration -> STATIC, and cached.
+        self.assertEqual(classify(WillBeRegistered()), STATIC)
+
+        # Registering must clear the cache so the stale STATIC entry is dropped.
+        register_graph_node_type(
+            WillBeRegistered,
+            flatten=lambda n: ([], None),
+            set_key=lambda n, k, v: None,
+            pop_key=lambda n, k: None,
+            create_empty=lambda aux: WillBeRegistered(),
+            clear=lambda n: None,
+        )
+
+        # Must now be GRAPH_NODE, not the stale STATIC.
+        self.assertEqual(classify(WillBeRegistered()), GRAPH_NODE)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainstate/graph/_convert.py
+++ b/brainstate/graph/_convert.py
@@ -31,11 +31,10 @@ import jax
 
 from brainstate._state import State
 from brainstate.typing import Missing, PyTree, SeedOrKey, PathParts
-from brainstate.util import PyTreeNode, field, NestedDict as GraphStateMapping
+from brainstate.util import PyTreeNode, field, FlattedDict, NestedDict as GraphStateMapping
 from ._context import SplitContext, MergeContext, split_context, merge_context
 from ._graphdef import GraphDef
 from ._node import Node as GraphNode
-from ._operations import states
 from ._reftrack import RefMap
 from ._walk import iter_leaf as iter_graph, _is_graph_node
 
@@ -239,10 +238,11 @@ def graph_to_tree(
                     leaf = split_fn(ctx, keypath, leaf_prefix, leaf)
                 leaves_out.append(leaf)
 
-    # Build a dict mirroring RefMap's content via the public API, then extract
-    # State objects from it.  We must not access the private ._mapping attribute.
-    public_map = {id(k): (k, v) for k, v in index_ref.items()}
-    find_states = states(public_map)
+    # index_ref maps each visited object -> its global index; pull the States
+    # out directly instead of re-walking a synthetic pytree.
+    find_states = FlattedDict(
+        {(idx,): obj for obj, idx in index_ref.items() if isinstance(obj, State)}
+    )
     pytree_out = jax.tree.unflatten(treedef, leaves_out)
     return pytree_out, find_states
 

--- a/brainstate/graph/_convert_test.py
+++ b/brainstate/graph/_convert_test.py
@@ -291,5 +291,28 @@ class TestLeafPrefixParityValidation(unittest.TestCase):
             _convert.broadcast_prefix = original
 
 
+class TestGraphToTreeStates(unittest.TestCase):
+    def test_find_states_and_sharing(self):
+        import jax.numpy as jnp
+        import brainstate as bs
+        from brainstate import graph
+
+        class Box(graph.Node):
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+
+        shared = bs.ParamState(jnp.ones((3, 3)))
+        a, b = Box(w=shared), Box(w=shared)
+        from brainstate.util import FlattedDict
+        tree, find = graph.graph_to_tree([a, b])
+        self.assertIsInstance(find, FlattedDict)
+        # shared State surfaces in find_states (deduped)
+        self.assertTrue(any(v is shared for v in find.values()))
+        # round-trip restores sharing
+        back = graph.tree_to_graph(tree)
+        self.assertIs(back[0].w, back[1].w)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/graph/_flatten.py
+++ b/brainstate/graph/_flatten.py
@@ -36,8 +36,9 @@ from ._graphdef import (
 )
 from ._reftrack import RefMap
 from ._walk import (
-    _is_node, _is_graph_node, _is_state_leaf, _get_node_impl,
-    get_node_impl_for_type, PYTREE_NODE_IMPL,
+    _is_node, get_node_impl_for_type, PYTREE_NODE_IMPL,
+    classify, GRAPH_NODE, PYTREE, STATE, STATE_LEAF,
+    _node_impl_for_type,
 )
 
 __all__ = ['flatten', 'unflatten']
@@ -66,23 +67,25 @@ class _Encoder:
         self.mapping: dict[PathParts, Any] = {}
 
     def edge(self, path: PathParts, value: Any) -> Edge:
-        if _is_node(value):
-            if _is_graph_node(value):
-                if value in self.ref_index:
-                    return NodeEdge(self.ref_index[value])
-                index = len(self.ref_index)
-                self.ref_index[value] = index
-                impl = _get_node_impl(value)
-                items, metadata = impl.flatten(value)
-                fields = tuple((k, self.edge((*path, k), v)) for k, v in items)
-                self.specs.append(NodeSpec(impl.type, index, metadata, fields))
-                return NodeEdge(index)
-            impl = _get_node_impl(value)               # pytree (re-expanded)
+        kind = classify(value)
+
+        if kind == GRAPH_NODE:
+            if value in self.ref_index:
+                return NodeEdge(self.ref_index[value])
+            index = len(self.ref_index)
+            self.ref_index[value] = index
+            impl = _node_impl_for_type[type(value)]
             items, metadata = impl.flatten(value)
+            fields = tuple((k, self.edge((*path, k), v)) for k, v in items)
+            self.specs.append(NodeSpec(impl.type, index, metadata, fields))
+            return NodeEdge(index)
+
+        if kind == PYTREE:
+            items, metadata = PYTREE_NODE_IMPL.flatten(value)
             fields = tuple((k, self.edge((*path, k), v)) for k, v in items)
             return PytreeEdge(metadata, fields)
 
-        if isinstance(value, State):
+        if kind == STATE:
             if value in self.ref_index:
                 return StateEdge(self.ref_index[value], None, type(value))
             index = len(self.ref_index)
@@ -90,13 +93,11 @@ class _Encoder:
             self.mapping[path] = value.to_state_ref() if self.treefy_state else value
             return StateEdge(index, path, type(value))
 
-        if _is_state_leaf(value):                      # bare TreefyState
+        if kind == STATE_LEAF:                  # bare non-pytree TreefyState (rare)
             self.mapping[path] = value
             return StateLeafEdge(path)
 
-        # Any other value is an inline static field. It is kept as-is (matching
-        # the legacy engine); hashability is enforced lazily by ``GraphDef`` so
-        # that graphs with unhashable static attributes still split/merge.
+        # STATIC — kept as-is; hashability enforced lazily by GraphDef.
         return StaticEdge(value)
 
 

--- a/brainstate/graph/_flatten.py
+++ b/brainstate/graph/_flatten.py
@@ -83,6 +83,21 @@ class _Encoder:
         if kind == PYTREE:
             items, metadata = PYTREE_NODE_IMPL.flatten(value)
             fields = tuple((k, self.edge((*path, k), v)) for k, v in items)
+            # Exclude identity-hashable objects (e.g. TreefyState): they hash()
+            # successfully but may wrap live JAX arrays and carry no value-equality
+            # guarantee, so collapsing them would bake a live array into the static
+            # IR. The hash() try/except below does NOT catch these (identity hash
+            # never raises) — this clause is the only thing that blocks them.
+            if (
+                all(type(e) is StaticEdge for _, e in fields)
+                and type(value).__hash__ is not object.__hash__
+            ):
+                try:
+                    hash(value)
+                except TypeError:
+                    pass               # unhashable container -> keep the PytreeEdge
+                else:
+                    return StaticEdge(value)
             return PytreeEdge(metadata, fields)
 
         if kind == STATE:

--- a/brainstate/graph/_flatten.py
+++ b/brainstate/graph/_flatten.py
@@ -200,7 +200,7 @@ def _iter_edges(graphdef: GraphDef):
     while stack:
         e = stack.pop()
         yield e
-        if isinstance(e, PytreeEdge):
+        if type(e) is PytreeEdge:
             stack.extend(c for _, c in e.fields)
 
 
@@ -261,7 +261,7 @@ def unflatten(
 
     # Pass 0 — materialize States into index_ref (handles all sharing/back-refs).
     for e in _iter_edges(graphdef):
-        if isinstance(e, StateEdge) and e.path is not None and e.index not in index_ref:
+        if type(e) is StateEdge and e.path is not None and e.index not in index_ref:
             value = flat_states.get(e.path, _MISSING)
             if value is not _MISSING:
                 index_ref[e.index] = _materialize_state(value, e.index, index_ref_cache)
@@ -284,18 +284,19 @@ def unflatten(
         index_ref[spec.index] = shell
 
     def resolve(edge):
-        if isinstance(edge, StaticEdge):
+        et = type(edge)
+        if et is StaticEdge:
             return edge.value
-        if isinstance(edge, NodeEdge):
+        if et is NodeEdge:
             return index_ref[edge.index]
-        if isinstance(edge, StateEdge):
+        if et is StateEdge:
             if edge.index in index_ref:
                 return index_ref[edge.index]
             raise ValueError(
                 f"Expected key {_format_path(edge.path) if edge.path else edge.path!r} "
                 f"in the state mapping while rebuilding the graph."
             )
-        if isinstance(edge, StateLeafEdge):
+        if et is StateLeafEdge:
             value = flat_states.get(edge.path, _MISSING)
             if value is _MISSING:
                 raise ValueError(
@@ -303,7 +304,7 @@ def unflatten(
                     f"in the state mapping while rebuilding the graph."
                 )
             return value.to_state() if isinstance(value, TreefyState) else value
-        if isinstance(edge, PytreeEdge):
+        if et is PytreeEdge:
             items = tuple((k, resolve(c)) for k, c in edge.fields)
             return PYTREE_NODE_IMPL.unflatten(items, edge.metadata)
         raise TypeError(f"Unknown edge type: {type(edge)}")

--- a/brainstate/graph/_flatten_test.py
+++ b/brainstate/graph/_flatten_test.py
@@ -268,5 +268,23 @@ class TestFormatPath(unittest.TestCase):
         self.assertEqual(_flatten._format_path(("a", "b", "c")), "a.b.c")
 
 
+class TestEncodeKinds(unittest.TestCase):
+    def test_bare_treefy_state_encodes_as_pytree(self):
+        import jax.numpy as jnp
+        import brainstate as bs
+        from brainstate import graph
+        from brainstate.graph import PytreeEdge
+
+        class Box(graph.Node):
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+
+        ts = bs.ParamState(jnp.ones(2)).to_state_ref()
+        gd, _ = graph.flatten(Box(ts=ts))
+        kinds = {k: type(e).__name__ for k, e in gd.node_specs[0].fields}
+        self.assertEqual(kinds['ts'], 'PytreeEdge')   # preserved legacy behavior
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/graph/_flatten_test.py
+++ b/brainstate/graph/_flatten_test.py
@@ -286,5 +286,77 @@ class TestEncodeKinds(unittest.TestCase):
         self.assertEqual(kinds['ts'], 'PytreeEdge')   # preserved legacy behavior
 
 
+class TestStaticCollapse(unittest.TestCase):
+    def setUp(self):
+        import brainstate as bs
+        from brainstate import graph
+
+        class Box(graph.Node):
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+
+        self.Box = Box
+
+    def test_hashable_static_tuple_collapses(self):
+        from brainstate import graph
+        from brainstate.graph import StaticEdge
+        gd, st = graph.flatten(self.Box(shape=(2, 3), name=None))
+        fields = dict(gd.node_specs[0].fields)
+        self.assertIsInstance(fields['shape'], StaticEdge)
+        self.assertEqual(fields['shape'].value, (2, 3))
+        self.assertIsInstance(fields['name'], StaticEdge)   # None collapses too
+        # round-trip + value fidelity
+        rebuilt = graph.unflatten(gd, st)
+        self.assertEqual(rebuilt.shape, (2, 3))
+        self.assertIsNone(rebuilt.name)
+        # GraphDef stays hashable and stable for equal models
+        gd2, _ = graph.flatten(self.Box(shape=(2, 3), name=None))
+        self.assertEqual(hash(gd), hash(gd2))
+
+    def test_unhashable_static_list_stays_pytree(self):
+        from brainstate import graph
+        from brainstate.graph import PytreeEdge
+        gd, st = graph.flatten(self.Box(shape=[2, 3]))
+        fields = dict(gd.node_specs[0].fields)
+        self.assertIsInstance(fields['shape'], PytreeEdge)   # list is unhashable
+        self.assertEqual(graph.unflatten(gd, st).shape, [2, 3])
+        hash(gd)   # still hashable (PytreeEdge of StaticEdges)
+
+    def test_static_tuple_with_array_not_collapsed(self):
+        import jax.numpy as jnp
+        from brainstate import graph
+        from brainstate.graph import PytreeEdge
+        gd, st = graph.flatten(self.Box(meta=(1, jnp.ones(2))))
+        fields = dict(gd.node_specs[0].fields)
+        # tuple holding an array is unhashable -> not collapsed -> stays a pytree
+        self.assertIsInstance(fields['meta'], PytreeEdge)
+        rebuilt = graph.unflatten(gd, st)
+        self.assertEqual(rebuilt.meta[0], 1)
+
+    def test_empty_containers_round_trip(self):
+        from brainstate import graph
+        b = self.Box(lst=[], d={}, t=())
+        r = graph.unflatten(*graph.flatten(b))
+        self.assertEqual((r.lst, r.d, r.t), ([], {}, ()))
+
+    def test_identity_hashable_pytree_not_collapsed(self):
+        # A bare TreefyState is PYTREE-classified and identity-hashable; its array
+        # child becomes a StaticEdge. The __hash__ guard must keep it a PytreeEdge
+        # so the live array is NOT baked into the static IR.
+        import jax.numpy as jnp
+        import brainstate as bs
+        from brainstate import graph
+        from brainstate.graph import PytreeEdge, StaticEdge
+        ts = bs.ParamState(jnp.ones(2)).to_state_ref()
+        gd, st = graph.flatten(self.Box(ts=ts))
+        fields = dict(gd.node_specs[0].fields)
+        self.assertIsInstance(fields['ts'], PytreeEdge)
+        self.assertNotIsInstance(fields['ts'], StaticEdge)
+        # round-trips with the value intact (not frozen as a static constant)
+        rebuilt = graph.unflatten(gd, st)
+        self.assertEqual(rebuilt.ts.value.shape, (2,))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/brainstate/graph/_operation_test.py
+++ b/brainstate/graph/_operation_test.py
@@ -1290,5 +1290,93 @@ class TestPopStatesSharedAliases(absltest.TestCase):
         self.assertTrue(hasattr(n, 'q'))
 
 
+class TestSharedStateDedup(unittest.TestCase):
+    def _tied_model(self):
+        import jax.numpy as jnp
+        import brainstate as bs
+        from brainstate import graph
+
+        class Box(graph.Node):
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+
+        shared = bs.ParamState(jnp.ones((2, 2)))
+        return Box(a=shared, z=shared), shared
+
+    def test_states_dedups_shared_state(self):
+        from brainstate import graph
+        model, shared = self._tied_model()
+        st = graph.states(model)
+        vals = list(st.values())
+        self.assertEqual(len(vals), 1)               # was 2 before the fix
+        self.assertIs(vals[0], shared)
+
+    def test_states_matches_treefy_states_count(self):
+        from brainstate import graph
+        model, _ = self._tied_model()
+        self.assertEqual(len(graph.states(model)),
+                         len(graph.treefy_states(model).to_flat()))
+
+    def test_iter_leaf_yields_shared_state_once(self):
+        from brainstate import graph
+        model, shared = self._tied_model()
+        n = sum(1 for _, v in graph.iter_leaf(model) if v is shared)
+        self.assertEqual(n, 1)
+
+    def test_nodes_still_dedups(self):
+        from brainstate import graph
+        import jax.numpy as jnp
+        import brainstate as bs
+
+        class Box(graph.Node):
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+
+        sub = Box(w=bs.ParamState(jnp.ones(1)))
+        parent = Box(a=sub, b=sub)
+        # nodes(parent) returns parent itself (level 0) + sub once (deduped).
+        # Without dedup it would be 3 (parent + sub twice); with dedup it's 2.
+        self.assertEqual(len(graph.nodes(parent)), 2)
+
+    def test_inconsistent_aliasing_still_detected(self):
+        # Deduping leaves must NOT defeat check_consistent_aliasing, which works
+        # across top-level graph_to_tree leaves (persistent node_prefixes), not
+        # within one traversal. Same node in two slots with conflicting prefixes.
+        from brainstate import graph
+        import jax.numpy as jnp
+        import brainstate as bs
+
+        class Box(graph.Node):
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+
+        shared = Box(w=bs.ParamState(jnp.ones(2)))
+        with self.assertRaises(ValueError):
+            graph.graph_to_tree([shared, shared], prefix=[0, 1])
+
+    def test_dedup_false_yields_all_paths(self):
+        from brainstate.graph._walk import _iter_graph, MAX_INT
+        model, shared = self._tied_model()
+        # Mirror iter_leaf's allowed_hierarchy/want exactly, but disable leaf dedup.
+        # iter_leaf calls: _iter_graph(node, allowed_hierarchy=(0, MAX_INT), want='leaf')
+        hits = [
+            (p, v)
+            for p, v in _iter_graph(model, allowed_hierarchy=(0, MAX_INT), want='leaf', dedup_leaves=False)
+            if v is shared
+        ]
+        self.assertEqual(len(hits), 2)               # both 'a' and 'z' paths
+
+        # The default (dedup=True) must still yield exactly one occurrence.
+        dedup_hits = [
+            (p, v)
+            for p, v in _iter_graph(model, allowed_hierarchy=(0, MAX_INT), want='leaf')
+            if v is shared
+        ]
+        self.assertEqual(len(dedup_hits), 1)
+
+
 if __name__ == '__main__':
     absltest.main()

--- a/brainstate/graph/_operations.py
+++ b/brainstate/graph/_operations.py
@@ -187,6 +187,10 @@ def states(
 ) -> Union[FlattedDict, Tuple[FlattedDict, ...]]:
     """Collect ``State`` objects from a graph node as ``FlattedDict``(s).
 
+    Shared ``State`` objects (reachable via multiple paths) are deduplicated by
+    identity: each unique State appears exactly once, matching the behaviour of
+    :func:`treefy_states`.
+
     Parameters
     ----------
     node : Any

--- a/brainstate/graph/_walk.py
+++ b/brainstate/graph/_walk.py
@@ -332,16 +332,23 @@ def _iter_graph(
     def _iter(node_, visited, path_, level_):
         if level_ > hi:
             return
-        if _is_node(node_):
+        kind = classify(node_)
+        if kind == GRAPH_NODE or kind == PYTREE:
             if id(node_) in visited:
                 return
             visited.add(id(node_))
-            for key, value in _get_node_impl(node_).node_dict(node_).items():
+            if kind == GRAPH_NODE:
+                impl = _node_impl_for_type[type(node_)]
+            else:
+                impl = PYTREE_NODE_IMPL
+            items, _ = impl.flatten(node_)
+            for key, value in items:
+                child_is_node = classify(value) == GRAPH_NODE
                 yield from _iter(
                     value, visited, (*path_, key),
-                    level_ + 1 if _is_graph_node(value) else level_,
+                    level_ + 1 if child_is_node else level_,
                 )
-            if want == 'node' and _is_graph_node(node_) and level_ >= lo:
+            if want == 'node' and kind == GRAPH_NODE and level_ >= lo:
                 yield path_, node_
         else:
             if want == 'leaf' and level_ >= lo:

--- a/brainstate/graph/_walk.py
+++ b/brainstate/graph/_walk.py
@@ -133,6 +133,51 @@ NodeImpl = GraphNodeImpl | PyTreeNodeImpl
 _node_impl_for_type: dict[type, NodeImpl] = {}
 
 
+# ---------------------------------------------------------------------------
+# Value classification (type-keyed, cached)
+# ---------------------------------------------------------------------------
+# Kinds, ordered to match the historical encoder/kernel dispatch exactly:
+# a value is a graph node, else a pytree container, else a State, else a bare
+# TreefyState leaf, else an inline static. The order matters: TreefyState IS a
+# registered jax pytree, so it must resolve to PYTREE (not STATE_LEAF) to keep
+# the legacy behavior of encoding a bare TreefyState attribute as a PytreeEdge.
+GRAPH_NODE, PYTREE, STATE, STATE_LEAF, STATIC = range(5)
+
+_KIND_CACHE: dict[type, int] = {}
+
+
+def _compute_kind(t: type, x: Any) -> int:
+    if t in _node_impl_for_type:
+        return GRAPH_NODE
+    if not jax.tree_util.all_leaves((x,)):  # x (the instance) is needed only for the pytree check; all other branches are type-only
+        return PYTREE
+    if issubclass(t, State):
+        return STATE
+    if issubclass(t, TreefyState):
+        return STATE_LEAF
+    return STATIC
+
+
+def classify(x: Any) -> int:
+    """Classify ``x`` into one of GRAPH_NODE/PYTREE/STATE/STATE_LEAF/STATIC.
+
+    The result depends only on ``type(x)`` for the registered/container types
+    the engine encounters, so it is memoized per type. The cache is cleared by
+    :func:`register_graph_node_type`.
+    """
+    t = type(x)
+    k = _KIND_CACHE.get(t)
+    if k is None:
+        k = _compute_kind(t, x)
+        _KIND_CACHE[t] = k
+    return k
+
+
+def _clear_classification_cache() -> None:
+    """Drop all memoized classifications (internal; tests / dynamic registration)."""
+    _KIND_CACHE.clear()
+
+
 @set_module_as('brainstate.graph')
 def register_graph_node_type(
     type: type,
@@ -181,6 +226,7 @@ def register_graph_node_type(
         type=type, flatten=flatten, set_key=set_key,
         pop_key=pop_key, create_empty=create_empty, clear=clear,
     )
+    _KIND_CACHE.clear()
 
 
 def _get_node_impl(x: Any) -> NodeImpl:

--- a/brainstate/graph/_walk.py
+++ b/brainstate/graph/_walk.py
@@ -317,7 +317,8 @@ PYTREE_NODE_IMPL = PyTreeNodeImpl(
 # ---------------------------------------------------------------------------
 
 def _iter_graph(
-    node: Any, *, allowed_hierarchy: tuple[int, int], want: str
+    node: Any, *, allowed_hierarchy: tuple[int, int], want: str,
+    dedup_leaves: bool = True,
 ) -> Iterator[tuple[PathParts, Any]]:
     """Shared depth-first traversal backing the iteration family.
 
@@ -352,6 +353,13 @@ def _iter_graph(
                 yield path_, node_
         else:
             if want == 'leaf' and level_ >= lo:
+                # State leaves dedup by identity (first pre-order path wins).
+                # Reusing `visited` is safe: containers and State leaves are
+                # disjoint object sets, so their ids never collide.
+                if dedup_leaves and (kind == STATE or kind == STATE_LEAF):
+                    if id(node_) in visited:
+                        return
+                    visited.add(id(node_))
                 yield path_, node_
 
     yield from _iter(node, set(), (), 0)
@@ -363,7 +371,9 @@ def iter_leaf(
 ) -> Iterator[tuple[PathParts, Any]]:
     """Iterate ``(path, value)`` over every leaf in the graph.
 
-    Repeated containers are visited only once (by identity).
+    Repeated containers are visited only once (by identity). State leaves are
+    likewise deduplicated by identity: if the same State object is reachable
+    via multiple paths, only its first pre-order occurrence is yielded.
 
     Parameters
     ----------

--- a/brainstate/graph/_walk.py
+++ b/brainstate/graph/_walk.py
@@ -68,17 +68,18 @@ def _is_node_leaf(x: Any) -> TypeGuard[State]:
 
 def _is_pytree_node(x: Any) -> bool:
     """Return whether ``x`` is a (non-leaf) JAX pytree container."""
-    return not jax.tree_util.all_leaves((x,))
+    return classify(x) == PYTREE
 
 
 def _is_graph_node(x: Any) -> bool:
     """Return whether ``type(x)`` is a registered mutable graph-node type."""
-    return type(x) in _node_impl_for_type
+    return classify(x) == GRAPH_NODE
 
 
 def _is_node(x: Any) -> bool:
     """Return whether ``x`` is a container the engine descends into."""
-    return _is_graph_node(x) or _is_pytree_node(x)
+    k = classify(x)
+    return k == GRAPH_NODE or k == PYTREE
 
 
 def _is_node_type(x: type) -> bool:


### PR DESCRIPTION
## Summary

Upgrades the `brainstate.graph` engine for **performance, correctness, and accuracy** without changing the public API. The engine flattens object graphs (`Node`s + `State`s) into a static `GraphDef` plus a dynamic state mapping and back; this PR makes the hot paths substantially faster and fixes a latent shared-`State` double-counting bug, while preserving round-trip semantics.

Three themes:

1. **Hot-path performance** — a type-keyed classification cache replaces per-value `jax.tree_util.all_leaves` + ABCMeta `isinstance` checks on every traversal; the encoder/traversal kernel classifies each value once; the decoder dispatches on exact edge type.
2. **Correctness** — `iter_leaf()`/`states()` now dedup shared `State`s by identity (first pre-order path wins), matching the long-standing behavior of `flatten()`/`treefy_states()`. The two halves of the API agreed on *nodes* but disagreed on *states*; they now agree.
3. **Accuracy/robustness** — all-static, value-hashable pytree containers collapse to a single `StaticEdge`, with a guard that prevents baking live JAX arrays into the static IR.

## Performance

Micro-benchmark, MLP depth=32 width=64 (96 leaves, 33 nodes), best of 7×120 iterations, `bench_graph.py`:

| operation | baseline | after | Δ |
|---|---:|---:|---:|
| flatten | 629.0 µs | 406.8 µs | **−35%** |
| unflatten | 299.3 µs | 138.4 µs | **−54%** |
| treefy_split | 627.7 µs | 408.7 µs | **−35%** |
| treefy_merge | 312.4 µs | 172.0 µs | **−45%** |
| states | 403.8 µs | 232.6 µs | **−42%** |
| iter_leaf | 328.1 µs | 199.8 µs | **−39%** |
| iter_node | 324.5 µs | 187.4 µs | **−42%** |
| graphdef | 619.4 µs | 414.8 µs | **−33%** |
| hash(fresh graphdef) | 639.7 µs | 448.2 µs | **−30%** |
| clone | 1.01 ms | 641.7 µs | **−37%** |

Similar −25% … −54% gains hold across the other benchmarked shapes (tiny `Linear`, MLP-8, `WideBag`-128, `DeepChain`-64, shared/tied weights). The `hash(cached graphdef)` fast path is unchanged (~57 ns). Mechanism confirmed by profiling: a warm `flatten()` now triggers **0** `all_leaves` calls on `State` objects (previously one per `State` per traversal).

## What changed, by phase

**Phase A — hot-path performance (`_walk.py`, `_flatten.py`)**
- New `classify(x)` cache keyed by `type(x)`: memoizes each type's kind (`GRAPH_NODE` → `PYTREE` → `STATE` → `STATE_LEAF` → `STATIC`). The probe order is behavior-preserving. `all_leaves` is now consulted at most once per *type*, not once per *value*.
- `register_graph_node_type()` clears the cache so newly registered node types reclassify correctly (covered by a mutation-checked test).
- The traversal kernel classifies each node once and iterates `impl.flatten(node)[0]` directly.
- The decoder dispatches on exact edge type (`type(e) is NodeEdge/PytreeEdge/StateEdge/StateLeafEdge/StaticEdge`); the edge dataclasses are `frozen=True` and unsubclassed, so `type(e) is X` is equivalent to `isinstance` and faster.

**Phase B — static-collapse (`_flatten.py`)**
- An all-static, value-hashable pytree container collapses to a single `StaticEdge` instead of an expanded `PytreeEdge`, shrinking the IR and the work on both encode and decode.
- **Discovered bug + guard:** a naive collapse would fold a bare `TreefyState` (identity-hashable; its array child encodes to `StaticEdge`; `hash()` doesn't raise) into a `StaticEdge`, **baking a live JAX array into the static IR**. The guard `type(value).__hash__ is not object.__hash__` excludes identity-hashable objects from collapse. This is load-bearing and covered by a dedicated regression test (verified to fail when the guard is removed).

**Phase C — shared-State dedup + convert cleanup (`_walk.py`, `_operations.py`, `_convert.py`)**
- `iter_leaf()`/`states()` dedup shared `State`s by identity via the existing node-`visited` set (containers and `State` leaves are disjoint object sets, so ids never collide). A `dedup_leaves=False` seam preserves all-paths enumeration for any caller that needs it.
- `graph_to_tree()` now pulls `State`s straight out of the `index_ref` `RefMap` instead of re-walking via `states()`.

## Behavior change & caller audit

`iter_leaf()`/`states()` previously yielded a shared `State` **once per path** it was reachable by; they now yield it **once**, matching `flatten()`/`treefy_states()`. `nodes()`/`iter_node()` already deduped — this removes the asymmetry.

Library-wide caller audit (full suite + per-call-site review of every `states()`/`iter_leaf()`/`iter_node()` consumer): every consumer wants unique states/nodes; none relied on the double-count. `check_consistent_aliasing` is unaffected (it operates across calls, not within a single traversal). One consumer's *output* changes: `brainstate.nn._utils.count_parameters` now counts a tied weight **once** (correct) instead of twice — i.e. this fixes a latent double-count rather than regressing it.

## Testing

- Full suite at this HEAD: **5312 passed, 23 skipped, 0 failed** (~11 min). Graph module alone: **223 passed, 48 subtests**.
- New tests: classification cache (kinds, cache stability, registration invalidation — mutation-checked); bare-`TreefyState`→`PytreeEdge` encoding; static-collapse (incl. identity-hashable-not-collapsed regression); shared-State dedup (states/iter_leaf dedup, count matches `treefy_states`, nodes still dedup, inconsistent-aliasing still detected, `dedup_leaves=False` recovers all paths); `graph_to_tree` state extraction + sharing.
- Round-trip fidelity battery (cycles, self-cycles, shared/tied states, pytree-rooted graphs, int-key dicts, empty nodes, deepcopy independence) all pass.

## Notes

- No public API changes. Pre-1.0; the dedup behavior change is intentional and documented in the `states()`/`iter_leaf()` docstrings.
- The design spec, implementation plan, and benchmark/probe scripts live under `dev/superpowers/` and are intentionally **gitignored** (local dev artifacts), so they are not part of this diff.

## Test plan

- [x] `pytest brainstate/graph/` — 223 passed
- [x] Full suite — 5312 passed, 0 failed
- [x] `bench_graph.py` baseline vs final — −25%…−54% across operations
- [x] `probe_graph.py` / `probe_graph2.py` — round-trip + dedup correctness
