### PR TITLE
fix(tests): skip optional-framework tests when the dep is present-but-broken (jax<0.10 CI)

### DIFF
--- a/brainstate/graph/_operation_test.py
+++ b/brainstate/graph/_operation_test.py
@@ -246,7 +246,7 @@ class TestGraphUtils(absltest.TestCase):
         assert node2.bar.weight is node2.baz.weight
 
     def test_tied_weights_example_with_braintools(self):
-        braintools = pytest.importorskip('braintools')
+        braintools = pytest.importorskip('braintools', exc_type=ImportError)
 
         class LinearTranspose(brainstate.nn.Module):
             def __init__(self, dout: int, din: int) -> None:

--- a/brainstate/interop/_conversion_test.py
+++ b/brainstate/interop/_conversion_test.py
@@ -62,7 +62,7 @@ class NnxConversionTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
 
     def _rngs(self):
         return self.nnx.Rngs(_key())
@@ -243,7 +243,7 @@ class LinenConversionTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nn = pytest.importorskip('flax.linen')
+        cls.nn = pytest.importorskip('flax.linen', exc_type=ImportError)
 
     def _apply(self, module, variables, *args, **kw):
         return module.apply(variables, *args, **kw)
@@ -390,7 +390,7 @@ class EquinoxConversionTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.eqx = pytest.importorskip('equinox')
+        cls.eqx = pytest.importorskip('equinox', exc_type=ImportError)
 
     def test_linear(self):
         eqx = self.eqx
@@ -555,7 +555,7 @@ class CustomMappingTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
 
     def test_register_custom_layer_mapping(self):
         nnx = self.nnx
@@ -596,7 +596,7 @@ class EngineErrorPathsTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
 
     def test_empty_sequential_import(self):
         nnx = self.nnx
@@ -657,7 +657,7 @@ class EngineErrorPathsTest(absltest.TestCase):
 class PublicApiTest(absltest.TestCase):
 
     def test_supported_layers_lists_core_types(self):
-        pytest.importorskip('flax.nnx')
+        pytest.importorskip('flax.nnx', exc_type=ImportError)
         table = interop.supported_layers('nnx')
         self.assertIn('nnx', table)
         self.assertIn('Linear', table['nnx'])
@@ -678,7 +678,7 @@ class NnxNormNoAffineTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
 
     def _rngs(self):
         return self.nnx.Rngs(brainstate.random.split_key())
@@ -727,7 +727,7 @@ class EquinoxNormNoAffineTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.eqx = pytest.importorskip('equinox')
+        cls.eqx = pytest.importorskip('equinox', exc_type=ImportError)
 
     def test_layernorm_no_affine_import_export(self):
         eqx = self.eqx
@@ -762,7 +762,7 @@ class NnxConvInputDilationTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
 
     def test_input_dilation_raises(self):
         nnx = self.nnx
@@ -776,8 +776,8 @@ class BiasOnlyBatchNormTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
-        cls.nn = pytest.importorskip('flax.linen')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
+        cls.nn = pytest.importorskip('flax.linen', exc_type=ImportError)
 
     def test_bias_only_batchnorm_from_nnx(self):
         nnx = self.nnx
@@ -817,8 +817,8 @@ class TwoDBatchNormRoundTripTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
-        cls.nn = pytest.importorskip('flax.linen')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
+        cls.nn = pytest.importorskip('flax.linen', exc_type=ImportError)
 
     def test_2d_batchnorm_nnx_round_trip(self):
         nnx = self.nnx
@@ -854,7 +854,7 @@ class LinenGroupNormGroupSizeTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nn = pytest.importorskip('flax.linen')
+        cls.nn = pytest.importorskip('flax.linen', exc_type=ImportError)
 
     def test_groupnorm_group_size_only(self):
         nn = self.nn
@@ -874,7 +874,7 @@ class EquinoxRmsNormBiasTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.eqx = pytest.importorskip('equinox')
+        cls.eqx = pytest.importorskip('equinox', exc_type=ImportError)
 
     def test_nonzero_bias_raises(self):
         eqx = self.eqx
@@ -903,7 +903,7 @@ class NnxDtypePreservationTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
 
     def _rngs(self):
         return self.nnx.Rngs(brainstate.random.split_key())
@@ -959,8 +959,8 @@ class DropoutEvalEquivalenceTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
-        cls.eqx = pytest.importorskip('equinox')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
+        cls.eqx = pytest.importorskip('equinox', exc_type=ImportError)
 
     def test_to_nnx_dropout_deterministic(self):
         nnx = self.nnx
@@ -983,7 +983,7 @@ class NnxConvChannelMismatchTest(absltest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.nnx = pytest.importorskip('flax.nnx')
+        cls.nnx = pytest.importorskip('flax.nnx', exc_type=ImportError)
 
     def test_channel_mismatch_raises(self):
         nnx = self.nnx

--- a/brainstate/nn/_utils_test.py
+++ b/brainstate/nn/_utils_test.py
@@ -471,7 +471,7 @@ class TestCountParameters(unittest.TestCase):
 
     def test_count_matches_param_numel(self):
         """The returned total equals the sum of ParamState element counts."""
-        pytest.importorskip("prettytable")
+        pytest.importorskip("prettytable", exc_type=ImportError)
         model = brainstate.nn.Linear(4, 3)
         total = brainstate.nn.count_parameters(model)
         # weight (4x3) + bias (3) = 15.
@@ -479,7 +479,7 @@ class TestCountParameters(unittest.TestCase):
 
     def test_return_table_returns_pair(self):
         """``return_table=True`` returns a ``(table, total)`` pair."""
-        prettytable = pytest.importorskip("prettytable")
+        prettytable = pytest.importorskip("prettytable", exc_type=ImportError)
         model = brainstate.nn.Linear(4, 3)
         table, total = brainstate.nn.count_parameters(model, return_table=True)
         self.assertIsInstance(table, prettytable.PrettyTable)
@@ -548,7 +548,7 @@ class TestNNPackageGetattr(unittest.TestCase):
 
     def test_deprecated_name_forwards_to_brainpy(self):
         """A name in ``_DEPRECATED_NAMES`` is forwarded to ``brainpy.state`` with a warning."""
-        brainpy = pytest.importorskip("brainpy")
+        brainpy = pytest.importorskip("brainpy", exc_type=ImportError)
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             obj = brainstate.nn.IF


### PR DESCRIPTION
## Problem

The scheduled (`--run-slow`) CI runs fail on the `jax==0.7.0`, `0.8.0`, and `0.9.0` matrix entries — each with **1 failed + 38 errors** — while the latest-jax entry passes.

All 39 problems share one cause:

```
ImportError: cannot import name 'Effect' from 'jax.extend.core'
  .../flax/nnx/variablelib.py:32: from jax.extend.core import Effect
```

### Root cause (two layers)

1. **Environment churn.** CI installs `requirements-dev.txt` first (pulling the latest `flax` 0.12.7, which `requires jax>=0.10.0`), then downgrades jax below 0.10. flax stays at 0.12.7 and becomes *importable-but-broken* — `flax.nnx` imports `Effect` from `jax.extend.core`, a name that only moved there in jax 0.10.

2. **The test bug we own.** **pytest 9.1** changed `pytest.importorskip`'s default `exc_type` from `ImportError` to `ModuleNotFoundError`. So `importorskip('flax.nnx')` now only skips when flax.nnx is *absent*; when it is *present but raises a plain `ImportError`*, the error propagates → ERROR (in `setUpClass`) / FAILED (in a test body).

## Fix

Pass `exc_type=ImportError` to every optional-framework `importorskip` call (`flax.nnx`, `flax.linen`, `equinox`, `braintools`, `brainpy`, `prettytable`) — exactly the remedy pytest documents. This restores graceful skipping when an optional dependency is incompatible with the installed jax.

The change is **strictly more permissive** (`ImportError` is a superclass of `ModuleNotFoundError`) and does **not** alter behavior when the framework imports cleanly (no `ImportError` → nothing skipped → tests run as before).

## Verification

Reproduced the exact CI state locally (conda envs with `flax==0.12.7` + jax pinned to 0.7.0/0.8.0/0.9.0) and ran the full suite with `--run-slow`:

| jax | before (CI) | after (this PR) |
|-----|-------------|-----------------|
| 0.9.0 | 1 failed, 38 errors | **5234 passed, 101 skipped, 0 failed** |
| 0.8.0 | 1 failed, 38 errors | **5234 passed, 101 skipped, 0 failed** |
| 0.7.0 | 1 failed, 38 errors | **5230 passed, 105 skipped, 0 failed** |

Also confirmed that with a *compatible* flax the interop tests still **run and pass** (72 passed), i.e. the fix does not over-skip.

## Summary by Sourcery

Tests:
- Update pytest.importorskip calls for optional frameworks (flax.nnx, flax.linen, equinox, braintools, brainpy, prettytable) to skip tests on generic ImportError instead of only missing modules, preventing spurious failures in incompatible environments.