### PR TITLE
fix(transform): restore JAX 0.10.2 compatibility (batching.not_mapped removal); release 0.5.1

### DIFF
--- a/brainstate/_version.py
+++ b/brainstate/_version.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __version_info__ = tuple(map(int, __version__.split('.')))
 

--- a/brainstate/transform/_unvmap.py
+++ b/brainstate/transform/_unvmap.py
@@ -31,6 +31,12 @@ __all__ = [
     "unvmap",
 ]
 
+# jax >= 0.10 removed `batching.not_mapped`; the "not batched" sentinel returned
+# from a primitive's batching rule is now simply `None` (NotMapped = type(None)).
+# Older jax versions expose it as the `batching.not_mapped` attribute. Resolve it
+# once here so the batching rules below work across all supported jax versions.
+not_mapped = getattr(batching, 'not_mapped', None)
+
 
 @set_module_as('brainstate.transform')
 def unvmap(x: ArrayLike, op: str = 'any') -> Any:
@@ -123,7 +129,7 @@ def _unvmap_all_abstract_eval(x):
 
 def _unvmap_all_batch(x, batch_axes):
     (x,) = x
-    return unvmap_all(x), batching.not_mapped
+    return unvmap_all(x), not_mapped
 
 
 unvmap_all_p.def_impl(_unvmap_all_impl)
@@ -178,7 +184,7 @@ def _unvmap_any_abstract_eval(x):
 
 def _unvmap_any_batch(x, batch_axes):
     (x,) = x
-    return unvmap_any(x), batching.not_mapped
+    return unvmap_any(x), not_mapped
 
 
 unvmap_any_p.def_impl(_unvmap_any_impl)
@@ -233,7 +239,7 @@ def _unvmap_max_abstract_eval(x):
 
 def _unvmap_max_batch(x, batch_axes):
     (x,) = x
-    return unvmap_max(x), batching.not_mapped
+    return unvmap_max(x), not_mapped
 
 
 unvmap_max_p.def_impl(_unvmap_max_impl)
@@ -259,7 +265,7 @@ def _without_vmap_abs(x):
 
 def _without_vmap_batch(x, batch_axes):
     (x,) = x
-    return _without_vmap(x), batching.not_mapped
+    return _without_vmap(x), not_mapped
 
 
 _no_vmap_prim = Primitive('no_vmap')

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,22 @@
 # Release Notes
 
 
+## Version 0.5.1 (2026-06-18)
+
+A compatibility patch release for JAX 0.10.2. JAX 0.10 removed the long-standing `jax.interpreters.batching.not_mapped` sentinel — the "not batched" marker that a primitive's batching rule returns to declare an unmapped output — collapsing it to plain `None` (`NotMapped = type(None)`). The custom `unvmap` primitives in `brainstate.transform` still referenced the removed attribute, so every `vmap` that crossed one of them raised `AttributeError`. This release restores compatibility while preserving support for the full `jax>=0.7.0` range. No public APIs are added, removed, or renamed.
+
+### Bug Fixes
+
+#### `brainstate.transform` (#222)
+
+- **JAX 0.10.2 `vmap` regression**: the `unvmap` primitives (`unvmap_all`, `unvmap_any`, `unvmap_max`, and the internal `no_vmap`) returned `jax.interpreters.batching.not_mapped` from their batching rules. JAX 0.10 deleted that attribute — the "not batched" sentinel is now simply `None` — so any `vmap`-traced path that reached these primitives failed with `AttributeError: module 'jax.interpreters.batching' has no attribute 'not_mapped'`. The affected public surface includes `ifelse`, `error_if` / `jit_error_if`, `bounded_while_loop`'s per-lane exit, and `unvmap` itself. The sentinel is now resolved once, version-agnostically, via `getattr(batching, 'not_mapped', None)`: it yields the real object on older JAX and `None` on 0.10+, which is exactly what the new batching machinery expects. Eight previously-failing regression tests now pass.
+
+### Quality
+
+- Full test suite: **5312 passed, 23 skipped** on JAX 0.10.2 (the eight `vmap`-related failures are resolved, with no regressions).
+- Compatibility preserved across the supported JAX range (`>=0.7.0`); the fix relies only on stable, public-facing batching behavior.
+
+
 ## Version 0.5.0 (2026-06-14)
 
 A repository-wide correctness release. Following the `brainstate.transform` audit that shipped in 0.4.x, this cycle extended the same expert-audit discipline to nearly every remaining module — `random`, `graph`, `interop`, `nn`, `util`, the `vmap` / `pmap` / `shard_map` mapping engine, and the `exp_euler` integrator — and then closed out a single consolidated cross-module audit (`dev/issues.md`) covering one critical, twenty-one high, forty-six medium, and twenty-nine low findings, plus a long appendix of unverified items. Every fix ships with a behavioral regression test (several previously-skipped "known bug" tests are now un-skipped and passing), and the suite is green across the full CI JAX matrix (0.7.0, 0.8.0, 0.9.0, and latest). The release also lands a graph-layer performance pass. No public APIs are removed or renamed; the only behavioral changes are previously-silent wrong-result or invalid-input paths that now fail loudly with descriptive errors.


### PR DESCRIPTION
## Summary

JAX 0.10 removed `jax.interpreters.batching.not_mapped` — the "not batched" sentinel returned from a primitive's batching rule, now collapsed to plain `None` (`NotMapped = type(None)`). The custom `unvmap` primitives in `brainstate/transform/_unvmap.py` still referenced the removed attribute, so under **JAX 0.10.2** every `vmap`-traced path that crossed one of them raised:

```
AttributeError: module 'jax.interpreters.batching' has no attribute 'not_mapped'
```

This surfaced as **8 test failures** across the affected public surface: `ifelse`, `error_if` / `jit_error_if`, `bounded_while_loop`'s per-lane exit, and `unvmap` itself.

## Fix

Resolve the sentinel once, version-agnostically:

```python
not_mapped = getattr(batching, 'not_mapped', None)
```

- On older JAX it yields the real `not_mapped` object — no behavior change.
- On JAX 0.10+ it yields `None`, which is exactly the sentinel the new batching machinery expects.

This preserves the full supported `jax>=0.7.0` range and relies only on stable, public-facing batching behavior. The 4 call sites in `_unvmap.py` now use the resolved local sentinel.

## Release 0.5.1

- Bump `__version__` `0.5.0` -> `0.5.1`.
- Add a professional `0.5.1` changelog entry.

## Verification

- The 8 previously-failing tests now pass.
- Full suite on JAX 0.10.2: **5312 passed, 0 failed, 23 skipped** (no regressions).

## Summary by Sourcery

Restore JAX 0.10.2 compatibility for brainstate.transform unvmap primitives and cut the 0.5.1 patch release.

Bug Fixes:
- Fix vmap batching for brainstate.transform unvmap-related primitives by using a version-agnostic sentinel so code runs on JAX 0.10.2 and older releases.

Documentation:
- Add 0.5.1 changelog entry documenting the JAX 0.10.2 compatibility fix and test coverage.

Chores:
- Bump the library version from 0.5.0 to 0.5.1.