### PR TITLE
feat(transform): in_new_state_probe() + complex/failure tests for *_new_states

### DIFF
--- a/brainstate/transform/__init__.py
+++ b/brainstate/transform/__init__.py
@@ -49,6 +49,9 @@ from ._mapping1 import (
 from ._mapping2 import (
     StatefulMapping, vmap2, pmap2, map, vmap2_new_states, pmap2_new_states,
 )
+from ._mapping_core import (
+    in_new_state_probe,
+)
 from ._shard_map import (
     shard_map,
 )
@@ -145,6 +148,7 @@ __all__ = [
     'pmap2',
     'pmap2_new_states',
     'map',
+    'in_new_state_probe',
     'shard_map',
 
     # Gradient transformations

--- a/brainstate/transform/_mapping1.py
+++ b/brainstate/transform/_mapping1.py
@@ -40,6 +40,7 @@ from ._mapping_core import (  # noqa: E402
     unwind_new_state_levels,
     _build_new_state_resolver,
     _resolve_new_state_axis,
+    _new_state_probe,
 )
 
 __all__ = [
@@ -305,9 +306,14 @@ def _vmap_new_states_transform(
 
         probe_trace.set_new_arg(probe_hook)
         try:
-            with catch_new_states(state_to_exclude=state_to_exclude):
-                with probe_trace:
-                    fun(*stripped)
+            # ``_new_state_probe`` marks this as the discovery pass: the states
+            # created here are thrown away, so one-shot consumers (e.g. graph
+            # compilers keyed off the created state objects) can defer to the
+            # real mapped pass via ``in_new_state_probe()``.
+            with _new_state_probe():
+                with catch_new_states(state_to_exclude=state_to_exclude):
+                    with probe_trace:
+                        fun(*stripped)
         finally:
             probe_trace.recovery_original_values()
         # B7: defensive de-dup. The ``new_arg`` hook fires at most once per

--- a/brainstate/transform/_mapping1_test.py
+++ b/brainstate/transform/_mapping1_test.py
@@ -58,6 +58,7 @@ from brainstate.transform._mapping_core import (
 )
 from brainstate._state import NonBatchState
 from brainstate._error import BatchAxisError
+from brainstate.util.filter import OfType
 
 
 class TestFlattenInOutStates(unittest.TestCase):
@@ -925,3 +926,253 @@ class TestFailedVmapNewStatesRestoresRng(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             bst.transform.vmap_new_states(f, axis_size=4)()
         self.assertFalse(isinstance(bst.random.DEFAULT.value, jax.core.Tracer))
+
+
+class TestVmapNewStatesFromOtherStates(unittest.TestCase):
+    """Complex ``vmap_new_states`` scenarios where new states are *created from
+    the values of other new states* (dependency chains, random -> derived, and
+    replicated -> batched mixes)."""
+
+    def test_dependent_chain_abc(self):
+        """A new state initialized from a previously-created state's value.
+
+        ``a`` is batched from the mapped input, ``b`` is built from ``a.value``,
+        and ``c`` from both ``b`` and ``a``. Every link must carry the batch
+        axis and the exact arithmetic must hold.
+        """
+        captured = {}
+
+        @vmap_new_states(in_axes=0, axis_size=5)
+        def fn(x):
+            a = bst.ShortTermState(x)                  # batched from input
+            b = bst.ParamState(a.value * 2.0 + 1.0)    # b created from a.value
+            c = bst.ShortTermState(b.value - a.value)  # c from b and a
+            captured['a'] = a
+            captured['b'] = b
+            captured['c'] = c
+            return c.value
+
+        xs = jnp.arange(5.0)
+        out = fn(xs)
+        # c == (2a + 1) - a == a + 1 == x + 1
+        self.assertEqual(out.shape, (5,))
+        self.assertTrue(jnp.allclose(out, xs + 1.0))
+        self.assertEqual(captured['a'].value.shape, (5,))
+        self.assertEqual(captured['b'].value.shape, (5,))
+        self.assertEqual(captured['c'].value.shape, (5,))
+        self.assertTrue(jnp.allclose(captured['b'].value, xs * 2.0 + 1.0))
+
+    def test_deep_chain_with_random(self):
+        """A 5-level chain rooted at a random draw stays internally consistent.
+
+        Each lane is seeded with its own split key, so lanes differ, yet the
+        deterministic chain identity (recomputed from the captured batched root)
+        must hold exactly for every lane.
+        """
+        bst.random.seed(0)
+        captured = {}
+
+        @vmap_new_states(axis_size=4)
+        def fn():
+            s0 = bst.ParamState(bst.random.randn(3))   # random root, per-lane
+            s1 = bst.ShortTermState(s0.value + 1.0)
+            s2 = bst.ShortTermState(s1.value * s0.value)
+            s3 = bst.ShortTermState(jnp.tanh(s2.value))
+            s4 = bst.ShortTermState(s3.value - s1.value)
+            captured['s0'] = s0
+            captured['s4'] = s4
+            return s4.value
+
+        out = fn()
+        self.assertEqual(out.shape, (4, 3))
+        # lanes are independently seeded -> distinct
+        self.assertFalse(jnp.allclose(out[0], out[1]))
+        # chain identity recomputed from the batched root
+        s0 = captured['s0'].value
+        expected = jnp.tanh((s0 + 1.0) * s0) - (s0 + 1.0)
+        self.assertTrue(jnp.allclose(out, expected))
+
+    def test_batched_state_from_nonbatch_value(self):
+        """A batched state derived from a *replicated* NonBatchState value.
+
+        The shared base stays un-batched (axis None), while the per-lane state
+        built from ``base.sum()`` gains the batch axis. The shared base value is
+        broadcast identically into every lane.
+        """
+        captured = {}
+
+        @vmap_new_states(in_axes=0, axis_size=3)
+        def fn(x):
+            base = NonBatchState(jnp.array([1.0, 2.0, 3.0]))   # replicated
+            per = bst.ShortTermState(base.value.sum() + x)     # batched (6 + x)
+            captured['base'] = base
+            captured['per'] = per
+            return per.value
+
+        out = fn(jnp.arange(3.0))
+        self.assertEqual(captured['base'].value.shape, (3,))    # un-batched
+        self.assertEqual(captured['per'].value.shape, (3,))     # batched
+        self.assertTrue(jnp.allclose(captured['base'].value, jnp.array([1.0, 2.0, 3.0])))
+        self.assertTrue(jnp.allclose(out, 6.0 + jnp.arange(3.0)))
+
+    def test_random_init_then_derived_distinct(self):
+        """A derived state tracks its random parent and stays per-lane distinct."""
+        bst.random.seed(1)
+        captured = {}
+
+        @vmap_new_states(axis_size=4)
+        def fn():
+            w = bst.ParamState(bst.random.randn(3))
+            scaled = bst.ShortTermState(w.value * 10.0)
+            captured['w'] = w
+            captured['scaled'] = scaled
+            return scaled.value
+
+        out = fn()
+        self.assertEqual(out.shape, (4, 3))
+        self.assertTrue(jnp.allclose(out, captured['w'].value * 10.0))
+        self.assertFalse(jnp.allclose(out[0], out[1]))
+
+    def test_two_random_states_derived_sum(self):
+        """Two independent RandomStates both split per lane; the derived sum holds."""
+        rng1 = bst.random.RandomState(1)
+        rng2 = bst.random.RandomState(2)
+
+        @vmap_new_states(axis_size=5)
+        def fn():
+            a = bst.ParamState(rng1.randn(3))
+            b = bst.ParamState(rng2.randn(3))
+            c = bst.ShortTermState(a.value + b.value)
+            return c.value, a.value, b.value
+
+        c, a, b = fn()
+        self.assertEqual(c.shape, (5, 3))
+        self.assertTrue(jnp.allclose(c, a + b))
+        self.assertFalse(jnp.allclose(c[0], c[1]))
+
+    def test_broadcast_input_plus_random_derived(self):
+        """A broadcast (in_axes=None) input combined with a per-lane random draw."""
+        bst.random.seed(7)
+
+        @vmap_new_states(in_axes=None, axis_size=4)
+        def fn(c):
+            a = bst.ParamState(bst.random.randn(3) + c)   # c broadcast, noise per-lane
+            return a.value
+
+        out = fn(jnp.array(10.0))
+        self.assertEqual(out.shape, (4, 3))
+        # centered around the broadcast constant, but distinct per lane
+        self.assertFalse(jnp.allclose(out[0], out[1]))
+        self.assertTrue(jnp.all(jnp.abs(out - 10.0) < 6.0))
+
+    def test_out_axes_nonzero_with_dependent_state(self):
+        """out_axes=1 relocates the mapped axis of a value built from a new state."""
+
+        @vmap_new_states(in_axes=0, out_axes=1, axis_size=3)
+        def fn(x):
+            a = bst.ShortTermState(x)
+            b = bst.ShortTermState(jnp.stack([a.value, a.value * 2.0]))  # (2,) per lane
+            return b.value
+
+        out = fn(jnp.arange(3.0))
+        self.assertEqual(out.shape, (2, 3))   # mapped axis placed at position 1
+        self.assertTrue(jnp.allclose(out[0], jnp.arange(3.0)))
+        self.assertTrue(jnp.allclose(out[1], jnp.arange(3.0) * 2.0))
+
+
+class TestVmapNewStatesFailureCases(unittest.TestCase):
+    """Boundary / failure behavior of ``vmap_new_states`` -- misuse must raise a
+    clear error and must not leave a key tracer in the global random state."""
+
+    def test_nonbatch_state_from_batched_value_raises(self):
+        """A NonBatchState (replicated, axis None) whose value depends on the
+        batched axis is a contradiction and must raise.
+
+        The global RNG must also be restored even though the failure happens
+        mid-trace inside the mapped pass.
+        """
+        bst.random.seed(0)
+
+        @vmap_new_states(in_axes=0, axis_size=4)
+        def fn(x):
+            r = bst.ShortTermState(bst.random.randn(3))   # forces an rng split
+            a = bst.ShortTermState(x)                     # batched
+            NonBatchState(a.value * 2.0)                  # replicated but batch-dependent
+            return x
+
+        with self.assertRaises(ValueError):
+            fn(jnp.arange(4.0))
+        self.assertFalse(isinstance(bst.random.DEFAULT.value, jax.core.Tracer))
+
+    def test_random_initialized_nonbatch_state_raises(self):
+        """A NonBatchState initialized from a per-lane random draw cannot be
+        replicated on axis None and must raise."""
+        bst.random.seed(0)
+
+        @vmap_new_states(axis_size=4)
+        def fn():
+            NonBatchState(bst.random.randn(3))   # per-lane value, axis None -> contradiction
+            return jnp.zeros(())
+
+        with self.assertRaises(ValueError):
+            fn()
+        self.assertFalse(isinstance(bst.random.DEFAULT.value, jax.core.Tracer))
+
+    def test_data_dependent_state_shape_raises(self):
+        """A new state whose shape depends on a traced value cannot be created."""
+
+        @vmap_new_states(in_axes=0, axis_size=4)
+        def fn(x):
+            a = bst.ShortTermState(x)
+            n = int(a.value)                       # concretize a tracer -> error
+            return bst.ShortTermState(jnp.zeros(n)).value.sum()
+
+        with self.assertRaises(jax.errors.ConcretizationTypeError):
+            fn(jnp.arange(1.0, 5.0))
+
+    def test_axis_size_conflicts_with_input_raises(self):
+        """An explicit axis_size that disagrees with the mapped input length raises."""
+
+        @vmap_new_states(in_axes=0, axis_size=5)
+        def fn(x):
+            return bst.ShortTermState(x * 2.0).value
+
+        with self.assertRaises(ValueError) as cm:
+            fn(jnp.arange(3.0))
+        msg = str(cm.exception)
+        self.assertIn('conflicts', msg)
+        self.assertIn('5', msg)
+        self.assertIn('3', msg)
+
+    def test_state_to_exclude_with_derived_state(self):
+        """Regression: a derived (batched) state built from an *excluded*
+        replicated state still maps correctly."""
+
+        @vmap_new_states(in_axes=0, axis_size=4,
+                         state_to_exclude=OfType(NonBatchState))
+        def fn(x):
+            base = NonBatchState(jnp.ones(2))                  # excluded from batching
+            per = bst.ShortTermState(base.value.sum() + x)     # 2 + x, batched
+            return per.value
+
+        out = fn(jnp.arange(4.0))
+        self.assertEqual(out.shape, (4,))
+        self.assertTrue(jnp.allclose(out, 2.0 + jnp.arange(4.0)))
+
+    def test_non_idempotent_random_draw_count(self):
+        """Regression: an extra random draw on the mapped pass (the source of
+        truth) still produces independent, well-shaped per-lane values."""
+        bst.random.seed(0)
+        state = {'n': 0}
+
+        @vmap_new_states(axis_size=4)
+        def fn():
+            state['n'] += 1
+            v = bst.random.randn(3)
+            if state['n'] >= 2:           # mapped pass draws an extra time
+                v = v + bst.random.randn(3)
+            return bst.ParamState(v).value
+
+        out = fn()
+        self.assertEqual(out.shape, (4, 3))
+        self.assertFalse(jnp.allclose(out[0], out[1]))

--- a/brainstate/transform/_mapping2.py
+++ b/brainstate/transform/_mapping2.py
@@ -36,6 +36,7 @@ from ._mapping_core import (
     state_map_transform,
     unwind_new_state_levels,
     _import_rand_state,
+    _new_state_probe,
     # New-state output-axis resolver (shared home is _mapping_core). Re-exported
     # from this module so existing imports keep working, e.g.
     # ``from brainstate.transform._mapping2 import INIT_NO_BATCHING`` in nn._delay.
@@ -827,8 +828,13 @@ def _map_new_states(
 
     probe_trace.set_new_arg(probe_hook)
     try:
-        with probe_trace:
-            module.init_all_states(**init_kwargs)
+        # ``_new_state_probe`` marks this as the discovery pass: the states
+        # created here are thrown away, so one-shot consumers (e.g. graph
+        # compilers keyed off the created state objects) can defer to the real
+        # mapped pass via ``in_new_state_probe()``.
+        with _new_state_probe():
+            with probe_trace:
+                module.init_all_states(**init_kwargs)
     finally:
         probe_trace.recovery_original_values()
     # B7: defensive de-dup, preserving order. The ``probe_hook`` fires at most

--- a/brainstate/transform/_mapping2_test.py
+++ b/brainstate/transform/_mapping2_test.py
@@ -52,7 +52,7 @@ import brainstate
 import brainstate.random
 from brainstate._state import NonBatchState
 from brainstate.transform import StatefulMapping, vmap2, vmap_new_states, pmap2, map
-from brainstate.transform import vmap2_new_states, pmap2_new_states
+from brainstate.transform import vmap2_new_states, pmap2_new_states, in_new_state_probe
 from brainstate.transform._mapping2 import (
     _ensure_tuple, _batch_and_remainder, _validate_leading_lengths,
     _build_new_state_resolver,
@@ -1243,3 +1243,249 @@ class TestFailedNewStatesMappingRestoresRng(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             brainstate.transform.vmap2_new_states(stub, {}, axis_size=4)
         self.assertFalse(isinstance(brainstate.random.DEFAULT.value, jax.core.Tracer))
+
+
+class TestVmap2NewStatesFromOtherStates(unittest.TestCase):
+    """Complex ``vmap2_new_states`` scenarios where a module's ``init_state``
+    creates states *from the values of other states it just created*."""
+
+    def test_module_weight_then_bias_from_weight(self):
+        """A bias initialized from the freshly-created weight's column means.
+
+        Both are batched on axis 0; the per-lane bias must equal the per-lane
+        weight's mean, proving the dependency was captured inside each lane (not
+        leaked across lanes).
+        """
+        brainstate.random.seed(0)
+
+        class M(brainstate.nn.Module):
+            def init_state(self, **kw):
+                self.w = brainstate.ParamState(brainstate.random.randn(4, 3))
+                self.b = brainstate.ParamState(self.w.value.mean(axis=0))  # from w
+
+        m = M()
+        vmap2_new_states(m, {}, axis_size=5)
+        self.assertEqual(m.w.value.shape, (5, 4, 3))
+        self.assertEqual(m.b.value.shape, (5, 3))
+        # per-lane bias == per-lane weight column means
+        self.assertTrue(jnp.allclose(m.b.value, m.w.value.mean(axis=1)))
+        # lanes are independently seeded
+        self.assertFalse(jnp.allclose(m.w.value[0], m.w.value[1]))
+
+    def test_module_chain_three_states(self):
+        """A three-link p -> q -> r dependency chain inside ``init_state``."""
+        brainstate.random.seed(1)
+
+        class M(brainstate.nn.Module):
+            def init_state(self, **kw):
+                self.p = brainstate.ParamState(brainstate.random.randn(3))
+                self.q = brainstate.ShortTermState(self.p.value * 2.0)
+                self.r = brainstate.ShortTermState(self.q.value + self.p.value)
+
+        m = M()
+        vmap2_new_states(m, {}, axis_size=4)
+        for st in (m.p, m.q, m.r):
+            self.assertEqual(st.value.shape, (4, 3))
+        self.assertTrue(jnp.allclose(m.q.value, m.p.value * 2.0))
+        self.assertTrue(jnp.allclose(m.r.value, m.p.value * 3.0))
+
+    def test_state_out_axes_routes_derived_to_axis1(self):
+        """A derived ShortTermState routed to output axis 1 via ``state_out_axes``."""
+        brainstate.random.seed(0)
+
+        class M(brainstate.nn.Module):
+            def init_state(self, **kw):
+                self.w = brainstate.ParamState(brainstate.random.randn(3))
+                self.d = brainstate.ShortTermState(self.w.value * 2.0)  # from w
+
+        m = M()
+        vmap2_new_states(
+            m, {}, axis_size=5,
+            state_out_axes={1: filter.OfType(brainstate.ShortTermState)},
+        )
+        self.assertEqual(m.w.value.shape, (5, 3))   # batched on axis 0
+        self.assertEqual(m.d.value.shape, (3, 5))   # batched on axis 1
+        # consistency across the transposed axis
+        self.assertTrue(jnp.allclose(m.d.value, (m.w.value * 2.0).T))
+
+    def test_nested_parent_child_modules(self):
+        """Two child modules each create an independent random param."""
+        brainstate.random.seed(0)
+
+        class Child(brainstate.nn.Module):
+            def init_state(self, **kw):
+                self.p = brainstate.ParamState(brainstate.random.randn(2))
+
+        class Parent(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.c1 = Child()
+                self.c2 = Child()
+
+        p = Parent()
+        vmap2_new_states(p, {}, axis_size=4)
+        self.assertEqual(p.c1.p.value.shape, (4, 2))
+        self.assertEqual(p.c2.p.value.shape, (4, 2))
+        # independent draws -> the two children differ
+        self.assertFalse(jnp.allclose(p.c1.p.value, p.c2.p.value))
+
+    def test_realistic_mlp_ensemble(self):
+        """A realistic MLP whose ``init_state`` derives one param from another,
+        vectorized into an ensemble of independently-initialized members.
+
+        ``b1`` is derived from ``w1`` (state-from-state), ``scale`` is a shared
+        replicated normalization constant (NonBatchState). After
+        ``vmap2_new_states`` the ensemble runs a batched forward pass and every
+        member must produce a distinct output.
+        """
+        brainstate.random.seed(0)
+
+        class MLP(brainstate.nn.Module):
+            def __init__(self, n_in, n_hid, n_out):
+                super().__init__()
+                self.n_in, self.n_hid, self.n_out = n_in, n_hid, n_out
+
+            def init_state(self, **kw):
+                self.w1 = brainstate.ParamState(
+                    brainstate.random.randn(self.n_in, self.n_hid) / jnp.sqrt(self.n_in)
+                )
+                # bias derived from the weight's column means (state-from-state)
+                self.b1 = brainstate.ParamState(self.w1.value.mean(axis=0))
+                self.w2 = brainstate.ParamState(
+                    brainstate.random.randn(self.n_hid, self.n_out) / jnp.sqrt(self.n_hid)
+                )
+                # shared replicated normalization constant (not batched)
+                self.scale = NonBatchState(jnp.array(1.0))
+
+        K, n_in, n_hid, n_out = 6, 4, 8, 3
+        m = MLP(n_in, n_hid, n_out)
+        vmap2_new_states(m, {}, axis_size=K)
+
+        self.assertEqual(m.w1.value.shape, (K, n_in, n_hid))
+        self.assertEqual(m.b1.value.shape, (K, n_hid))
+        self.assertEqual(m.w2.value.shape, (K, n_hid, n_out))
+        self.assertEqual(m.scale.value.shape, ())             # replicated, un-batched
+        self.assertTrue(jnp.allclose(m.b1.value, m.w1.value.mean(axis=1)))
+        self.assertFalse(jnp.allclose(m.w1.value[0], m.w1.value[1]))
+
+        # ensemble forward over the batched weights for one shared input
+        x = jnp.ones((n_in,))
+        h = jnp.tanh(jnp.einsum('i,kih->kh', x, m.w1.value) + m.b1.value)
+        y = jnp.einsum('kh,kho->ko', h, m.w2.value) * m.scale.value
+        self.assertEqual(y.shape, (K, n_out))
+        self.assertFalse(jnp.allclose(y[0], y[1]))            # members differ
+
+
+class TestVmap2NewStatesFailureCases(unittest.TestCase):
+    """Boundary / failure behavior of ``vmap2_new_states``."""
+
+    def test_nonbatch_state_from_batched_value_raises(self):
+        """A NonBatchState whose value depends on a batched state is a
+        contradiction (axis None vs batched) and must raise; the RNG must be
+        restored."""
+        brainstate.random.seed(0)
+
+        class M(brainstate.nn.Module):
+            def init_state(self, **kw):
+                self.w = brainstate.ParamState(brainstate.random.randn(3))  # batched
+                self.nb = NonBatchState(self.w.value * 2.0)                  # batch-dependent
+
+        with self.assertRaises(ValueError):
+            vmap2_new_states(M(), {}, axis_size=4)
+        self.assertFalse(isinstance(brainstate.random.DEFAULT.value, jax.core.Tracer))
+
+    def test_data_dependent_state_shape_raises(self):
+        """A state whose shape depends on a per-lane (traced) value cannot be
+        created under the mapped pass.
+
+        The eager probe runs with *concrete* random values, so ``int(...)``
+        succeeds there (``abs(...) + 1`` keeps the probe shape valid). Under the
+        mapped ``jax.vmap`` pass the weight is a per-lane tracer, so the same
+        ``int(...)`` concretization raises.
+        """
+        brainstate.random.seed(0)
+
+        class M(brainstate.nn.Module):
+            def init_state(self, **kw):
+                self.w = brainstate.ParamState(brainstate.random.randn(3))
+                # shape derived from a traced value; +1 keeps the probe shape >= 1
+                n = int(jnp.abs(self.w.value).sum()) + 1
+                self.extra = brainstate.ParamState(jnp.zeros(n))
+
+        with self.assertRaises(jax.errors.ConcretizationTypeError):
+            vmap2_new_states(M(), {}, axis_size=4)
+
+
+class TestInNewStateProbe(unittest.TestCase):
+    """``in_new_state_probe()`` lets one-shot, state-bound side effects defer to
+    the real mapped pass instead of binding to the throwaway probe states."""
+
+    def test_probe_false_outside(self):
+        """Outside any ``*_new_states`` transform the probe flag is False."""
+        self.assertFalse(in_new_state_probe())
+
+    def test_probe_true_only_during_discovery(self):
+        """The flag is True during the discovery probe and False during the
+        mapped pass, and resets afterwards."""
+        brainstate.random.seed(0)
+        flags = []
+
+        class M(brainstate.nn.Module):
+            def init_state(self, **kw):
+                flags.append(in_new_state_probe())
+                self.w = brainstate.ParamState(brainstate.random.randn(3))
+
+        self.assertFalse(in_new_state_probe())          # before
+        vmap2_new_states(M(), {}, axis_size=4)
+        self.assertFalse(in_new_state_probe())          # after
+        # init ran twice: probe (True) then mapped pass (False)
+        self.assertEqual(flags, [True, False])
+
+    def test_one_shot_consumer_without_guard_binds_probe_state(self):
+        """Documents the failure mode: a one-shot graph cached on first init
+        binds to the throwaway *probe* state, not the real mapped state."""
+        brainstate.random.seed(0)
+
+        class Algo(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._graph = None
+
+            def init_state(self, **kw):
+                self.w = brainstate.ParamState(brainstate.random.randn(3))
+                if self._graph is None:                 # one-shot, NO guard
+                    w = self.w
+                    self._graph = lambda: w.value.shape
+
+        a = Algo()
+        vmap2_new_states(a, {}, axis_size=6)
+        # the real state is batched ...
+        self.assertEqual(a.w.value.shape, (6, 3))
+        # ... but the cached graph captured the un-batched throwaway probe state
+        self.assertEqual(a._graph(), (3,))
+        self.assertNotEqual(a._graph(), a.w.value.shape)
+
+    def test_one_shot_consumer_with_guard_binds_mapped_state(self):
+        """With the ``in_new_state_probe()`` guard the one-shot graph defers to
+        the mapped pass and binds to the real (batched) state."""
+        brainstate.random.seed(0)
+
+        class Algo(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._graph = None
+
+            def init_state(self, **kw):
+                self.w = brainstate.ParamState(brainstate.random.randn(3))
+                if in_new_state_probe():                # defer during discovery
+                    return
+                if self._graph is None:
+                    w = self.w
+                    self._graph = lambda: w.value.shape
+
+        a = Algo()
+        vmap2_new_states(a, {}, axis_size=6)
+        self.assertEqual(a.w.value.shape, (6, 3))
+        # cached graph now binds to the real mapped state
+        self.assertEqual(a._graph(), (6, 3))
+        self.assertEqual(a._graph(), a.w.value.shape)

--- a/brainstate/transform/_mapping_core.py
+++ b/brainstate/transform/_mapping_core.py
@@ -85,6 +85,7 @@ Caveats
 """
 
 import functools
+import threading
 import warnings
 import weakref
 from collections import defaultdict
@@ -120,6 +121,8 @@ __all__ = [
     # Phase 3 -- rng + stack level
     'split_rng_keys',
     'unwind_new_state_levels',
+    # New-state discovery probe context
+    'in_new_state_probe',
     # Phase 3b -- new-state output-axis resolver
     'INIT_NO_BATCHING',
     '_build_new_state_resolver',
@@ -151,6 +154,99 @@ def _import_rand_state():
         from brainstate.random import RandomState
         _rand = RandomState
     return _rand
+
+
+# ============================================================================ #
+# New-state discovery probe context
+# ============================================================================ #
+#
+# ``vmap_new_states`` / ``vmap2_new_states`` / ``pmap2_new_states`` execute the
+# wrapped function an extra *eager probe* pass to enumerate the random states it
+# touches, so each mapped lane can be seeded with an independently split key
+# (see the ``probe_hook`` in ``_mapping1._vmap_new_states_transform`` and
+# ``_mapping2._map_new_states``). The probe's :class:`~brainstate.State` *value*
+# mutations are rolled back via ``StateTraceStack.recovery_original_values``, but
+# the function body still runs once, and the State objects it creates are
+# discarded in favour of the ones created by the real mapped pass.
+#
+# Ordinary, idempotent initialisation needs no awareness of this. But a consumer
+# that performs a *one-shot, stateful side effect bound to the created state
+# objects* -- most notably compiling and caching a computation graph over the
+# freshly-initialised states -- would otherwise bind that cache to the throwaway
+# probe states (left untagged and un-batched) instead of the real mapped states,
+# producing downstream batching errors. ``in_new_state_probe()`` lets such code
+# detect the probe and defer its one-shot work to the real mapped pass.
+#
+# A thread-local *depth* counter (rather than a bool) keeps nested ``*_new_states``
+# transforms composable.
+
+_NEW_STATE_PROBE_TLS = threading.local()
+
+
+def _new_state_probe_depth() -> int:
+    return getattr(_NEW_STATE_PROBE_TLS, 'depth', 0)
+
+
+class _new_state_probe:
+    """Internal context manager marking the eager new-state discovery probe.
+
+    Wrapped around the probe execution of the user function in
+    ``vmap_new_states`` / ``vmap2_new_states`` / ``pmap2_new_states`` so that
+    :func:`in_new_state_probe` reports ``True`` for code running inside it.
+    """
+    __slots__ = ()
+
+    def __enter__(self):
+        _NEW_STATE_PROBE_TLS.depth = _new_state_probe_depth() + 1
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        _NEW_STATE_PROBE_TLS.depth = _new_state_probe_depth() - 1
+        return False
+
+
+def in_new_state_probe() -> bool:
+    """Whether the caller is running inside a ``*_new_states`` discovery probe.
+
+    :func:`brainstate.transform.vmap_new_states`,
+    :func:`~brainstate.transform.vmap2_new_states` and
+    :func:`~brainstate.transform.pmap2_new_states` execute the wrapped function
+    an extra *eager probe* pass to enumerate the random states it touches before
+    the real mapped pass. The probe's :class:`~brainstate.State` *value*
+    mutations are rolled back, but the function body still runs, and the states
+    it creates are discarded in favour of the ones created by the real mapped
+    pass.
+
+    Code that performs a **one-shot, stateful side effect bound to the created
+    state objects** -- for example compiling and caching a computation graph over
+    freshly-initialised states -- should skip or defer that work while this
+    returns ``True``, so the cache binds to the real mapped states (correctly
+    tagged and batched) rather than the throwaway probe states. Ordinary,
+    idempotent initialisation needs no special handling.
+
+    Returns
+    -------
+    bool
+        ``True`` if currently inside a new-state discovery probe, ``False``
+        otherwise.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import brainstate
+
+        class MyAlgorithm:
+            def compile_graph(self, *args):
+                # the probe runs this once against throwaway states; defer the
+                # real, one-shot compilation to the mapped pass
+                if brainstate.transform.in_new_state_probe():
+                    return
+                if not self._compiled:
+                    self._build_graph(*args)
+                    self._compiled = True
+    """
+    return _new_state_probe_depth() > 0
 
 
 # ============================================================================ #

--- a/brainstate/transform/_mapping_core_test.py
+++ b/brainstate/transform/_mapping_core_test.py
@@ -37,6 +37,9 @@ from brainstate.transform._mapping_core import (
     unwind_new_state_levels,
     leaf_batch_dim,
     state_map_transform,
+    in_new_state_probe,
+    _new_state_probe,
+    _new_state_probe_depth,
 )
 from brainstate.util import filter
 
@@ -1549,6 +1552,49 @@ class TestRemoveAxisScalar(unittest.TestCase):
     def test_array_leaf_still_works(self):
         out = _remove_axis(jnp.arange(6.).reshape(2, 3), 0)
         self.assertEqual(out.shape, (3,))
+
+
+class TestNewStateProbeContext(unittest.TestCase):
+    """Unit tests for the ``_new_state_probe`` discovery-probe context manager
+    and its public query ``in_new_state_probe``."""
+
+    def test_depth_false_by_default(self):
+        """Outside any probe the depth is 0 and the query is False."""
+        self.assertEqual(_new_state_probe_depth(), 0)
+        self.assertFalse(in_new_state_probe())
+
+    def test_probe_sets_and_restores(self):
+        """Entering the probe reports True; exiting restores False."""
+        self.assertFalse(in_new_state_probe())
+        with _new_state_probe():
+            self.assertTrue(in_new_state_probe())
+            self.assertEqual(_new_state_probe_depth(), 1)
+        self.assertFalse(in_new_state_probe())
+        self.assertEqual(_new_state_probe_depth(), 0)
+
+    def test_nested_probe_depth_composes(self):
+        """Nested probes use a depth counter so the query stays True until the
+        outermost context exits (keeps nested ``*_new_states`` composable)."""
+        with _new_state_probe():
+            self.assertEqual(_new_state_probe_depth(), 1)
+            with _new_state_probe():
+                self.assertEqual(_new_state_probe_depth(), 2)
+                self.assertTrue(in_new_state_probe())
+            # inner exit: still inside the outer probe
+            self.assertEqual(_new_state_probe_depth(), 1)
+            self.assertTrue(in_new_state_probe())
+        self.assertEqual(_new_state_probe_depth(), 0)
+        self.assertFalse(in_new_state_probe())
+
+    def test_depth_resets_after_exception(self):
+        """An exception raised inside the probe still restores the depth (the
+        decrement lives in ``__exit__``)."""
+        with self.assertRaises(RuntimeError):
+            with _new_state_probe():
+                self.assertTrue(in_new_state_probe())
+                raise RuntimeError('boom')
+        self.assertEqual(_new_state_probe_depth(), 0)
+        self.assertFalse(in_new_state_probe())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Exposes **`in_new_state_probe()`** — a thread-local discovery-probe marker so one-shot, state-bound consumers (e.g. graph compilers keyed on the created state objects) can defer their work to the real mapped pass of `vmap_new_states` / `vmap2_new_states` / `pmap2_new_states`, instead of binding to the throwaway probe states. Wrapped around the eager discovery pass in `_mapping1` and `_mapping2`.
- Adds **28 tests** covering complex *state-created-from-another-state's-value* scenarios and failure boundaries.

## Tests

**`_mapping1_test.py` — `vmap_new_states`**
- `TestVmapNewStatesFromOtherStates`: dependency chains `a→b→c`, deep 5-level chain rooted at a random draw, batched-from-`NonBatchState`, two independent RNGs → `c=a+b`, broadcast input + per-lane random, `out_axes=1` placement.
- `TestVmapNewStatesFailureCases`: `NonBatchState` from a batched value → `ValueError`; random `NonBatchState`; data-dependent shape → `ConcretizationTypeError`; `axis_size`-vs-input conflict; `state_to_exclude`+derived and non-idempotent random regressions. Each failure asserts the global RNG is not left as a tracer.

**`_mapping2_test.py` — `vmap2_new_states` + `in_new_state_probe`**
- `TestVmap2NewStatesFromOtherStates`: weight→bias-from-weight, `p→q→r` chain, `state_out_axes` routing a derived state to axis 1, nested parent/child modules, and a realistic MLP ensemble with a batched forward.
- `TestVmap2NewStatesFailureCases` + `TestInNewStateProbe`: one-shot graph cache binds to the throwaway probe state **without** the guard (documents the bug) and to the real batched state **with** it; probe flag is True only during discovery.

**`_mapping_core_test.py`** — `TestNewStateProbeContext`: depth default, set/restore, nested composability, reset-after-exception.

## Verification

- 287/287 tests pass across the three suites.
- Coverage: `_mapping1.py` 100%, `_mapping2.py` 99%, `_mapping_core.py` 98%; the new `in_new_state_probe` path is fully covered.

## Summary by Sourcery

Introduce a probe context for new-state discovery in mapping transforms and expand test coverage for complex state-dependency and failure scenarios.

New Features:
- Add the thread-local in_new_state_probe() API and underlying probe context to detect discovery passes in vmap_new_states, vmap2_new_states, and pmap2_new_states so one-shot state-bound consumers can defer work to the real mapped pass.

Enhancements:
- Wrap the eager discovery probe in vmap_new_states and vmap2_new_states with the new probe context to clearly distinguish probe-created states from those in the mapped pass.

Documentation:
- Document the semantics and usage of in_new_state_probe() in the mapping core, including examples for deferring one-shot graph compilation.

Tests:
- Add extensive vmap_new_states tests for states derived from other states, complex random chains, NonBatchState interactions, broadcasting, and out_axes handling.
- Add vmap_new_states failure tests covering invalid NonBatchState usage, data-dependent shapes, axis_size mismatches, excluded states with derivatives, and non-idempotent random draw regressions.
- Add vmap2_new_states tests for module-level state dependencies, nested modules, state_out_axes routing, and a realistic MLP ensemble forward pass.
- Add vmap2_new_states failure and probe-behavior tests, including documented misbinding without the probe guard and correct binding with it for one-shot graph consumers.
- Add core tests for the new-state probe context manager to verify depth tracking, nesting behavior, and correct reset after exceptions.