### PR TITLE
fix: jax 0.11.0 compatibility, CI 0.10.0 matrix, jax>=0.8.0 floor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.13"]
-        jax-version: ["0.7.0", "0.8.0", "0.9.0", ""]
+        jax-version: ["0.8.0", "0.9.0", "0.10.0", ""]
 
     steps:
       - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,5 @@ docs/_brand/
 docs/_static/css/brainx-header.css
 docs/_static/js/brainx-header.js
 /.claudegitignore
-/CLAUDE.md
 docs/_static/css/brainx-footer.css
 docs/_static/js/brainx-footer.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@
 5. Every correction: reflect on the mistake, plan to avoid repeating it.
 6. All updates must be happened on the worktree branch, not main. 
 7. Use `brainstate.random` instead of `jax.random` directly for all random number generation. 
-8. Write spec and plan under `/mnt/d/codes/projects/brainstate/dev/superpowers` as gitignored files before implementation. This makes them available for reference during implementation, but not clutter the repo history.
+8. Write spec and plan under `<PROJECT_ROOT>/doc/specs` before implementation, so they're available for reference during implementation.
 9. Tests should >90% coverage, but focus on meaningful tests that cover edge cases and critical paths, not just trivial lines. 
+10. Maintain compatibility with JAX versions >= 0.8.0. Guard any version-specific behavior in `brainstate/_compatible_import.py`, preferring feature/shape detection over hard version checks.
 
 
 ## Docstring style (NumPy-doc)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# brainstate
+
+## Working agreement
+
+1. Before writing any code, describe approach, wait for approval.
+2. Requirements ambiguous? Ask clarifying questions before writing code.
+3. After writing code, list edge cases + suggest test cases.
+4. Bug? Write a test that reproduces it, then fix until the test passes.
+5. Every correction: reflect on the mistake, plan to avoid repeating it.
+6. All updates must be happened on the worktree branch, not main. 
+7. Use `brainstate.random` instead of `jax.random` directly for all random number generation. 
+8. Write spec and plan under `/mnt/d/codes/projects/brainstate/dev/superpowers` as gitignored files before implementation. This makes them available for reference during implementation, but not clutter the repo history.
+9. Tests should >90% coverage, but focus on meaningful tests that cover edge cases and critical paths, not just trivial lines. 
+
+
+## Docstring style (NumPy-doc)
+
+All public classes, methods, functions must use [NumPy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html). Canonical section order:
+
+1. **Short summary** – one-line imperative description (no blank line before).
+2. **Extended summary** – optional, follow blank line after short summary.
+3. **Parameters** – each entry: `name : type` on own line, description indented below.
+4. **Returns** / **Yields** – same format as Parameters.
+5. **Raises** – exception type and when raised.
+6. **See Also** – related functions / classes.
+7. **Notes** – implementation details, math, references.
+8. **References** – numbered bibliography entries (`.. [1]`).
+9. **Examples** – runnable, doctestable code snippets.
+
+### Rules for the Examples section
+
+- Wrap example code in `.. code-block:: python` directive so Sphinx render with syntax highlighting.
+- Prefix every input line with `>>>` (continuation lines with `...`) for `doctest` compatibility.
+- Show expected output on line immediately after statement, **without** prompt prefix.
+- Separate distinct scenarios with blank `>>>` line.
+- Always include necessary imports (`import brainunit as u`, etc.) at top of example block so self-contained.

--- a/brainstate/_compatible_import.py
+++ b/brainstate/_compatible_import.py
@@ -76,6 +76,7 @@ __all__ = [
 
     # others
     'is_jit_primitive',
+    'scan_num_consts_carry',
     'Primitive',
     'jaxpr_as_fun',
     'get_aval',
@@ -454,6 +455,49 @@ def is_jit_primitive(eqn: JaxprEqn) -> bool:
         return eqn.primitive.name in ['pjit', 'xla_call']
     else:
         return eqn.primitive.name in ['jit', 'xla_call']
+
+
+def scan_num_consts_carry(eqn_params) -> tuple:
+    """Return ``(num_consts, num_carry)`` for a ``scan``/``map`` equation.
+
+    JAX exposes the constant/carry split of a ``scan`` primitive differently
+    across versions. JAX < 0.11 stores ``num_consts`` and ``num_carry`` as
+    integer params directly on the equation. JAX >= 0.11 removed those params in
+    favor of a ``ft_in`` FlatTree whose unpacked groups are
+    ``(consts, carry, xs)``; the two counts are recovered from the group
+    lengths. ``jax.lax.map`` lowers to a ``scan`` and is handled identically.
+
+    The JAX version is detected from the param *shape* (presence of
+    ``num_consts``) rather than from :data:`jax.__version_info__`, so this keeps
+    working if the exact release boundary shifts.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The ``params`` mapping of a ``scan`` :class:`JaxprEqn`.
+
+    Returns
+    -------
+    tuple of int
+        The ``(num_consts, num_carry)`` pair.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import jax, jax.numpy as jnp
+        >>> from brainstate._compatible_import import scan_num_consts_carry
+        >>> def f(init, xs):
+        ...     return jax.lax.scan(lambda c, x: (c + x, c * x), init, xs)
+        >>> jaxpr = jax.make_jaxpr(f)(1.0, jnp.arange(4.0))
+        >>> scan_eqn = [e for e in jaxpr.jaxpr.eqns if e.primitive.name == 'scan'][0]
+        >>> scan_num_consts_carry(scan_eqn.params)
+        (0, 1)
+    """
+    if 'num_consts' in eqn_params:  # jax < 0.11.0
+        return eqn_params['num_consts'], eqn_params['num_carry']
+    consts, carry, _xs = eqn_params['ft_in'].unpack()  # jax >= 0.11.0
+    return len(consts), len(carry)
 
 
 # Resolve jax.shard_map across versions: it was promoted to the top level in

--- a/brainstate/transform/_ir_tocode.py
+++ b/brainstate/transform/_ir_tocode.py
@@ -30,7 +30,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax._src.sharding_impls import UNSPECIFIED
 
-from brainstate._compatible_import import Literal, Var, Jaxpr
+from brainstate._compatible_import import Literal, Var, Jaxpr, scan_num_consts_carry
 from brainstate.transform._ir_utils import IRError, UnsupportedPrimitiveError
 
 
@@ -1099,8 +1099,7 @@ def _astify_scan(state, eqn):
 
     # the args to scan are [constants, carry, xs]
     # constants aren't exposed in the Python API, so we need to handle them specially (we use a lambda)
-    num_consts = eqn.params['num_consts']
-    num_carry = eqn.params['num_carry']
+    num_consts, num_carry = scan_num_consts_carry(eqn.params)
 
     # TODO: bring back map
     # if num_carry == 0:
@@ -1256,7 +1255,7 @@ def _astify_scan(state, eqn):
 
 def _astify_map(state, eqn):
     assert eqn.primitive.name == 'scan'
-    assert eqn.params['num_carry'] == 0
+    assert scan_num_consts_carry(eqn.params)[1] == 0
 
     jaxpr = eqn.params['jaxpr']
     jaxpr = constant_fold_jaxpr(jaxpr.jaxpr)

--- a/brainstate/transform/_ir_tocode_test.py
+++ b/brainstate/transform/_ir_tocode_test.py
@@ -23,6 +23,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+from brainstate._compatible_import import scan_num_consts_carry
 from brainstate.transform import fn_to_python_code, jaxpr_to_python_code
 from brainstate.transform import _ir_tocode
 
@@ -720,7 +721,7 @@ class TestScanMapAndClosedCall(unittest.TestCase):
 
         xs = jnp.float32([1., 2., 3.])
         folded, scan_eqn = self._scan_eqn(f, xs)
-        self.assertEqual(scan_eqn.params['num_carry'], 0)
+        self.assertEqual(scan_num_consts_carry(scan_eqn.params)[1], 0)
 
         state = _ir_tocode.SourcerorState()
         for v in folded.invars:

--- a/brainstate/transform/_ir_utils_test.py
+++ b/brainstate/transform/_ir_utils_test.py
@@ -19,7 +19,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from brainstate._compatible_import import Literal, Var
+from brainstate._compatible_import import Literal, Var, Jaxpr, ClosedJaxpr
 from brainstate.transform._ir_utils import (
     IRError, IRValidationError, UnsupportedPrimitiveError,
     IdentitySet, IdentityMap,
@@ -107,8 +107,16 @@ class TestValidationHelpers(unittest.TestCase):
         jaxpr, consts, was_closed = ensure_jaxpr(cj)
         self.assertTrue(was_closed)
         self.assertEqual(list(consts), list(cj.consts))
+
+        # jax >= 0.11 merged Jaxpr and ClosedJaxpr into a single class, and
+        # ``make_jaxpr(...).jaxpr is`` the closed object itself -- there is no
+        # longer a distinct "bare" Jaxpr to pass, so ``ensure_jaxpr`` reports it
+        # as closed. On older jax, ``cj.jaxpr`` is a bare Jaxpr (not closed).
         jaxpr2, consts2, was_closed2 = ensure_jaxpr(cj.jaxpr)
-        self.assertFalse(was_closed2)
+        if ClosedJaxpr is Jaxpr:  # jax >= 0.11.0
+            self.assertTrue(was_closed2)
+        else:
+            self.assertFalse(was_closed2)
         self.assertEqual(consts2, [])
 
     def test_ensure_jaxpr_rejects_other(self):

--- a/brainstate/transform/_ir_visualize.py
+++ b/brainstate/transform/_ir_visualize.py
@@ -21,7 +21,7 @@ from typing import Tuple, Union, List
 import jax
 
 from brainstate._compatible_import import (
-    Var, ClosedJaxpr, Jaxpr, JaxprEqn, Literal, DropVar
+    Var, ClosedJaxpr, Jaxpr, JaxprEqn, Literal, DropVar, scan_num_consts_carry
 )
 from brainstate.transform._ir_utils import UnsupportedPrimitiveError
 
@@ -878,13 +878,17 @@ if pydot_is_installed:
             **GRAPH_STYLING,
         )
 
+        # jax >= 0.11 dropped the ``num_consts``/``num_carry`` scan params in
+        # favor of ``ft_in``/``ft_out``; resolve both across versions here.
+        num_consts, num_carry = scan_num_consts_carry(eqn.params)
+
         argument_nodes, argument_edges = get_scan_arguments(
             graph_id,
             parent_id,
             eqn.params["jaxpr"].jaxpr.invars,
             eqn.invars,
-            eqn.params["num_consts"],
-            eqn.params["num_carry"],
+            num_consts,
+            num_carry,
             show_avals,
         )
         graph.add_subgraph(argument_nodes)
@@ -962,7 +966,7 @@ if pydot_is_installed:
             eqn.params["jaxpr"].jaxpr.invars,
             eqn.params["jaxpr"].jaxpr.outvars,
             eqn.outvars,
-            eqn.params["num_carry"],
+            num_carry,
             show_avals,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,22 +77,22 @@ progressbar = [
     'tqdm',
 ]
 cpu = [
-    'jax[cpu]>=0.7.0',
+    'jax[cpu]>=0.8.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
 cuda12 = [
-    'jax[cuda12]>=0.7.0',
+    'jax[cuda12]>=0.8.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
 cuda13 = [
-    'jax[cuda13]>=0.7.0',
+    'jax[cuda13]>=0.8.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
 tpu = [
-    'jax[tpu]>=0.7.0',
+    'jax[tpu]>=0.8.0',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',
 ]
@@ -100,7 +100,7 @@ testing = [
     'absl-py',
     'pytest',
     'coverage',
-    'jax>=0.7.0',
+    'jax>=0.8.0',
     'tqdm',
     'brainunit>=0.3.0',
     'brainevent>=0.0.7',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-jax>=0.7.0
+jax>=0.8.0
 jaxlib
 brainunit>=0.3.0
 brainevent


### PR DESCRIPTION
## Summary

Fixes jax 0.11.0 compatibility, adds a pinned 0.10.0 CI entry, and raises the supported jax floor to 0.8.0.

jax 0.11.0 shipped two breaking changes that broke **18 tests, all in `transform`**:

1. **`scan` primitive** dropped the `num_consts`/`num_carry` integer params in favor of `ft_in`/`ft_out` FlatTrees. Added a shape-detecting helper `scan_num_consts_carry()` in `_compatible_import.py` (recovers the counts from `ft_in.unpack()` on >=0.11, reads the old params otherwise) and routed `_astify_scan`/`_astify_map` (`_ir_tocode`) and `get_scan` (`_ir_visualize`) through it. Also covers `jax.lax.map`, which lowers to a scan.
2. **`Jaxpr` and `ClosedJaxpr` merged** into one class (`ClosedJaxpr is Jaxpr`), and `make_jaxpr(...).jaxpr is` the object itself. `isinstance` can no longer distinguish "bare" from "closed", so `ensure_jaxpr` reports every jaxpr as closed. Made `test_ensure_jaxpr_accepts_jaxpr` version-aware. The `isinstance` branches in `_ir_inline`/`_ir_optim` stay correct because the merged class still carries `.consts` and `ClosedJaxpr(jaxpr, consts)` remains a valid backward-compat constructor (verified: inline/optim suites pass).

## CI / packaging

- Add pinned `"0.10.0"` to the jax matrix and drop `"0.7.0"`; the `""` entry already exercises latest (0.11.0).
- Bump supported floor to `jax>=0.8.0` in `pyproject.toml` (all extras) and `requirements.txt`.

## Docs

- Rename gitignored `CLAUDE.md` to a tracked `AGENTS.md`; update the spec-path rule and add a rule requiring compatibility with jax >= 0.8.0.

## Verification (jax 0.11.0)

- `transform`: **1282 passed, 0 failed** (was 18 failed / 1264 passed)
- `util` 402, `graph` 223, `interop` 93, `nn` 1977, `random` 592 — green
- `mypy` clean on changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure compatibility with newer JAX releases while updating minimum supported versions and project guidelines.

New Features:
- Introduce a compatibility helper to derive scan constant and carry counts across differing JAX scan parameter representations.

Bug Fixes:
- Fix transform code generation and visualization for scan/map primitives to work with JAX 0.11.0’s updated scan parameters.
- Adjust jaxpr handling in tests to account for JAX 0.11.0’s merged Jaxpr/ClosedJaxpr classes.

Enhancements:
- Refine scan-related assertions in code generation tests to rely on the new compatibility helper.

Build:
- Raise the minimum supported JAX version to 0.8.0 across extras and base requirements.
- Update CI matrix to drop JAX 0.7.0 and add a pinned JAX 0.10.0 entry.

Documentation:
- Add an AGENTS working-agreement document that includes guidelines such as maintaining compatibility with JAX >= 0.8.0.